### PR TITLE
fix(logging): dedupe cmp field and quiet noisy raft debug logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,6 +87,7 @@ require (
 require (
 	github.com/aws/aws-sdk-go-v2/feature/s3/transfermanager v0.3.16
 	github.com/benbjohnson/immutable v0.4.3
+	github.com/dustin/go-humanize v1.0.1
 	go.uber.org/goleak v1.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -229,6 +229,8 @@ github.com/docker/go-connections v0.6.0 h1:LlMG9azAe1TqfR7sO+NJttz1gy6KO7VJBh+pM
 github.com/docker/go-connections v0.6.0/go.mod h1:AahvXYshr6JgfUJGdDCs2b5EZG/vmaMAntpSFH5BFKE=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/eapache/go-resiliency v1.7.0 h1:n3NRTnBn5N0Cbi/IeOHuQn9s2UwVUH7Ga0ZWcP+9JTA=
 github.com/eapache/go-resiliency v1.7.0/go.mod h1:5yPzW0MIvSe0JDsv0v+DvcjEv2FyD6iZYSs1ZI+iQho=
 github.com/eapache/go-xerial-snappy v0.0.0-20230731223053-c322873962e3 h1:Oy0F4ALJ04o5Qqpdz8XLIpNA3WM/iSIXqxtqo7UGVws=

--- a/internal/bootstrap/module.go
+++ b/internal/bootstrap/module.go
@@ -281,9 +281,7 @@ func Module() fx.Option {
 				return dal.NewSmartCompactor(store, logger, machine.ColdCompactionCh())
 			},
 			func(cfg Config, logger logging.Logger, meterProvider metric.MeterProvider) (*wal.DefaultWAL, error) {
-				return wal.New(cfg.RaftConfig.WalDir, logger.WithFields(map[string]any{
-					"cmp": "wal",
-				}), meterProvider.Meter("wal"))
+				return wal.New(cfg.RaftConfig.WalDir, logger, meterProvider.Meter("wal"))
 			},
 			func(cfg Config, logger logging.Logger) (*spool.Default, error) {
 				return spool.NewDefault(spool.DefaultSpoolConfig{

--- a/internal/infra/health/healthcheck.go
+++ b/internal/infra/health/healthcheck.go
@@ -2,10 +2,12 @@ package health
 
 import (
 	"context"
+	"fmt"
 	"sync/atomic"
 	"time"
 
 	"github.com/antithesishq/antithesis-sdk-go/assert"
+	"github.com/dustin/go-humanize"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
@@ -294,13 +296,13 @@ func (hc *HealthChecker) logDiskUsageSummary(reports []nodeUsageReport) {
 			continue
 		}
 
-		fields["wal_used"] = r.walUsed
-		fields["wal_total"] = r.walTotal
-		fields["wal_percent"] = r.walPercent
-		fields["data_used"] = r.dataUsed
-		fields["data_total"] = r.dataTotal
-		fields["data_percent"] = r.dataPercent
-		hc.logger.WithFields(fields).Infof("Disk usage check: wal=%.1f%% data=%.1f%%", r.walPercent, r.dataPercent)
+		fields["wal_used"] = humanize.IBytes(r.walUsed)
+		fields["wal_total"] = humanize.IBytes(r.walTotal)
+		fields["wal_percent"] = fmt.Sprintf("%.2f%%", r.walPercent)
+		fields["data_used"] = humanize.IBytes(r.dataUsed)
+		fields["data_total"] = humanize.IBytes(r.dataTotal)
+		fields["data_percent"] = fmt.Sprintf("%.2f%%", r.dataPercent)
+		hc.logger.WithFields(fields).Infof("Disk usage check")
 	}
 }
 

--- a/internal/infra/node/node.go
+++ b/internal/infra/node/node.go
@@ -1461,14 +1461,14 @@ func (node *Node) finishReady(result readyResult, stop chan struct{}) error {
 		}
 
 		after := node.indexTracker.Next()
-		if before != after {
+		if before != after && node.logger.Enabled(logging.DebugLevel) {
 			node.logger.WithFields(map[string]any{
 				"lastCommitted":  lastCommitted,
 				"trackerBefore":  before,
 				"trackerAfter":   after,
 				"committedCount": len(rd.CommittedEntries),
 				"isLeader":       isLeader,
-			}).Infof("IndexTracker updated in finishReady")
+			}).Debugf("IndexTracker updated in finishReady")
 		}
 	}
 
@@ -1643,7 +1643,7 @@ func (node *Node) orchestrate(ctx context.Context, stop chan struct{}) error {
 
 			// Diagnostic: log messages stepped while a Ready is being processed,
 			// as they can mutate rawNode state before Advance is called.
-			if node.readyTerminated != nil && (msgType == raftpb.MsgApp || msgType == raftpb.MsgSnap) {
+			if node.readyTerminated != nil && (msgType == raftpb.MsgApp || msgType == raftpb.MsgSnap) && node.logger.Enabled(logging.DebugLevel) {
 				node.logger.WithFields(map[string]any{
 					"type":       msgType.String(),
 					"from":       msg.GetFrom(),
@@ -1652,7 +1652,7 @@ func (node *Node) orchestrate(ctx context.Context, stop chan struct{}) error {
 					"index":      msg.GetIndex(),
 					"commit":     msg.GetCommit(),
 					"entryCount": len(msg.GetEntries()),
-				}).Infof("Stepping MsgApp/MsgSnap while Ready in flight")
+				}).Debugf("Stepping MsgApp/MsgSnap while Ready in flight")
 			}
 
 			err := node.rawNode.Step(msg)


### PR DESCRIPTION
## Summary
- Removed the duplicate `cmp=wal` field tagging on the WAL logger — `wal.New` already tags it internally, so the bootstrap wiring in `internal/bootstrap/module.go` was tagging it a second time, producing `cmp=wal cmp=wal` in every WAL log line.
- Downgraded two internal raft-bookkeeping logs (`IndexTracker updated in finishReady`, `Stepping MsgApp/MsgSnap while Ready in flight`) from `Infof` to `Debugf`, guarded with `logger.Enabled(logging.DebugLevel)` per repo convention, since they fire on the raft hot path and are only useful for debugging.
- Reworked the periodic disk-usage-check log: the message no longer embeds formatted values (they were already duplicated as structured fields), byte fields (`wal_used`/`wal_total`/`data_used`/`data_total`) are now human-readable via `github.com/dustin/go-humanize`'s `IBytes`, and percent fields use 2-decimal precision.

## Test plan
- [x] `go build ./internal/infra/health/... ./internal/infra/node/... ./internal/bootstrap/... ./internal/storage/wal/...`
- [x] `go mod tidy` clean (no drift)
- [x] Reviewed via `oh-my-claudecode:code-reviewer` (Fable) — no blocking issues