### PR TITLE
fix(reads): preserve routed consistency guarantees

### DIFF
--- a/internal/adapter/grpc/client_bucket.go
+++ b/internal/adapter/grpc/client_bucket.go
@@ -190,7 +190,7 @@ func (g *BucketGrpcClient) GetLedgerByName(ctx context.Context, name string) (*c
 	})
 }
 
-func (g *BucketGrpcClient) ListAuditEntries(ctx context.Context, pageSize uint32, afterSequence uint64, filter *commonpb.QueryFilter, reverse bool) (cursor.Cursor[*auditpb.AuditEntry], error) {
+func (g *BucketGrpcClient) ListAuditEntries(ctx context.Context, pageSize uint32, afterSequence uint64, filter *commonpb.QueryFilter, reverse bool, minLogSequence uint64) (cursor.Cursor[*auditpb.AuditEntry], error) {
 	var cursorStr string
 	if afterSequence > 0 {
 		cursorStr = strconv.FormatUint(afterSequence, 10)
@@ -202,6 +202,7 @@ func (g *BucketGrpcClient) ListAuditEntries(ctx context.Context, pageSize uint32
 			Cursor:   cursorStr,
 			Reverse:  reverse,
 			Filter:   filter,
+			Read:     &commonpb.ReadOptions{MinLogSequence: minLogSequence},
 		},
 	})
 	if err != nil {

--- a/internal/adapter/grpc/client_bucket_test.go
+++ b/internal/adapter/grpc/client_bucket_test.go
@@ -385,10 +385,16 @@ func TestListAuditEntries_Success(t *testing.T) {
 	stream := newRecvStream[auditpb.AuditEntry](ctrl, []*auditpb.AuditEntry{
 		{Sequence: 1},
 	}, nil)
-	mock.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any()).Return(stream, nil)
+	mock.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, req *servicepb.ListAuditEntriesRequest, _ ...grpc.CallOption) (servicepb.BucketService_ListAuditEntriesClient, error) {
+			require.Equal(t, uint64(7), req.GetOptions().GetRead().GetMinLogSequence())
+
+			return stream, nil
+		},
+	)
 
 	client := NewLedgerGrpcClient(mock)
-	cursor, err := client.ListAuditEntries(context.Background(), 10, 5, nil, false)
+	cursor, err := client.ListAuditEntries(context.Background(), 10, 5, nil, false, 7)
 	require.NoError(t, err)
 
 	entry, err := cursor.Next()
@@ -404,7 +410,7 @@ func TestListAuditEntries_StreamError(t *testing.T) {
 	mock.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any()).Return(nil, errors.New("audit error"))
 
 	client := NewLedgerGrpcClient(mock)
-	_, err := client.ListAuditEntries(context.Background(), 10, 0, nil, false)
+	_, err := client.ListAuditEntries(context.Background(), 10, 0, nil, false, 0)
 	require.Error(t, err)
 }
 

--- a/internal/adapter/grpc/consistency.go
+++ b/internal/adapter/grpc/consistency.go
@@ -15,8 +15,9 @@ const (
 	// ConsistencyStale skips the ReadIndex barrier and reads from the local store directly.
 	// Data may lag behind the latest committed index.
 	ConsistencyStale = "stale"
-	// ConsistencyLeader forwards the read to the leader node, which always has
-	// the most up-to-date data and a fast ReadIndex barrier.
+	// ConsistencyLeader routes the read to the node currently considered leader.
+	// A remote leader applies the default ReadIndex barrier, but a node that
+	// already considers itself leader serves the read locally without one.
 	ConsistencyLeader = "leader"
 )
 

--- a/internal/adapter/grpc/controller_generated_test.go
+++ b/internal/adapter/grpc/controller_generated_test.go
@@ -905,18 +905,18 @@ func (c *MockControllerListAccountsCall) DoAndReturn(f func(context.Context, str
 }
 
 // ListAuditEntries mocks base method.
-func (m *MockController) ListAuditEntries(ctx context.Context, pageSize uint32, afterSequence uint64, filter *commonpb.QueryFilter, reverse bool) (cursor.Cursor[*auditpb.AuditEntry], error) {
+func (m *MockController) ListAuditEntries(ctx context.Context, pageSize uint32, afterSequence uint64, filter *commonpb.QueryFilter, reverse bool, minLogSequence uint64) (cursor.Cursor[*auditpb.AuditEntry], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAuditEntries", ctx, pageSize, afterSequence, filter, reverse)
+	ret := m.ctrl.Call(m, "ListAuditEntries", ctx, pageSize, afterSequence, filter, reverse, minLogSequence)
 	ret0, _ := ret[0].(cursor.Cursor[*auditpb.AuditEntry])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListAuditEntries indicates an expected call of ListAuditEntries.
-func (mr *MockControllerMockRecorder) ListAuditEntries(ctx, pageSize, afterSequence, filter, reverse any) *MockControllerListAuditEntriesCall {
+func (mr *MockControllerMockRecorder) ListAuditEntries(ctx, pageSize, afterSequence, filter, reverse, minLogSequence any) *MockControllerListAuditEntriesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuditEntries", reflect.TypeOf((*MockController)(nil).ListAuditEntries), ctx, pageSize, afterSequence, filter, reverse)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuditEntries", reflect.TypeOf((*MockController)(nil).ListAuditEntries), ctx, pageSize, afterSequence, filter, reverse, minLogSequence)
 	return &MockControllerListAuditEntriesCall{Call: call}
 }
 
@@ -932,13 +932,13 @@ func (c *MockControllerListAuditEntriesCall) Return(arg0 cursor.Cursor[*auditpb.
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockControllerListAuditEntriesCall) Do(f func(context.Context, uint32, uint64, *commonpb.QueryFilter, bool) (cursor.Cursor[*auditpb.AuditEntry], error)) *MockControllerListAuditEntriesCall {
+func (c *MockControllerListAuditEntriesCall) Do(f func(context.Context, uint32, uint64, *commonpb.QueryFilter, bool, uint64) (cursor.Cursor[*auditpb.AuditEntry], error)) *MockControllerListAuditEntriesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockControllerListAuditEntriesCall) DoAndReturn(f func(context.Context, uint32, uint64, *commonpb.QueryFilter, bool) (cursor.Cursor[*auditpb.AuditEntry], error)) *MockControllerListAuditEntriesCall {
+func (c *MockControllerListAuditEntriesCall) DoAndReturn(f func(context.Context, uint32, uint64, *commonpb.QueryFilter, bool, uint64) (cursor.Cursor[*auditpb.AuditEntry], error)) *MockControllerListAuditEntriesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/adapter/grpc/server_bucket.go
+++ b/internal/adapter/grpc/server_bucket.go
@@ -1045,13 +1045,11 @@ func (impl *BucketServiceServerImpl) ListAuditEntries(req *servicepb.ListAuditEn
 	} else {
 		minLogSeq := opts.GetRead().GetMinLogSequence()
 
-		// A filtered live read resolves through the async audit secondary index,
-		// which lags the audit zone independently of the log index. Gate it on the
-		// audit-index progress so the requested consistency bound actually covers
-		// the index this read consults. An unfiltered read scans the Cold/Audit
-		// zone directly and is always current, so it keeps the plain log-index wait
-		// (its fast path is unchanged).
-		if opts.GetFilter() != nil {
+		// Filters that consult the async audit secondary index need its independent
+		// progress gate. Nil filters and conjunctions made only of seq bounds scan
+		// the Cold/Audit zone directly, so coupling them to audit-index progress
+		// would make an authoritative read wait for a projection it never uses.
+		if query.AuditFilterNeedsIndex(opts.GetFilter()) {
 			if waitErr := impl.waitFilteredAuditConsistency(ctx, minLogSeq); waitErr != nil {
 				return waitErr
 			}
@@ -1059,7 +1057,7 @@ func (impl *BucketServiceServerImpl) ListAuditEntries(req *servicepb.ListAuditEn
 			return waitErr
 		}
 
-		c, err = impl.ctrl.ListAuditEntries(ctx, fetchSize, afterSeq, opts.GetFilter(), opts.GetReverse())
+		c, err = impl.ctrl.ListAuditEntries(ctx, fetchSize, afterSeq, opts.GetFilter(), opts.GetReverse(), minLogSeq)
 	}
 
 	if err != nil {

--- a/internal/adapter/grpc/server_bucket_audit_consistency_test.go
+++ b/internal/adapter/grpc/server_bucket_audit_consistency_test.go
@@ -112,12 +112,32 @@ func newAuditConsistencyHarness(t *testing.T) (*BucketServiceServerImpl, *ctrlmo
 	return impl, mockCtrl, mainStore, rs
 }
 
-// singleFieldFilter builds a minimal non-nil QueryFilter so the handler takes
-// the filtered branch. Its content is irrelevant here: the controller is mocked,
-// so the filter is never actually compiled — only its presence matters.
-func singleFieldFilter() *commonpb.QueryFilter {
+func indexedAuditFilter() *commonpb.QueryFilter {
 	return &commonpb.QueryFilter{
-		Filter: &commonpb.QueryFilter_Field{Field: &commonpb.FieldCondition{}},
+		Filter: &commonpb.QueryFilter_Audit{Audit: &commonpb.AuditCondition{
+			Field: commonpb.AuditField_AUDIT_FIELD_OUTCOME,
+			Condition: &commonpb.AuditCondition_StringCond{StringCond: &commonpb.StringCondition{
+				Value: &commonpb.StringCondition_Hardcoded{Hardcoded: "failure"},
+			}},
+		}},
+	}
+}
+
+func auditSequenceFilter(lower, upper *uint64) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{
+		Filter: &commonpb.QueryFilter_Audit{Audit: &commonpb.AuditCondition{
+			Field: commonpb.AuditField_AUDIT_FIELD_SEQUENCE,
+			Condition: &commonpb.AuditCondition_UintCond{UintCond: &commonpb.UintCondition{
+				Min: lower,
+				Max: upper,
+			}},
+		}},
+	}
+}
+
+func auditAnd(filters ...*commonpb.QueryFilter) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{
+		Filter: &commonpb.QueryFilter_And{And: &commonpb.AndFilter{Filters: filters}},
 	}
 }
 
@@ -139,8 +159,8 @@ func TestListAuditEntriesFilteredWaitsForAuditProgress(t *testing.T) {
 	// The controller must only be called AFTER the audit index catches up.
 	controllerCalled := make(chan struct{})
 	mockCtrl.EXPECT().
-		ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ uint32, _ uint64, _ *commonpb.QueryFilter, _ bool) (cursor.Cursor[*auditpb.AuditEntry], error) {
+		ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any(), uint64(5)).
+		DoAndReturn(func(_ context.Context, _ uint32, _ uint64, _ *commonpb.QueryFilter, _ bool, _ uint64) (cursor.Cursor[*auditpb.AuditEntry], error) {
 			close(controllerCalled)
 
 			return cursor.NewSliceCursor([]*auditpb.AuditEntry(nil)), nil
@@ -154,7 +174,7 @@ func TestListAuditEntriesFilteredWaitsForAuditProgress(t *testing.T) {
 		stream := newAuditStream(t, ctx)
 		req := &servicepb.ListAuditEntriesRequest{Options: &commonpb.ListOptions{
 			PageSize: 2,
-			Filter:   singleFieldFilter(),
+			Filter:   indexedAuditFilter(),
 			Read:     &commonpb.ReadOptions{MinLogSequence: 5},
 		}}
 		handlerErr <- impl.ListAuditEntries(req, stream)
@@ -205,7 +225,7 @@ func TestListAuditEntriesFilteredDoesNotWaitOnLogSequenceInAuditSpace(t *testing
 	writeReadstoreAuditProgress(t, rs, 2)
 
 	mockCtrl.EXPECT().
-		ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any()).
+		ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Not(gomock.Nil()), gomock.Any(), uint64(10)).
 		Return(cursor.NewSliceCursor([]*auditpb.AuditEntry(nil)), nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -214,7 +234,7 @@ func TestListAuditEntriesFilteredDoesNotWaitOnLogSequenceInAuditSpace(t *testing
 	stream := newAuditStream(t, ctx)
 	req := &servicepb.ListAuditEntriesRequest{Options: &commonpb.ListOptions{
 		PageSize: 2,
-		Filter:   singleFieldFilter(),
+		Filter:   indexedAuditFilter(),
 		Read:     &commonpb.ReadOptions{MinLogSequence: 10},
 	}}
 
@@ -237,7 +257,7 @@ func TestListAuditEntriesUnfilteredDoesNotWaitOnAuditProgress(t *testing.T) {
 	// Audit index deliberately left at 0 — an unfiltered read must not care.
 
 	mockCtrl.EXPECT().
-		ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Nil(), gomock.Any()).
+		ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Nil(), gomock.Any(), uint64(5)).
 		Return(cursor.NewSliceCursor([]*auditpb.AuditEntry(nil)), nil)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -251,6 +271,106 @@ func TestListAuditEntriesUnfilteredDoesNotWaitOnAuditProgress(t *testing.T) {
 	}}
 
 	require.NoError(t, impl.ListAuditEntries(req, stream))
+}
+
+func TestListAuditEntriesSequenceBoundsDoNotWaitOnAuditProgress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		filter *commonpb.QueryFilter
+	}{
+		{
+			name:   "single sequence bound",
+			filter: auditSequenceFilter(new(uint64(3)), nil),
+		},
+		{
+			name: "and-combined sequence bounds",
+			filter: auditAnd(
+				auditSequenceFilter(new(uint64(3)), nil),
+				auditSequenceFilter(nil, new(uint64(12))),
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			impl, mockCtrl, mainStore, rs := newAuditConsistencyHarness(t)
+			writeReadstoreLogProgress(t, rs, 5)
+			writeMainAuditEntry(t, mainStore, 9)
+			// The query scans the audit zone directly, so a stalled audit index
+			// must not prevent the controller call.
+			writeReadstoreAuditProgress(t, rs, 1)
+
+			mockCtrl.EXPECT().
+				ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), tt.filter, gomock.Any(), uint64(5)).
+				Return(cursor.NewSliceCursor([]*auditpb.AuditEntry(nil)), nil)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			req := &servicepb.ListAuditEntriesRequest{Options: &commonpb.ListOptions{
+				PageSize: 2,
+				Filter:   tt.filter,
+				Read:     &commonpb.ReadOptions{MinLogSequence: 5},
+			}}
+
+			require.NoError(t, impl.ListAuditEntries(req, newAuditStream(t, ctx)))
+		})
+	}
+}
+
+func TestListAuditEntriesSequenceAndIndexedFieldWaitsForAuditProgress(t *testing.T) {
+	t.Parallel()
+
+	impl, mockCtrl, mainStore, rs := newAuditConsistencyHarness(t)
+	writeReadstoreLogProgress(t, rs, 5)
+	writeMainAuditEntry(t, mainStore, 9)
+	writeReadstoreAuditProgress(t, rs, 3)
+
+	filter := auditAnd(
+		auditSequenceFilter(new(uint64(3)), nil),
+		indexedAuditFilter(),
+	)
+	controllerCalled := make(chan struct{})
+	mockCtrl.EXPECT().
+		ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), filter, gomock.Any(), uint64(5)).
+		DoAndReturn(func(_ context.Context, _ uint32, _ uint64, _ *commonpb.QueryFilter, _ bool, _ uint64) (cursor.Cursor[*auditpb.AuditEntry], error) {
+			close(controllerCalled)
+
+			return cursor.NewSliceCursor([]*auditpb.AuditEntry(nil)), nil
+		})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	handlerErr := make(chan error, 1)
+	go func() {
+		req := &servicepb.ListAuditEntriesRequest{Options: &commonpb.ListOptions{
+			PageSize: 2,
+			Filter:   filter,
+			Read:     &commonpb.ReadOptions{MinLogSequence: 5},
+		}}
+		handlerErr <- impl.ListAuditEntries(req, newAuditStream(t, ctx))
+	}()
+
+	select {
+	case <-controllerCalled:
+		t.Fatal("controller called before audit index caught up for a mixed filter")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	writeReadstoreAuditProgress(t, rs, 9)
+	rs.NotifyProgress()
+
+	select {
+	case err := <-handlerErr:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("handler did not return after audit index caught up")
+	}
 }
 
 // TestListAuditEntriesFilteredContextCancelWhileWaiting verifies a filtered read
@@ -267,7 +387,7 @@ func TestListAuditEntriesFilteredContextCancelWhileWaiting(t *testing.T) {
 
 	// Controller must never be reached.
 	mockCtrl.EXPECT().
-		ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Times(0)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -277,7 +397,7 @@ func TestListAuditEntriesFilteredContextCancelWhileWaiting(t *testing.T) {
 		stream := newAuditStream(t, ctx)
 		req := &servicepb.ListAuditEntriesRequest{Options: &commonpb.ListOptions{
 			PageSize: 2,
-			Filter:   singleFieldFilter(),
+			Filter:   indexedAuditFilter(),
 			Read:     &commonpb.ReadOptions{MinLogSequence: 5},
 		}}
 		handlerErr <- impl.ListAuditEntries(req, stream)

--- a/internal/adapter/grpc/server_bucket_list_test.go
+++ b/internal/adapter/grpc/server_bucket_list_test.go
@@ -268,8 +268,8 @@ func TestListAuditEntries(t *testing.T) {
 		t.Parallel()
 
 		impl, mockCtrl := newListHandlerHarness(t)
-		// ListAuditEntries(ctx, pageSize, afterSequence, filter, reverse)
-		mockCtrl.EXPECT().ListAuditEntries(gomock.Any(), uint32(3), uint64(0), nil, false).
+		// ListAuditEntries(ctx, pageSize, afterSequence, filter, reverse, minLogSequence)
+		mockCtrl.EXPECT().ListAuditEntries(gomock.Any(), uint32(3), uint64(0), nil, false, uint64(0)).
 			Return(page(
 				&auditpb.AuditEntry{Sequence: 1},
 				&auditpb.AuditEntry{Sequence: 2},

--- a/internal/adapter/http/backend_generated_test.go
+++ b/internal/adapter/http/backend_generated_test.go
@@ -1059,18 +1059,18 @@ func (c *MockBackendListAccountsCall) DoAndReturn(f func(context.Context, string
 }
 
 // ListAuditEntries mocks base method.
-func (m *MockBackend) ListAuditEntries(ctx context.Context, pageSize uint32, afterSequence uint64, filter *commonpb.QueryFilter, reverse bool) (cursor.Cursor[*auditpb.AuditEntry], error) {
+func (m *MockBackend) ListAuditEntries(ctx context.Context, pageSize uint32, afterSequence uint64, filter *commonpb.QueryFilter, reverse bool, minLogSequence uint64) (cursor.Cursor[*auditpb.AuditEntry], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAuditEntries", ctx, pageSize, afterSequence, filter, reverse)
+	ret := m.ctrl.Call(m, "ListAuditEntries", ctx, pageSize, afterSequence, filter, reverse, minLogSequence)
 	ret0, _ := ret[0].(cursor.Cursor[*auditpb.AuditEntry])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListAuditEntries indicates an expected call of ListAuditEntries.
-func (mr *MockBackendMockRecorder) ListAuditEntries(ctx, pageSize, afterSequence, filter, reverse any) *MockBackendListAuditEntriesCall {
+func (mr *MockBackendMockRecorder) ListAuditEntries(ctx, pageSize, afterSequence, filter, reverse, minLogSequence any) *MockBackendListAuditEntriesCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuditEntries", reflect.TypeOf((*MockBackend)(nil).ListAuditEntries), ctx, pageSize, afterSequence, filter, reverse)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuditEntries", reflect.TypeOf((*MockBackend)(nil).ListAuditEntries), ctx, pageSize, afterSequence, filter, reverse, minLogSequence)
 	return &MockBackendListAuditEntriesCall{Call: call}
 }
 
@@ -1086,13 +1086,13 @@ func (c *MockBackendListAuditEntriesCall) Return(arg0 cursor.Cursor[*auditpb.Aud
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockBackendListAuditEntriesCall) Do(f func(context.Context, uint32, uint64, *commonpb.QueryFilter, bool) (cursor.Cursor[*auditpb.AuditEntry], error)) *MockBackendListAuditEntriesCall {
+func (c *MockBackendListAuditEntriesCall) Do(f func(context.Context, uint32, uint64, *commonpb.QueryFilter, bool, uint64) (cursor.Cursor[*auditpb.AuditEntry], error)) *MockBackendListAuditEntriesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockBackendListAuditEntriesCall) DoAndReturn(f func(context.Context, uint32, uint64, *commonpb.QueryFilter, bool) (cursor.Cursor[*auditpb.AuditEntry], error)) *MockBackendListAuditEntriesCall {
+func (c *MockBackendListAuditEntriesCall) DoAndReturn(f func(context.Context, uint32, uint64, *commonpb.QueryFilter, bool, uint64) (cursor.Cursor[*auditpb.AuditEntry], error)) *MockBackendListAuditEntriesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/adapter/http/handlers_get_audit_entry_test.go
+++ b/internal/adapter/http/handlers_get_audit_entry_test.go
@@ -111,8 +111,8 @@ func TestAuditRoutes_FullRouteIntegration(t *testing.T) {
 	t.Parallel()
 
 	backend := NewMockBackend(gomock.NewController(t))
-	backend.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ uint32, _ uint64, _ *commonpb.QueryFilter, _ bool) (cursor.Cursor[*auditpb.AuditEntry], error) {
+	backend.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), uint64(0)).DoAndReturn(
+		func(_ context.Context, _ uint32, _ uint64, _ *commonpb.QueryFilter, _ bool, _ uint64) (cursor.Cursor[*auditpb.AuditEntry], error) {
 			return cursor.NewSliceCursor([]*auditpb.AuditEntry{{Sequence: 1}}), nil
 		}).AnyTimes()
 	backend.EXPECT().GetAuditEntry(gomock.Any(), uint64(1)).DoAndReturn(

--- a/internal/adapter/http/handlers_get_numscript_usage.go
+++ b/internal/adapter/http/handlers_get_numscript_usage.go
@@ -43,9 +43,9 @@ func toTemplateUsageJSON(usage *commonpb.TemplateUsage) *templateUsageJSON {
 // handleGetNumscriptUsage handles GET /{ledgerName}/numscripts/{name}/usage.
 // Returns the invocation counter + last-used timestamp populated by the
 // usagebuilder subsystem. Values are eventually consistent with the FSM
-// (may lag by up to one usagebuilder tick). A never-invoked template on
-// an existing ledger returns a zero-valued response, not a 404 — clients
-// treat 0 uniformly. Unknown / soft-deleted ledgers surface a 404 (via
+// (may lag while the usagebuilder drains pending batches). A never-invoked
+// template on an existing ledger returns a zero-valued response, not a 404 —
+// clients treat 0 uniformly. Unknown / soft-deleted ledgers surface a 404 (via
 // the underlying controller).
 func (s *Server) handleGetNumscriptUsage(w http.ResponseWriter, r *http.Request) {
 	ledgerName, ok := requireLedgerName(w, r)

--- a/internal/adapter/http/handlers_list_audit_entries.go
+++ b/internal/adapter/http/handlers_list_audit_entries.go
@@ -36,12 +36,13 @@ import (
 // additionally honors the read-consistency options `checkpointId` (pinned
 // checkpoint read) and `minLogSequence` (audit-index catch-up wait for filtered
 // reads). This HTTP endpoint intentionally does not expose either — it always
-// performs a live, best-effort read. A filtered live read therefore resolves
-// through the async audit secondary index and may transiently omit very recent
-// entries that have not yet been indexed; a client needing a pinned or
-// consistency-bounded audit read must use the gRPC surface. If these options
-// are added to HTTP later, wire them through the same controller entry points
-// the gRPC path uses (impl.openCheckpointStores / minLogSequence gating).
+// performs a live, best-effort read. A filter containing a field other than
+// seq therefore resolves through the async audit secondary index and may
+// transiently omit very recent entries that have not yet been indexed; a client
+// needing a pinned or consistency-bounded audit read must use the gRPC surface.
+// If these options are added to HTTP later, wire them through the same
+// controller entry points the gRPC path uses (impl.openCheckpointStores /
+// minLogSequence gating).
 func (s *Server) handleListAuditEntries(w http.ResponseWriter, r *http.Request) {
 	pageSize, ok := parsePageSize(w, r)
 	if !ok {
@@ -67,7 +68,7 @@ func (s *Server) handleListAuditEntries(w http.ResponseWriter, r *http.Request) 
 
 	reverse := queryParamBool(r, "reverse")
 
-	cursor, err := s.backend.ListAuditEntries(r.Context(), pageSize, afterSequence, filter, reverse)
+	cursor, err := s.backend.ListAuditEntries(r.Context(), pageSize, afterSequence, filter, reverse, 0)
 	if err != nil {
 		handleError(w, r, err)
 

--- a/internal/adapter/http/handlers_list_audit_entries_test.go
+++ b/internal/adapter/http/handlers_list_audit_entries_test.go
@@ -21,8 +21,8 @@ func TestHandleListAuditEntries_Success(t *testing.T) {
 	t.Parallel()
 
 	backend := NewMockBackend(gomock.NewController(t))
-	backend.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ uint32, _ uint64, _ *commonpb.QueryFilter, _ bool) (cursor.Cursor[*auditpb.AuditEntry], error) {
+	backend.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), uint64(0)).DoAndReturn(
+		func(_ context.Context, _ uint32, _ uint64, _ *commonpb.QueryFilter, _ bool, _ uint64) (cursor.Cursor[*auditpb.AuditEntry], error) {
 			return cursor.NewSliceCursor([]*auditpb.AuditEntry{
 				{Sequence: 1},
 				{Sequence: 2},
@@ -47,8 +47,8 @@ func TestHandleListAuditEntries_Empty(t *testing.T) {
 	t.Parallel()
 
 	backend := NewMockBackend(gomock.NewController(t))
-	backend.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ uint32, _ uint64, _ *commonpb.QueryFilter, _ bool) (cursor.Cursor[*auditpb.AuditEntry], error) {
+	backend.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), uint64(0)).DoAndReturn(
+		func(_ context.Context, _ uint32, _ uint64, _ *commonpb.QueryFilter, _ bool, _ uint64) (cursor.Cursor[*auditpb.AuditEntry], error) {
 			return cursor.NewSliceCursor[*auditpb.AuditEntry](nil), nil
 		}).AnyTimes()
 	srv := newTestServer(t, backend)
@@ -68,8 +68,8 @@ func TestHandleListAuditEntries_Pagination(t *testing.T) {
 	t.Parallel()
 
 	backend := NewMockBackend(gomock.NewController(t))
-	backend.EXPECT().ListAuditEntries(gomock.Any(), uint32(10), uint64(42), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, pageSize uint32, afterSequence uint64, _ *commonpb.QueryFilter, _ bool) (cursor.Cursor[*auditpb.AuditEntry], error) {
+	backend.EXPECT().ListAuditEntries(gomock.Any(), uint32(10), uint64(42), gomock.Any(), gomock.Any(), uint64(0)).DoAndReturn(
+		func(_ context.Context, pageSize uint32, afterSequence uint64, _ *commonpb.QueryFilter, _ bool, _ uint64) (cursor.Cursor[*auditpb.AuditEntry], error) {
 			require.EqualValues(t, 10, pageSize)
 			require.EqualValues(t, 42, afterSequence)
 
@@ -89,8 +89,8 @@ func TestHandleListAuditEntries_Reverse(t *testing.T) {
 	t.Parallel()
 
 	backend := NewMockBackend(gomock.NewController(t))
-	backend.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), true).DoAndReturn(
-		func(_ context.Context, _ uint32, _ uint64, _ *commonpb.QueryFilter, reverse bool) (cursor.Cursor[*auditpb.AuditEntry], error) {
+	backend.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), true, uint64(0)).DoAndReturn(
+		func(_ context.Context, _ uint32, _ uint64, _ *commonpb.QueryFilter, reverse bool, _ uint64) (cursor.Cursor[*auditpb.AuditEntry], error) {
 			require.True(t, reverse)
 
 			return cursor.NewSliceCursor[*auditpb.AuditEntry](nil), nil
@@ -114,8 +114,8 @@ func TestHandleListAuditEntries_MarshalFailureIsClean500(t *testing.T) {
 	t.Parallel()
 
 	backend := NewMockBackend(gomock.NewController(t))
-	backend.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ uint32, _ uint64, _ *commonpb.QueryFilter, _ bool) (cursor.Cursor[*auditpb.AuditEntry], error) {
+	backend.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), uint64(0)).DoAndReturn(
+		func(_ context.Context, _ uint32, _ uint64, _ *commonpb.QueryFilter, _ bool, _ uint64) (cursor.Cursor[*auditpb.AuditEntry], error) {
 			return cursor.NewSliceCursor([]*auditpb.AuditEntry{
 				{
 					Sequence:       1,
@@ -169,8 +169,8 @@ func TestHandleListAuditEntries_LedgerFilter(t *testing.T) {
 	t.Parallel()
 
 	backend := NewMockBackend(gomock.NewController(t))
-	backend.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ uint32, _ uint64, filter *commonpb.QueryFilter, _ bool) (cursor.Cursor[*auditpb.AuditEntry], error) {
+	backend.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), uint64(0)).DoAndReturn(
+		func(_ context.Context, _ uint32, _ uint64, filter *commonpb.QueryFilter, _ bool, _ uint64) (cursor.Cursor[*auditpb.AuditEntry], error) {
 			require.NotNil(t, filter)
 			audit := filter.GetAudit()
 			require.NotNil(t, audit)
@@ -195,8 +195,8 @@ func TestHandleListAuditEntries_OutcomeFilter(t *testing.T) {
 	t.Parallel()
 
 	backend := NewMockBackend(gomock.NewController(t))
-	backend.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ uint32, _ uint64, filter *commonpb.QueryFilter, _ bool) (cursor.Cursor[*auditpb.AuditEntry], error) {
+	backend.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), uint64(0)).DoAndReturn(
+		func(_ context.Context, _ uint32, _ uint64, filter *commonpb.QueryFilter, _ bool, _ uint64) (cursor.Cursor[*auditpb.AuditEntry], error) {
 			require.NotNil(t, filter)
 			require.Equal(t, commonpb.AuditField_AUDIT_FIELD_OUTCOME, filter.GetAudit().GetField())
 
@@ -233,8 +233,8 @@ func TestHandleListAuditEntries_UnsupportedFilterMapsTo400(t *testing.T) {
 	t.Parallel()
 
 	backend := NewMockBackend(gomock.NewController(t))
-	backend.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, _ uint32, _ uint64, _ *commonpb.QueryFilter, _ bool) (cursor.Cursor[*auditpb.AuditEntry], error) {
+	backend.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), uint64(0)).DoAndReturn(
+		func(_ context.Context, _ uint32, _ uint64, _ *commonpb.QueryFilter, _ bool, _ uint64) (cursor.Cursor[*auditpb.AuditEntry], error) {
 			return nil, status.Error(codes.InvalidArgument, "unsupported filter for audit entries")
 		}).Times(1)
 	srv := newTestServer(t, backend)

--- a/internal/application/ctrl/controller.go
+++ b/internal/application/ctrl/controller.go
@@ -52,7 +52,9 @@ type Controller interface {
 	GetLog(ctx context.Context, sequence uint64) (*commonpb.Log, error)
 
 	// Audit operations
-	ListAuditEntries(ctx context.Context, pageSize uint32, afterSequence uint64, filter *commonpb.QueryFilter, reverse bool) (cursor.Cursor[*auditpb.AuditEntry], error)
+	// minLogSequence is carried across routed controller hops so the serving
+	// gRPC handler can enforce audit-index freshness on its own replica.
+	ListAuditEntries(ctx context.Context, pageSize uint32, afterSequence uint64, filter *commonpb.QueryFilter, reverse bool, minLogSequence uint64) (cursor.Cursor[*auditpb.AuditEntry], error)
 	GetAuditEntry(ctx context.Context, sequence uint64) (*auditpb.AuditEntry, error)
 
 	// Chapter operations
@@ -82,9 +84,9 @@ type Controller interface {
 
 	// GetTemplateUsage returns the invocation counter and last-used timestamp
 	// for a Numscript template. Reads from the usagebuilder side-store, so
-	// values may lag the live FSM by up to one tick interval. Returns a
-	// zero-valued TemplateUsage when the template has never been invoked (or
-	// the usagebuilder has not caught up to any of its invocations yet).
+	// values may lag the live FSM while the worker drains pending batches.
+	// Returns a zero-valued TemplateUsage when the template has never been
+	// invoked (or the usagebuilder has not caught up to any invocation yet).
 	GetTemplateUsage(ctx context.Context, ledger, name string) (*commonpb.TemplateUsage, error)
 
 	// Cluster-wide config operations (read-only)

--- a/internal/application/ctrl/controller_default.go
+++ b/internal/application/ctrl/controller_default.go
@@ -622,8 +622,8 @@ func (ctrl *DefaultController) GetAccount(ctx context.Context, ledgerName string
 // counter (PostingCount, RevertCount, NumscriptExecutionCount,
 // ReferenceCount, EphemeralEvictedCount, TransientUsedCount, VolumeCount)
 // is derived from the audit chain by the usagebuilder and read from the
-// usagestore side-store through a single Pebble snapshot — expect up to
-// one usagebuilder tick interval of lag behind the live FSM. See EN-1420
+// usagestore side-store through a single Pebble snapshot. The projection may
+// lag the live FSM while the usagebuilder drains pending batches. See EN-1420
 // and EN-1422.
 //
 // MetadataCount is intentionally not returned: the admission preload no
@@ -1753,7 +1753,7 @@ func (ctrl *DefaultController) ListLogs(ctx context.Context, ledgerName string, 
 // iterates ascending by sequence (oldest first) — this is the audit trail's
 // natural read order and is preserved from the pre-ListOptions behavior.
 // reverse=true iterates descending (newest first).
-func (ctrl *DefaultController) ListAuditEntries(ctx context.Context, pageSize uint32, afterSequence uint64, filter *commonpb.QueryFilter, reverse bool) (cursor.Cursor[*auditpb.AuditEntry], error) {
+func (ctrl *DefaultController) ListAuditEntries(ctx context.Context, pageSize uint32, afterSequence uint64, filter *commonpb.QueryFilter, reverse bool, _ uint64) (cursor.Cursor[*auditpb.AuditEntry], error) {
 	return ctrl.ListAuditEntriesFrom(ctx, ctrl.store, ctrl.readStore, pageSize, afterSequence, filter, reverse)
 }
 
@@ -1957,9 +1957,9 @@ func (ctrl *DefaultController) GetNumscript(ctx context.Context, ledger, name st
 // GetTemplateUsage returns the invocation counter and last-used timestamp
 // for a Numscript template. Values are populated by the usagebuilder
 // subsystem asynchronously from the audit chain: a template that was just
-// invoked may not yet be reflected here for up to one usagebuilder tick
-// (100 ms). Returns a zero-valued TemplateUsage (never nil) when the
-// template has never been invoked on an existing ledger.
+// invoked may not yet be reflected here while the worker drains pending
+// batches. Returns a zero-valued TemplateUsage (never nil) when the template
+// has never been invoked on an existing ledger.
 //
 // Ledger existence is validated first so an unknown or soft-deleted ledger
 // surfaces a NotFound business error (HTTP 404) rather than a zero-valued 200 —

--- a/internal/application/ctrl/controller_generated_test.go
+++ b/internal/application/ctrl/controller_generated_test.go
@@ -376,18 +376,18 @@ func (mr *MockControllerMockRecorder) ListAccounts(ctx, ledgerName, pageSize, af
 }
 
 // ListAuditEntries mocks base method.
-func (m *MockController) ListAuditEntries(ctx context.Context, pageSize uint32, afterSequence uint64, filter *commonpb.QueryFilter, reverse bool) (cursor.Cursor[*auditpb.AuditEntry], error) {
+func (m *MockController) ListAuditEntries(ctx context.Context, pageSize uint32, afterSequence uint64, filter *commonpb.QueryFilter, reverse bool, minLogSequence uint64) (cursor.Cursor[*auditpb.AuditEntry], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAuditEntries", ctx, pageSize, afterSequence, filter, reverse)
+	ret := m.ctrl.Call(m, "ListAuditEntries", ctx, pageSize, afterSequence, filter, reverse, minLogSequence)
 	ret0, _ := ret[0].(cursor.Cursor[*auditpb.AuditEntry])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListAuditEntries indicates an expected call of ListAuditEntries.
-func (mr *MockControllerMockRecorder) ListAuditEntries(ctx, pageSize, afterSequence, filter, reverse any) *gomock.Call {
+func (mr *MockControllerMockRecorder) ListAuditEntries(ctx, pageSize, afterSequence, filter, reverse, minLogSequence any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuditEntries", reflect.TypeOf((*MockController)(nil).ListAuditEntries), ctx, pageSize, afterSequence, filter, reverse)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuditEntries", reflect.TypeOf((*MockController)(nil).ListAuditEntries), ctx, pageSize, afterSequence, filter, reverse, minLogSequence)
 }
 
 // ListChapters mocks base method.

--- a/internal/application/ctrl/ctrlmock/controller_generated.go
+++ b/internal/application/ctrl/ctrlmock/controller_generated.go
@@ -377,18 +377,18 @@ func (mr *MockControllerMockRecorder) ListAccounts(ctx, ledgerName, pageSize, af
 }
 
 // ListAuditEntries mocks base method.
-func (m *MockController) ListAuditEntries(ctx context.Context, pageSize uint32, afterSequence uint64, filter *commonpb.QueryFilter, reverse bool) (cursor.Cursor[*auditpb.AuditEntry], error) {
+func (m *MockController) ListAuditEntries(ctx context.Context, pageSize uint32, afterSequence uint64, filter *commonpb.QueryFilter, reverse bool, minLogSequence uint64) (cursor.Cursor[*auditpb.AuditEntry], error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAuditEntries", ctx, pageSize, afterSequence, filter, reverse)
+	ret := m.ctrl.Call(m, "ListAuditEntries", ctx, pageSize, afterSequence, filter, reverse, minLogSequence)
 	ret0, _ := ret[0].(cursor.Cursor[*auditpb.AuditEntry])
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListAuditEntries indicates an expected call of ListAuditEntries.
-func (mr *MockControllerMockRecorder) ListAuditEntries(ctx, pageSize, afterSequence, filter, reverse any) *gomock.Call {
+func (mr *MockControllerMockRecorder) ListAuditEntries(ctx, pageSize, afterSequence, filter, reverse, minLogSequence any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuditEntries", reflect.TypeOf((*MockController)(nil).ListAuditEntries), ctx, pageSize, afterSequence, filter, reverse)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAuditEntries", reflect.TypeOf((*MockController)(nil).ListAuditEntries), ctx, pageSize, afterSequence, filter, reverse, minLogSequence)
 }
 
 // ListChapters mocks base method.

--- a/internal/bootstrap/controller_routed.go
+++ b/internal/bootstrap/controller_routed.go
@@ -29,8 +29,8 @@ type RoutedController struct {
 	localController ctrl.Controller
 }
 
-// getLeaderCtrl returns a controller that talks to the leader.
-// Used only for operations that must execute on the leader (Apply, ListChapters).
+// getLeaderCtrl returns the local controller when this node considers itself
+// leader, or a client controller for the currently known remote leader.
 func (b *RoutedController) getLeaderCtrl() (ctrl.Controller, error) {
 	if b.IsLeader() {
 		return b.localController, nil
@@ -53,7 +53,8 @@ func (b *RoutedController) getLeaderCtrl() (ctrl.Controller, error) {
 // The consistency level is determined from the context (set by the gRPC interceptor):
 //   - linearizable (default): ReadIndex+WaitForApplied barrier on the local node
 //   - stale: skip the barrier and read from the local store directly
-//   - leader: forward the read to the leader node
+//   - leader: route the read to the node currently considered leader; the local
+//     leader shortcut does not perform a ReadIndex barrier
 //
 // For linearizable reads, if the local node is still syncing the read is
 // transparently forwarded to the leader.
@@ -72,17 +73,22 @@ func (b *RoutedController) readCtrl(ctx context.Context) (ctrl.Controller, *node
 	case grpcadp.ConsistencyLeader:
 		span.SetAttributes(attribute.String("route", "leader"))
 
-		// Forwarded: the leader runs its own ReadIndex barrier (x-consistency is
-		// not propagated, so it defaults to linearizable there) and its own
-		// execution. Neither is visible to this profile — the whole remote cost
-		// arrives as row-production time inside the local execute phase, and this
-		// node's barrier_duration_us stays 0. Flag it so a reader does not take
-		// that 0 to mean "no barrier was needed" (EN-1859).
-		query.ProfileFromContext(ctx).MarkForwarded()
-
 		c, err := b.getLeaderCtrl()
+		if err != nil {
+			return nil, nil, err
+		}
 
-		return c, nil, err
+		// When getLeaderCtrl returns a remote controller, that node runs its own
+		// ReadIndex barrier (x-consistency is not propagated, so it defaults to
+		// linearizable there). The remote barrier and execution are invisible to
+		// this profile — the whole remote cost arrives as row-production time
+		// inside the local execute phase, and this node's barrier_duration_us stays
+		// 0. Flag it so a reader does not take that 0 to mean "no barrier was
+		// needed" (EN-1859). When this node already considers itself leader,
+		// getLeaderCtrl returns the local controller and no barrier is performed.
+		b.markForwardedIfRemote(ctx, c)
+
+		return c, nil, nil
 	}
 
 	// The ReadIndex quorum round-trip plus the local WaitForApplied catch-up is
@@ -117,11 +123,9 @@ func (b *RoutedController) readCtrl(ctx context.Context) (ctrl.Controller, *node
 			// execute_duration_us and from there in the server total. Hence
 			// forwarded=true with a non-zero barrier_duration_us is a valid,
 			// documented combination.
-			query.ProfileFromContext(ctx).MarkForwarded()
-
 			c, leaderErr := b.getLeaderCtrl()
 
-			return c, nil, leaderErr
+			return b.finishLeaderFallback(ctx, c, leaderErr, err)
 		}
 
 		span.SetAttributes(attribute.String("route", "leader_readindex_failed"))
@@ -130,11 +134,40 @@ func (b *RoutedController) readCtrl(ctx context.Context) (ctrl.Controller, *node
 	return nil, nil, err
 }
 
+// finishLeaderFallback closes the leadership-transition race between the
+// initial IsLeader check and getLeaderCtrl. If leadership moved to this node in
+// that window, getLeaderCtrl returns the local controller; serving it would
+// bypass the ReadIndex barrier that just failed. Return the original barrier
+// failure instead. A route is profiled as forwarded only after a remote
+// controller has been resolved successfully.
+func (b *RoutedController) finishLeaderFallback(ctx context.Context, selected ctrl.Controller, resolutionErr, barrierErr error) (ctrl.Controller, *node.ReadBarrierInfo, error) {
+	if resolutionErr != nil {
+		return nil, nil, resolutionErr
+	}
+
+	if selected == b.localController {
+		return nil, nil, barrierErr
+	}
+
+	query.ProfileFromContext(ctx).MarkForwarded()
+
+	return selected, nil, nil
+}
+
+// markForwardedIfRemote preserves the query-profile contract that Forwarded
+// means another node served the read. The explicit leader-consistency path can
+// resolve to the local controller when this node considers itself leader.
+func (b *RoutedController) markForwardedIfRemote(ctx context.Context, selected ctrl.Controller) {
+	if selected != b.localController {
+		query.ProfileFromContext(ctx).MarkForwarded()
+	}
+}
+
 func (b *RoutedController) IsHealthy() bool {
 	return b.Node.IsHealthy()
 }
 
-// --- Write operations: forwarded to leader ---
+// --- Write operations: routed to leader ---
 
 func (b *RoutedController) Apply(ctx context.Context, req *servicepb.ApplyRequest) ([]*commonpb.Log, error) {
 	leaderCtrl, err := b.getLeaderCtrl()
@@ -154,10 +187,11 @@ func (b *RoutedController) Barrier(ctx context.Context) (uint64, error) {
 	return leaderCtrl.Barrier(ctx)
 }
 
-// --- Read operations requiring leader state: forwarded to leader ---
+// --- Read operations requiring leader routing ---
 
 func (b *RoutedController) ListChapters(ctx context.Context) (cursor.Cursor[*commonpb.Chapter], error) {
-	// Chapter state is in-memory on the leader — route to leader
+	// Chapter lifecycle operations are coordinated by the perceived leader, so
+	// keep reads on the same routing path even though the rows live in Pebble.
 	leaderCtrl, err := b.getLeaderCtrl()
 	if err != nil {
 		return nil, err
@@ -241,13 +275,13 @@ func (b *RoutedController) GetLog(ctx context.Context, sequence uint64) (*common
 	return c.GetLog(ctx, sequence)
 }
 
-func (b *RoutedController) ListAuditEntries(ctx context.Context, pageSize uint32, afterSequence uint64, filter *commonpb.QueryFilter, reverse bool) (cursor.Cursor[*auditpb.AuditEntry], error) {
+func (b *RoutedController) ListAuditEntries(ctx context.Context, pageSize uint32, afterSequence uint64, filter *commonpb.QueryFilter, reverse bool, minLogSequence uint64) (cursor.Cursor[*auditpb.AuditEntry], error) {
 	c, _, err := b.readCtrl(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.ListAuditEntries(ctx, pageSize, afterSequence, filter, reverse)
+	return c.ListAuditEntries(ctx, pageSize, afterSequence, filter, reverse, minLogSequence)
 }
 
 func (b *RoutedController) GetAuditEntry(ctx context.Context, sequence uint64) (*auditpb.AuditEntry, error) {

--- a/internal/bootstrap/controller_routed_test.go
+++ b/internal/bootstrap/controller_routed_test.go
@@ -1,11 +1,19 @@
 package bootstrap
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
+	grpcadp "github.com/formancehq/ledger/v3/internal/adapter/grpc"
 	"github.com/formancehq/ledger/v3/internal/application/ctrl"
+	"github.com/formancehq/ledger/v3/internal/application/ctrl/ctrlmock"
+	"github.com/formancehq/ledger/v3/internal/infra/node"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/query"
 )
 
 func TestNewRoutedController(t *testing.T) {
@@ -29,4 +37,76 @@ func TestRoutedController_IsHealthy_NilNode(t *testing.T) {
 	// Here we just confirm the method signature matches ctrl.Controller.
 	rc := &RoutedController{}
 	assert.NotNil(t, rc) // RoutedController can be instantiated
+}
+
+func TestRoutedController_MarkForwardedOnlyForRemoteController(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	local := ctrlmock.NewMockController(mockCtrl)
+	remote := ctrlmock.NewMockController(mockCtrl)
+	routed := &RoutedController{localController: local}
+
+	localCtx, localProfile := query.WithProfile(context.Background())
+	routed.markForwardedIfRemote(localCtx, local)
+	assert.False(t, localProfile.Forwarded)
+
+	remoteCtx, remoteProfile := query.WithProfile(context.Background())
+	routed.markForwardedIfRemote(remoteCtx, remote)
+	assert.True(t, remoteProfile.Forwarded)
+}
+
+func TestRoutedController_LeaderRoutingErrorIsNotForwarded(t *testing.T) {
+	t.Parallel()
+
+	routed := &RoutedController{Node: &node.Node{}}
+	ctx, profile := query.WithProfile(context.Background())
+	ctx = grpcadp.WithConsistency(ctx, grpcadp.ConsistencyLeader)
+
+	_, _, err := routed.readCtrl(ctx)
+	require.ErrorIs(t, err, commonpb.ErrNoLeader)
+	assert.False(t, profile.Forwarded)
+}
+
+func TestRoutedController_FinishLeaderFallback(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	local := ctrlmock.NewMockController(mockCtrl)
+	remote := ctrlmock.NewMockController(mockCtrl)
+	routed := &RoutedController{localController: local}
+	barrierErr := node.ErrNotLeader
+
+	t.Run("leadership moved local", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, profile := query.WithProfile(context.Background())
+		selected, barrier, err := routed.finishLeaderFallback(ctx, local, nil, barrierErr)
+		require.ErrorIs(t, err, barrierErr)
+		assert.Nil(t, selected)
+		assert.Nil(t, barrier)
+		assert.False(t, profile.Forwarded)
+	})
+
+	t.Run("remote leader resolved", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, profile := query.WithProfile(context.Background())
+		selected, barrier, err := routed.finishLeaderFallback(ctx, remote, nil, barrierErr)
+		require.NoError(t, err)
+		assert.Same(t, remote, selected)
+		assert.Nil(t, barrier)
+		assert.True(t, profile.Forwarded)
+	})
+
+	t.Run("leader resolution failed", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, profile := query.WithProfile(context.Background())
+		selected, barrier, err := routed.finishLeaderFallback(ctx, nil, commonpb.ErrNoLeader, barrierErr)
+		require.ErrorIs(t, err, commonpb.ErrNoLeader)
+		assert.Nil(t, selected)
+		assert.Nil(t, barrier)
+		assert.False(t, profile.Forwarded)
+	})
 }

--- a/internal/query/audit_filter.go
+++ b/internal/query/audit_filter.go
@@ -44,6 +44,54 @@ type auditCompiled struct {
 	hiSeq uint64
 }
 
+// AuditFilterNeedsIndex reports whether answering an audit filter may require
+// the asynchronous audit secondary index. A nil filter and a conjunction made
+// exclusively of valid sequence bounds use the authoritative audit-zone scan
+// directly. Every other shape returns true conservatively, including malformed,
+// unknown, OR, or over-depth trees; validation and compilation remain
+// responsible for returning the precise client error later.
+//
+// This predicate deliberately performs no index reads. The gRPC handler uses it
+// before the consistency wait, so compiling first would capture stale index
+// candidates before the barrier intended to make them fresh.
+func AuditFilterNeedsIndex(filter *commonpb.QueryFilter) bool {
+	return auditFilterNeedsIndex(filter, 0)
+}
+
+func auditFilterNeedsIndex(filter *commonpb.QueryFilter, depth int) bool {
+	if filter == nil {
+		return false
+	}
+	if depth >= MaxFilterDepth || filter.GetFilter() == nil {
+		return true
+	}
+
+	switch f := filter.GetFilter().(type) {
+	case *commonpb.QueryFilter_Audit:
+		if f.Audit == nil || f.Audit.GetField() != commonpb.AuditField_AUDIT_FIELD_SEQUENCE {
+			return true
+		}
+
+		_, err := compileAuditSeqBound(f.Audit)
+
+		return err != nil
+	case *commonpb.QueryFilter_And:
+		if f.And == nil {
+			return true
+		}
+
+		for _, child := range f.And.GetFilters() {
+			if auditFilterNeedsIndex(child, depth+1) {
+				return true
+			}
+		}
+
+		return false
+	default:
+		return true
+	}
+}
+
 // CompileAuditFilter turns a QueryFilter into the set of audit sequences that
 // satisfy it, resolved entirely through the audit secondary index plus an
 // audit-zone sequence bound. It returns:

--- a/internal/query/audit_filter_test.go
+++ b/internal/query/audit_filter_test.go
@@ -74,6 +74,57 @@ func TestCompileAuditFilter_Nil(t *testing.T) {
 	require.Equal(t, uint64(math.MaxUint64), hi)
 }
 
+func TestAuditFilterNeedsIndex(t *testing.T) {
+	t.Parallel()
+
+	seqLower := auditUint(commonpb.AuditField_AUDIT_FIELD_SEQUENCE, new(uint64(5)), nil)
+	seqUpper := auditUint(commonpb.AuditField_AUDIT_FIELD_SEQUENCE, nil, new(uint64(20)))
+	outcome := auditString(commonpb.AuditField_AUDIT_FIELD_OUTCOME, "failure")
+
+	seqAnd := &commonpb.QueryFilter{
+		Filter: &commonpb.QueryFilter_And{And: &commonpb.AndFilter{Filters: []*commonpb.QueryFilter{
+			seqLower,
+			seqUpper,
+		}}},
+	}
+	mixedAnd := &commonpb.QueryFilter{
+		Filter: &commonpb.QueryFilter_And{And: &commonpb.AndFilter{Filters: []*commonpb.QueryFilter{
+			seqLower,
+			outcome,
+		}}},
+	}
+
+	tooDeep := seqLower
+	for range MaxFilterDepth {
+		tooDeep = &commonpb.QueryFilter{
+			Filter: &commonpb.QueryFilter_And{And: &commonpb.AndFilter{Filters: []*commonpb.QueryFilter{tooDeep}}},
+		}
+	}
+
+	tests := []struct {
+		name  string
+		input *commonpb.QueryFilter
+		want  bool
+	}{
+		{name: "nil", input: nil, want: false},
+		{name: "sequence bound", input: seqLower, want: false},
+		{name: "and of sequence bounds", input: seqAnd, want: false},
+		{name: "indexed field", input: outcome, want: true},
+		{name: "sequence and indexed field", input: mixedAnd, want: true},
+		{name: "malformed sequence condition", input: auditString(commonpb.AuditField_AUDIT_FIELD_SEQUENCE, "bad"), want: true},
+		{name: "missing filter arm", input: &commonpb.QueryFilter{}, want: true},
+		{name: "over depth", input: tooDeep, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.want, AuditFilterNeedsIndex(tt.input))
+		})
+	}
+}
+
 func TestCompileAuditFilter_Outcome(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- prevent a failed default ReadIndex fallback from serving a newly local controller or reporting a failed route as forwarded
- preserve audit `minLogSequence` across routing hops so the serving replica enforces the requested freshness bound
- wait for the asynchronous audit index only when the filter actually consults it; sequence-only filters keep the direct audit-zone path
- add regression coverage for routing transitions and audit-index consistency waits

## Documentation

The documentation changes are intentionally split into the stacked PR #1868.

## Validation

- `bash scripts/agent-check`
- `env -u GOROOT nix develop --command go test ./internal/bootstrap ./internal/adapter/grpc ./internal/adapter/http ./internal/application/ctrl ./internal/query`