### PR TITLE
fix(release): format GoReleaser changelog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -98,7 +98,7 @@ checksum:
 
 changelog:
   sort: asc
-  use: github
+  use: git
   filters:
     exclude:
     - "^docs(\\([^)]*\\))?!?:"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -101,9 +101,9 @@ changelog:
   use: github
   filters:
     exclude:
-    - "^docs(\\([^)]*\\))?:"
-    - "^chore(\\([^)]*\\))?:"
-    - "^ci(\\([^)]*\\))?:"
+    - "^docs(\\([^)]*\\))?!?:"
+    - "^chore(\\([^)]*\\))?!?:"
+    - "^ci(\\([^)]*\\))?!?:"
   groups:
   - title: "New Features"
     regexp: "^.*feat(\\([^)]*\\))?!?:.*$"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -98,6 +98,7 @@ checksum:
 
 changelog:
   sort: asc
+  # Keep tagged and nightly releases independent of remote compare APIs.
   use: git
   filters:
     exclude:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -98,11 +98,21 @@ checksum:
 
 changelog:
   sort: asc
+  use: github
   filters:
     exclude:
-    - "^docs:"
-    - "^chore:"
-    - "^ci:"
+    - "^docs(\\([^)]*\\))?:"
+    - "^chore(\\([^)]*\\))?:"
+    - "^ci(\\([^)]*\\))?:"
+  groups:
+  - title: "New Features"
+    regexp: "^.*feat(\\([^)]*\\))?!?:.*$"
+    order: 0
+  - title: "Bug fixes"
+    regexp: "^.*fix(\\([^)]*\\))?!?:.*$"
+    order: 10
+  - title: "Other work"
+    order: 999
 
 dockers:
 - image_templates: ["{{ .Env.IMAGE_REPOSITORY }}:{{ if not .IsNightly }}v{{ end }}{{ .Version }}-amd64"]


### PR DESCRIPTION
## Summary

- Restore grouped GoReleaser changelogs for features, bug fixes, and other work.
- Recognize scoped and breaking Conventional Commits while excluding docs, chore, and CI entries.
- Keep changelog generation based on local Git history so tagged and nightly releases do not depend on the remote compare API.

## Validation

- `nix develop --command goreleaser check --config .goreleaser.yml`
- `bash scripts/agent-check`
- Synthetic Git history preview covering scoped and unscoped breaking commits
- `AI_REVIEW_BASE_SHA=deaa0a5bad566b4403842efe2c0891dd6ed3a513 bash scripts/agent-check-pr` (the full race suite hit the existing timing-sensitive `TestRunSynchronizedTimeoutTerminatesAndReportsEveryPeer`; the isolated test passed 10/10)

## Risk

Low. This only changes generated release notes; build artifacts and runtime behavior are unchanged.