### PR TITLE
feat(chart): allow several variable segments per chart-of-accounts level

### DIFF
--- a/docs/events/InsertedSchema.json
+++ b/docs/events/InsertedSchema.json
@@ -44,8 +44,11 @@
     },
     "ChartSegment": {
       "properties": {
-        "VariableSegment": {
-          "$ref": "#/$defs/ChartVariableSegment"
+        "VariableSegments": {
+          "items": {
+            "$ref": "#/$defs/ChartVariableSegment"
+          },
+          "type": "array"
         },
         "FixedSegments": {
           "additionalProperties": {
@@ -60,15 +63,18 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "VariableSegment",
+        "VariableSegments",
         "FixedSegments",
         "Account"
       ]
     },
     "ChartVariableSegment": {
       "properties": {
-        "VariableSegment": {
-          "$ref": "#/$defs/ChartVariableSegment"
+        "VariableSegments": {
+          "items": {
+            "$ref": "#/$defs/ChartVariableSegment"
+          },
+          "type": "array"
         },
         "FixedSegments": {
           "additionalProperties": {
@@ -89,7 +95,7 @@
       "additionalProperties": false,
       "type": "object",
       "required": [
-        "VariableSegment",
+        "VariableSegments",
         "FixedSegments",
         "Account",
         "Pattern",

--- a/internal/README.md
+++ b/internal/README.md
@@ -335,7 +335,7 @@ func SpecMetadata(name string) string
 
 
 <a name="ValidateSegment"></a>
-## func [ValidateSegment](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L46>)
+## func [ValidateSegment](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L51>)
 
 ```go
 func ValidateSegment(addr string) bool
@@ -447,7 +447,7 @@ type BalancesByAssetsByAccounts map[string]BalancesByAssets
 ```
 
 <a name="ChartAccount"></a>
-## type [ChartAccount](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L18-L21>)
+## type [ChartAccount](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L19-L22>)
 
 
 
@@ -459,7 +459,7 @@ type ChartAccount struct {
 ```
 
 <a name="ChartAccount.DefaultMetadata"></a>
-### func \(\*ChartAccount\) [DefaultMetadata](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L318>)
+### func \(\*ChartAccount\) [DefaultMetadata](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L355>)
 
 ```go
 func (c *ChartAccount) DefaultMetadata() metadata.Metadata
@@ -468,7 +468,7 @@ func (c *ChartAccount) DefaultMetadata() metadata.Metadata
 
 
 <a name="ChartAccountMetadata"></a>
-## type [ChartAccountMetadata](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L14-L16>)
+## type [ChartAccountMetadata](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L15-L17>)
 
 
 
@@ -479,7 +479,7 @@ type ChartAccountMetadata struct {
 ```
 
 <a name="ChartAccountRules"></a>
-## type [ChartAccountRules](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L12>)
+## type [ChartAccountRules](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L13>)
 
 
 
@@ -488,7 +488,7 @@ type ChartAccountRules struct{}
 ```
 
 <a name="ChartOfAccounts"></a>
-## type [ChartOfAccounts](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L42>)
+## type [ChartOfAccounts](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L47>)
 
 
 
@@ -497,7 +497,7 @@ type ChartOfAccounts map[string]ChartSegment
 ```
 
 <a name="ChartOfAccounts.FindAccountSchema"></a>
-### func \(\*ChartOfAccounts\) [FindAccountSchema](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L298>)
+### func \(\*ChartOfAccounts\) [FindAccountSchema](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L335>)
 
 ```go
 func (c *ChartOfAccounts) FindAccountSchema(account string) (*ChartAccount, error)
@@ -506,7 +506,7 @@ func (c *ChartOfAccounts) FindAccountSchema(account string) (*ChartAccount, erro
 
 
 <a name="ChartOfAccounts.MarshalJSON"></a>
-### func \(ChartOfAccounts\) [MarshalJSON](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L188>)
+### func \(ChartOfAccounts\) [MarshalJSON](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L208>)
 
 ```go
 func (s ChartOfAccounts) MarshalJSON() ([]byte, error)
@@ -515,7 +515,7 @@ func (s ChartOfAccounts) MarshalJSON() ([]byte, error)
 
 
 <a name="ChartOfAccounts.UnmarshalJSON"></a>
-### func \(\*ChartOfAccounts\) [UnmarshalJSON](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L50>)
+### func \(\*ChartOfAccounts\) [UnmarshalJSON](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L55>)
 
 ```go
 func (s *ChartOfAccounts) UnmarshalJSON(data []byte) error
@@ -524,7 +524,7 @@ func (s *ChartOfAccounts) UnmarshalJSON(data []byte) error
 
 
 <a name="ChartOfAccounts.ValidatePosting"></a>
-### func \(\*ChartOfAccounts\) [ValidatePosting](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L306>)
+### func \(\*ChartOfAccounts\) [ValidatePosting](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L343>)
 
 ```go
 func (c *ChartOfAccounts) ValidatePosting(posting Posting) error
@@ -533,20 +533,24 @@ func (c *ChartOfAccounts) ValidatePosting(posting Posting) error
 
 
 <a name="ChartSegment"></a>
-## type [ChartSegment](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L23-L27>)
+## type [ChartSegment](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L24-L32>)
 
 
 
 ```go
 type ChartSegment struct {
-    VariableSegment *ChartVariableSegment
-    FixedSegments   map[string]ChartSegment
-    Account         *ChartAccount
+    // VariableSegments holds every `$variable` child declared at this level,
+    // ordered by label. A level may declare several of them as long as each one
+    // carries a `.pattern`, which is how a single level fans out into subtrees
+    // of different shapes depending on the value of the segment.
+    VariableSegments []ChartVariableSegment
+    FixedSegments    map[string]ChartSegment
+    Account          *ChartAccount
 }
 ```
 
 <a name="ChartSegment.MarshalJSON"></a>
-### func \(ChartSegment\) [MarshalJSON](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L232>)
+### func \(ChartSegment\) [MarshalJSON](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L252>)
 
 ```go
 func (s ChartSegment) MarshalJSON() ([]byte, error)
@@ -555,7 +559,7 @@ func (s ChartSegment) MarshalJSON() ([]byte, error)
 
 
 <a name="ChartSegment.UnmarshalJSON"></a>
-### func \(\*ChartSegment\) [UnmarshalJSON](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L89>)
+### func \(\*ChartSegment\) [UnmarshalJSON](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L94>)
 
 ```go
 func (s *ChartSegment) UnmarshalJSON(data []byte) error
@@ -564,7 +568,7 @@ func (s *ChartSegment) UnmarshalJSON(data []byte) error
 
 
 <a name="ChartVariableSegment"></a>
-## type [ChartVariableSegment](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L29-L34>)
+## type [ChartVariableSegment](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L34-L39>)
 
 
 
@@ -578,7 +582,7 @@ type ChartVariableSegment struct {
 ```
 
 <a name="ChartVariableSegment.MarshalJSON"></a>
-### func \(ChartVariableSegment\) [MarshalJSON](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L240>)
+### func \(ChartVariableSegment\) [MarshalJSON](<https://github.com/formancehq/ledger/blob/main/internal/chart.go#L260>)
 
 ```go
 func (s ChartVariableSegment) MarshalJSON() ([]byte, error)

--- a/internal/chart.go
+++ b/internal/chart.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/formancehq/go-libs/v5/pkg/types/metadata"
@@ -21,9 +22,13 @@ type ChartAccount struct {
 }
 
 type ChartSegment struct {
-	VariableSegment *ChartVariableSegment
-	FixedSegments   map[string]ChartSegment
-	Account         *ChartAccount
+	// VariableSegments holds every `$variable` child declared at this level,
+	// ordered by label. A level may declare several of them as long as each one
+	// carries a `.pattern`, which is how a single level fans out into subtrees
+	// of different shapes depending on the value of the segment.
+	VariableSegments []ChartVariableSegment
+	FixedSegments    map[string]ChartSegment
+	Account          *ChartAccount
 }
 
 type ChartVariableSegment struct {
@@ -92,11 +97,11 @@ func (s *ChartSegment) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	var (
-		isLeaf          = true
-		isAccount       bool
-		account         ChartAccount
-		fixedSegments   map[string]ChartSegment
-		variableSegment *ChartVariableSegment
+		isLeaf           = true
+		isAccount        bool
+		account          ChartAccount
+		fixedSegments    map[string]ChartSegment
+		variableSegments []ChartVariableSegment
 	)
 	for key, value := range segment {
 		isSubsegment := !strings.HasPrefix(key, PROPERTY_PREFIX)
@@ -130,14 +135,11 @@ func (s *ChartSegment) UnmarshalJSON(data []byte) error {
 				return fmt.Errorf("invalid segment: %v", err)
 			}
 			if strings.HasPrefix(key, "$") {
-				if variableSegment != nil {
-					return fmt.Errorf("cannot have two variable segments with the same prefix")
-				}
-				variableSegment = &ChartVariableSegment{
+				variableSegments = append(variableSegments, ChartVariableSegment{
 					ChartSegment: segment,
 					Pattern:      pattern,
 					Label:        key[1:],
-				}
+				})
 			} else if pattern != nil {
 				return fmt.Errorf("cannot have a pattern on a fixed segment")
 			} else {
@@ -168,12 +170,30 @@ func (s *ChartSegment) UnmarshalJSON(data []byte) error {
 			}
 		}
 	}
+	// A pattern is what keeps sibling variable segments apart: an ungated one
+	// matches every value, so it would make its siblings ambiguous.
+	if len(variableSegments) > 1 {
+		for _, variableSegment := range variableSegments {
+			if variableSegment.Pattern == nil {
+				return fmt.Errorf(
+					"variable segment $%v needs a %v: a level declaring several variable segments requires one on each of them",
+					variableSegment.Label, PATTERN_KEY,
+				)
+			}
+		}
+	}
+	// Subsegments come out of a map, so order by label to keep resolution and
+	// serialization deterministic.
+	slices.SortFunc(variableSegments, func(a, b ChartVariableSegment) int {
+		return strings.Compare(a.Label, b.Label)
+	})
+
 	isAccount = isAccount || isLeaf
 	if isAccount {
 		s.Account = &account
 	}
 	s.FixedSegments = fixedSegments
-	s.VariableSegment = variableSegment
+	s.VariableSegments = variableSegments
 
 	if _, ok := segment[METADATA_KEY]; ok && !isAccount {
 		return fmt.Errorf("cannot have %v on a non-account segment", METADATA_KEY)
@@ -206,9 +226,9 @@ func (s ChartSegment) marshalJsonObject() (map[string]any, error) {
 		}
 		out[key] = json.RawMessage(serialized)
 	}
-	if s.VariableSegment != nil {
-		key := fmt.Sprintf("$%v", s.VariableSegment.Label)
-		serialized, err := s.VariableSegment.MarshalJSON()
+	for _, variableSegment := range s.VariableSegments {
+		key := fmt.Sprintf("$%v", variableSegment.Label)
+		serialized, err := variableSegment.MarshalJSON()
 		if err != nil {
 			return nil, err
 		}
@@ -222,7 +242,7 @@ func (s ChartSegment) marshalJsonObject() (map[string]any, error) {
 		if s.Account.Rules != (ChartAccountRules{}) {
 			out[RULES_KEY] = s.Account.Rules
 		}
-		if len(s.FixedSegments) > 0 || s.VariableSegment != nil {
+		if len(s.FixedSegments) > 0 || len(s.VariableSegments) > 0 {
 			out[SELF_KEY] = map[string]any{}
 		}
 	}
@@ -248,50 +268,67 @@ func (s ChartVariableSegment) MarshalJSON() ([]byte, error) {
 	return json.Marshal(out)
 }
 
-func findAccountSchema(path []string, fixedSegments map[string]ChartSegment, variableSegment *ChartVariableSegment, account []string) (*ChartAccount, error) {
+// descendInto resolves the remainder of an address against the segment
+// `account[0]` was matched by, either by recursing into its children or, when
+// the address stops here, by returning the account the segment carries.
+func descendInto(path []string, segment ChartSegment, account []string) (*ChartAccount, error) {
 	nextSegment := account[0]
-	if segment, ok := fixedSegments[nextSegment]; ok {
-		if len(account) > 1 {
-			return findAccountSchema(append(path, nextSegment), segment.FixedSegments, segment.VariableSegment, account[1:])
-		} else if segment.Account != nil {
-			return segment.Account, nil
-		} else {
-			return nil, ErrInvalidAccount{
-				path:            path,
-				segment:         nextSegment,
-				patternMismatch: false,
-				hasSubsegments:  len(account) > 1,
-			}
-		}
+	if len(account) > 1 {
+		// Cap the slice so append allocates instead of writing into the
+		// caller's backing array: sibling variable segments are tried in turn
+		// and each one's errors keep a reference to the path they were built
+		// from.
+		childPath := append(path[:len(path):len(path)], nextSegment)
+		return findAccountSchema(childPath, segment.FixedSegments, segment.VariableSegments, account[1:])
 	}
-	if variableSegment != nil {
-		matches := true
-		if variableSegment.Pattern != nil {
-			var err error
-			matches, err = regexp.Match(*variableSegment.Pattern, []byte(nextSegment))
-			if err != nil {
-				return nil, fmt.Errorf("invalid pattern regex: %v", err)
-			}
-		}
-		if matches {
-			if len(account) > 1 {
-				return findAccountSchema(append(path, nextSegment), variableSegment.FixedSegments, variableSegment.VariableSegment, account[1:])
-			} else if variableSegment.Account != nil {
-				return variableSegment.Account, nil
-			} else {
-				return nil, ErrInvalidAccount{
-					path:            path,
-					segment:         nextSegment,
-					patternMismatch: false,
-					hasSubsegments:  len(account) > 1,
-				}
-			}
-		}
+	if segment.Account != nil {
+		return segment.Account, nil
 	}
 	return nil, ErrInvalidAccount{
 		path:            path,
 		segment:         nextSegment,
-		patternMismatch: variableSegment != nil,
+		patternMismatch: false,
+		hasSubsegments:  false,
+	}
+}
+
+func findAccountSchema(path []string, fixedSegments map[string]ChartSegment, variableSegments []ChartVariableSegment, account []string) (*ChartAccount, error) {
+	nextSegment := account[0]
+	if segment, ok := fixedSegments[nextSegment]; ok {
+		return descendInto(path, segment, account)
+	}
+	// A level can declare several variable segments, each gated by its own
+	// pattern, so the same level can hold subtrees of different shapes. They are
+	// tried in label order and the first one resolving the rest of the address
+	// wins; a candidate whose pattern matches but whose subtree rejects the
+	// remainder does not hide the others.
+	var firstMatchErr error
+	for _, variableSegment := range variableSegments {
+		if variableSegment.Pattern != nil {
+			matches, err := regexp.Match(*variableSegment.Pattern, []byte(nextSegment))
+			if err != nil {
+				return nil, fmt.Errorf("invalid pattern regex: %v", err)
+			}
+			if !matches {
+				continue
+			}
+		}
+		schema, err := descendInto(path, variableSegment.ChartSegment, account)
+		if err == nil {
+			return schema, nil
+		}
+		if firstMatchErr == nil {
+			firstMatchErr = err
+		}
+	}
+	// Some pattern admitted the segment, the address was rejected further down.
+	if firstMatchErr != nil {
+		return nil, firstMatchErr
+	}
+	return nil, ErrInvalidAccount{
+		path:            path,
+		segment:         nextSegment,
+		patternMismatch: len(variableSegments) > 0,
 		hasSubsegments:  len(account) > 1,
 	}
 }

--- a/internal/chart_test.go
+++ b/internal/chart_test.go
@@ -47,7 +47,7 @@ func TestChartValidation(t *testing.T) {
 }`,
 			expectedChart: ChartOfAccounts{
 				"banks": {
-					VariableSegment: &ChartVariableSegment{
+					VariableSegments: []ChartVariableSegment{{
 						Label:   "iban",
 						Pattern: pointer.For("^[0-9]{10}$"),
 						ChartSegment: ChartSegment{
@@ -72,10 +72,10 @@ func TestChartValidation(t *testing.T) {
 								},
 							},
 						},
-					},
+					}},
 				},
 				"users": {
-					VariableSegment: &ChartVariableSegment{
+					VariableSegments: []ChartVariableSegment{{
 						Label:   "userID",
 						Pattern: nil,
 						ChartSegment: ChartSegment{
@@ -86,7 +86,7 @@ func TestChartValidation(t *testing.T) {
 								},
 							},
 						},
-					},
+					}},
 				},
 			},
 		},
@@ -149,18 +149,54 @@ func TestChartValidation(t *testing.T) {
 			expectedError: "cannot have .rules on a non-account segment",
 		},
 		{
-			name: "two variable segments with same prefix",
+			name: "several variable segments at the same level",
+			source: `{
+    "users": {
+        "$userID": {
+            ".pattern": "^[0-9]{3}$",
+            "main": {}
+        },
+        "$username": {
+            ".pattern": "^[a-z]+$"
+        }
+    }
+}`,
+			expectedChart: ChartOfAccounts{
+				"users": {
+					VariableSegments: []ChartVariableSegment{
+						{
+							Label:   "userID",
+							Pattern: pointer.For("^[0-9]{3}$"),
+							ChartSegment: ChartSegment{
+								FixedSegments: map[string]ChartSegment{
+									"main": {
+										Account: &ChartAccount{},
+									},
+								},
+							},
+						},
+						{
+							Label:   "username",
+							Pattern: pointer.For("^[a-z]+$"),
+							ChartSegment: ChartSegment{
+								Account: &ChartAccount{},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "several variable segments with a missing pattern",
 			source: `{
 				"users": {
 					"$userID": {
 						".pattern": "^[0-9]{3}$"
 					},
-					"$otherID": {
-						".pattern": "^[0-9]{4}$"
-					}
+					"$username": {}
 				}
 			}`,
-			expectedError: "cannot have two variable segments with the same prefix",
+			expectedError: "variable segment $username needs a .pattern",
 		},
 		{
 			name: "invalid metadata",
@@ -264,7 +300,7 @@ func testChart() ChartOfAccounts {
 			Account: &ChartAccount{},
 		},
 		"bank": {
-			VariableSegment: &ChartVariableSegment{
+			VariableSegments: []ChartVariableSegment{{
 				Label:   "bankID",
 				Pattern: pointer.For("^[0-9]{3}$"),
 				ChartSegment: ChartSegment{
@@ -277,7 +313,7 @@ func testChart() ChartOfAccounts {
 						},
 					},
 				},
-			},
+			}},
 			Account: &ChartAccount{
 				Metadata: map[string]ChartAccountMetadata{
 					"root_bank_account": {},
@@ -285,7 +321,7 @@ func testChart() ChartOfAccounts {
 			},
 		},
 		"users": {
-			VariableSegment: &ChartVariableSegment{
+			VariableSegments: []ChartVariableSegment{{
 				Label:   "userID",
 				Pattern: pointer.For("^[0-9]{3}$"),
 				ChartSegment: ChartSegment{
@@ -297,10 +333,10 @@ func testChart() ChartOfAccounts {
 						},
 					},
 				},
-			},
+			}},
 		},
 		"shops": {
-			VariableSegment: &ChartVariableSegment{
+			VariableSegments: []ChartVariableSegment{{
 				Label: "shopID",
 				ChartSegment: ChartSegment{
 					Account: &ChartAccount{
@@ -311,7 +347,7 @@ func testChart() ChartOfAccounts {
 						},
 					},
 				},
-			},
+			}},
 		},
 	}
 }
@@ -450,6 +486,173 @@ func TestPostingValidation(t *testing.T) {
 			require.ErrorIs(t, err, ErrInvalidAccount{}, tc.name)
 		} else {
 			err := chart.ValidatePosting(tc.posting)
+			require.NoError(t, err, tc.name)
+		}
+	}
+}
+
+// Barrier accounts carry a `_TYPE` suffix and must never hold a client
+// subaccount, while a bare stub may. The two shapes are kept apart by giving
+// the account level one variable segment per shape, each gated by its own
+// pattern -- a single `$accountId` whose pattern makes the suffix optional
+// cannot express it, since `.pattern` only sees the segment in isolation and
+// has no visibility on whether a `client` child was addressed below it.
+const barrierChart = `{
+	"world": {},
+	"bank": {
+		"$bankId": {
+			".pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+			"branch": {
+				"$branchId": {
+					".pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+					"account": {
+						"$accountId": {
+							".self": {},
+							".pattern": "^(?<stub>[A-Z]{4})$",
+							"client": {
+								"$clientId": {
+									".pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
+								}
+							}
+						},
+						"$barrierAccountId": {
+							".pattern": "^(?<stub>[A-Z]{4})_(?<type>TRADING|TOPUP|UNIDENTIFIED|CLEARED)$"
+						}
+					}
+				}
+			}
+		}
+	}
+}`
+
+func TestBarrierAccountValidation(t *testing.T) {
+	t.Parallel()
+
+	var chart ChartOfAccounts
+	require.NoError(t, json.Unmarshal([]byte(barrierChart), &chart))
+
+	const (
+		bankID   = "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+		branchID = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+		clientID = "c73bcdcc-2669-4bf6-81d3-e4ae73fb11fd"
+	)
+	accounts := "bank:" + bankID + ":branch:" + branchID + ":account:"
+
+	type testCase struct {
+		name          string
+		address       string
+		expectedError string
+	}
+
+	for _, tc := range []testCase{
+		{
+			name:    "plain account with a client",
+			address: accounts + "LSER:client:" + clientID,
+		},
+		{
+			name:    "plain account without a client",
+			address: accounts + "LSER",
+		},
+		{
+			name:    "barrier account without a client",
+			address: accounts + "LSER_TRADING",
+		},
+		{
+			name:    "every barrier type is addressable",
+			address: accounts + "LSER_UNIDENTIFIED",
+		},
+		{
+			name:          "barrier account with a client",
+			address:       accounts + "LSER_TRADING:client:" + clientID,
+			expectedError: "segment `client` is not allowed by the chart of accounts at `" + accounts + "LSER_TRADING`",
+		},
+		{
+			name:          "barrier account with an empty client subtree",
+			address:       accounts + "LSER_CLEARED:client",
+			expectedError: "segment `client` is not allowed by the chart of accounts at `" + accounts + "LSER_CLEARED`",
+		},
+		{
+			name:          "unknown barrier type",
+			address:       accounts + "LSER_SETTLED",
+			expectedError: "segment `LSER_SETTLED` defined by the chart of accounts at `bank:" + bankID + ":branch:" + branchID + ":account` does not match the pattern",
+		},
+		{
+			name:          "client of an unknown barrier type",
+			address:       accounts + "LSER_SETTLED:client:" + clientID,
+			expectedError: "segment `LSER_SETTLED` defined by the chart of accounts at `bank:" + bankID + ":branch:" + branchID + ":account` does not match the pattern",
+		},
+		{
+			name:          "plain account with an invalid client",
+			address:       accounts + "LSER:client:not-a-uuid",
+			expectedError: "segment `not-a-uuid` defined by the chart of accounts at `" + accounts + "LSER:client` does not match the pattern",
+		},
+	} {
+		_, err := chart.FindAccountSchema(tc.address)
+		if tc.expectedError == "" {
+			require.NoError(t, err, tc.name)
+		} else {
+			require.EqualError(t, err, tc.expectedError, tc.name)
+		}
+	}
+}
+
+// Postings are the enforcement point: a barrier account with a client
+// underneath it must be rejected whichever side of the posting it sits on.
+func TestBarrierPostingValidation(t *testing.T) {
+	t.Parallel()
+
+	var chart ChartOfAccounts
+	require.NoError(t, json.Unmarshal([]byte(barrierChart), &chart))
+
+	const (
+		bankID   = "3f2504e0-4f89-11d3-9a0c-0305e82c3301"
+		branchID = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+		clientID = "c73bcdcc-2669-4bf6-81d3-e4ae73fb11fd"
+	)
+	accounts := "bank:" + bankID + ":branch:" + branchID + ":account:"
+
+	type testCase struct {
+		name        string
+		posting     Posting
+		expectError bool
+	}
+
+	for _, tc := range []testCase{
+		{
+			name: "client account funded from a barrier account",
+			posting: Posting{
+				Source:      accounts + "LSER_TOPUP",
+				Destination: accounts + "LSER:client:" + clientID,
+			},
+		},
+		{
+			name: "barrier account as destination of a client account",
+			posting: Posting{
+				Source:      accounts + "LSER:client:" + clientID,
+				Destination: accounts + "LSER_TRADING",
+			},
+		},
+		{
+			name: "client of a barrier account as source",
+			posting: Posting{
+				Source:      accounts + "LSER_TRADING:client:" + clientID,
+				Destination: "world",
+			},
+			expectError: true,
+		},
+		{
+			name: "client of a barrier account as destination",
+			posting: Posting{
+				Source:      "world",
+				Destination: accounts + "LSER_TRADING:client:" + clientID,
+			},
+			expectError: true,
+		},
+	} {
+		err := chart.ValidatePosting(tc.posting)
+		if tc.expectError {
+			require.ErrorIs(t, err, ErrInvalidAccount{}, tc.name)
+		} else {
 			require.NoError(t, err, tc.name)
 		}
 	}


### PR DESCRIPTION
## What changed

A chart-of-accounts level could declare at most one `$variable` child. It may now declare several, as long as each carries a `.pattern`. Candidates resolve in label order with backtracking, so a candidate whose pattern matches but whose subtree rejects the rest of the address does not hide its siblings.

This is a pure relaxation — charts with zero or one variable segment per level take the identical code path, and `V2ChartSegment` is already a recursive free-form map in the OpenAPI spec, so sibling wildcards need no API or SDK change.

## Why

A segment whose subtree *shape* depends on its own value had no representation. The motivating case: an account level where suffixed "barrier" accounts (`LSER_TRADING`, `LSER_TOPUP`, …) must never hold a `client` subaccount, while bare stubs (`LSER`) may.

The example the client gave is:

bank:BC:branch:U K:account:LSER:client:001 = Valid, 
bank:BC:branch:U K:account:LSER_TRADING = Valid, 
bank:BC:branch:U K:account:LSER_TRADING:client:001 = Invalid.

That can't be a regex. `.pattern` is matched against one segment string in isolation and has no visibility on whether a `client` child was addressed below it, so a single `$accountId` with an optional suffix silently accepts `account:LSER_TRADING:client:<uuid>` — verified against the parser before this change. Splitting the level into `$accountId` (bare stub, has `client`) and `$barrierAccountId` (suffixed, leaf) expresses the rule structurally, with no bespoke validation code.

## Risk

**LOW**

Contained to `internal/chart.go`; `VariableSegment` had no references outside that file. Existing charts are unaffected — the change only admits schemas that were previously rejected at parse time.

## Validation

- [x] Baseline validation: `go build ./...`, `golangci-lint run --build-tags it,local` — 0 issues
- [x] Targeted tests: `TestBarrierAccountValidation` and `TestBarrierPostingValidation` cover plain+client, plain alone, barrier alone, every barrier type, barrier+client rejected (both posting sides), unknown suffix, invalid client id. `TestChartValidation` gains a valid multi-wildcard case with roundtrip assertion, plus a missing-`.pattern` rejection.
- [x] Full suite / broader validation: all 23 unit-test packages pass. The `-tags it` suite was **not** run (needs a local docker daemon) — please let CI cover it.

## Architecture / behavior impact

- `ChartSegment.VariableSegment *ChartVariableSegment` becomes `VariableSegments []ChartVariableSegment`. Internal type, no exported-API consumers outside `chart.go`.
- One previously-rejected schema class now parses: the `cannot have two variable segments with the same prefix` error is gone, replaced by a requirement that each sibling wildcard carry a `.pattern`. Its test is updated accordingly.
- No OpenAPI, SDK, storage, or migration impact. Serialization is unchanged for single-wildcard charts, and variable segments are sorted by label so output stays deterministic.

## Review focus

- **Resolution semantics.** Where sibling patterns overlap, the lexicographically first label wins. Deterministic, but arbitrary from the schema author's point of view — worth deciding whether overlap should instead be an error, and if so whether at parse time (regex disjointness isn't decidable with stdlib `regexp`) or at resolution time.
- **`descendInto` path handling.** It uses `append(path[:len(path):len(path)], …)` to force a copy. `ErrInvalidAccount` retains the path slice, and now that candidates are tried in a loop, the previous shared-backing-array `append` would corrupt an earlier candidate's error message.
- **Requiring `.pattern` on siblings.** An ungated wildcard matches every value and would make its siblings ambiguous, so this seemed like the right guard — but it does mean a level can't mix one gated and one catch-all wildcard.

## Known concerns

Two follow-ups, neither blocking and both out of scope here:

1. **Docs now contradict the engine.** `ledger-schema.mdx` states "One variable per level" and shows this exact restructure as an *invalid* example (plus the `docs-mint` / `product-content-ref` mirrors and generated `llms-full.txt`). Separate repo — needs its own PR alongside this one.
2. **`coa-architect`'s `validate_schema.py`** has `_var_key()` returning the *first* `$` key it finds across 6 call sites, so it would validate a multi-wildcard chart against one arbitrary branch.

Also noticed while in here, pre-existing and unrelated: unknown dot-prefixed properties (`.patern`, `.forbiden`, anything) parse successfully and are silently discarded. Worth tightening, but it's a behavior change that could reject charts already stored, so it wants its own PR.