### PR TITLE
chore(release): migrate docker images to goreleaser dockers_v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -104,50 +104,28 @@ changelog:
     - "^chore:"
     - "^ci:"
 
-dockers:
-- image_templates: ["{{ .Env.IMAGE_REPOSITORY }}:{{ if not .IsNightly }}v{{ end }}{{ .Version }}-amd64"]
-  goarch: amd64
-  ids:
+dockers_v2:
+- ids:
   - ledger-server
   - ledgerctl
   dockerfile: build.Dockerfile
-  use: buildx
-  build_flag_templates:
+  images:
+  - "{{ .Env.IMAGE_REPOSITORY }}"
+  tags:
+  - "{{ if not .IsNightly }}v{{ end }}{{ .Version }}"
+  - "{{ if not .IsNightly }}{{ if not .Prerelease }}latest{{ end }}{{ end }}"
+  platforms:
+  - linux/amd64
+  - linux/arm64
+  sbom: false
+  flags:
   - --provenance=false
-  - --platform=linux/amd64
-  - --label=org.opencontainers.image.title=ledger
-  - --label=org.opencontainers.image.description=ledger
-  - --label=org.opencontainers.image.url=https://github.com/formancehq/ledger
-  - --label=org.opencontainers.image.source=https://github.com/formancehq/ledger
-  - --label=org.opencontainers.image.version={{ .Version }}
-  - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
-  - --label=org.opencontainers.image.revision={{ .FullCommit }}
-  - --label=org.opencontainers.image.licenses=MIT
-- image_templates: ["{{ .Env.IMAGE_REPOSITORY }}:{{ if not .IsNightly }}v{{ end }}{{ .Version }}-arm64"]
-  goarch: arm64
-  ids:
-  - ledger-server
-  - ledgerctl
-  dockerfile: build.Dockerfile
-  use: buildx
-  build_flag_templates:
-  - --provenance=false
-  - --platform=linux/arm64/v8
-  - --label=org.opencontainers.image.title=ledger
-  - --label=org.opencontainers.image.description=ledger
-  - --label=org.opencontainers.image.url=https://github.com/formancehq/ledger
-  - --label=org.opencontainers.image.source=https://github.com/formancehq/ledger
-  - --label=org.opencontainers.image.version={{ .Version }}
-  - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
-  - --label=org.opencontainers.image.revision={{ .FullCommit }}
-  - --label=org.opencontainers.image.licenses=MIT
-
-docker_manifests:
-- name_template: '{{ .Env.IMAGE_REPOSITORY }}:{{ if not .IsNightly }}v{{ end }}{{ .Version }}'
-  image_templates:
-  - '{{ .Env.IMAGE_REPOSITORY }}:{{ if not .IsNightly }}v{{ end }}{{ .Version }}-amd64'
-  - '{{ .Env.IMAGE_REPOSITORY }}:{{ if not .IsNightly }}v{{ end }}{{ .Version }}-arm64'
-- name_template: '{{ if not .IsNightly }}{{ if not .Prerelease }}{{ .Env.IMAGE_REPOSITORY }}:latest{{ end }}{{ end }}'
-  image_templates:
-  - '{{ .Env.IMAGE_REPOSITORY }}:{{ if not .IsNightly }}v{{ end }}{{ .Version }}-amd64'
-  - '{{ .Env.IMAGE_REPOSITORY }}:{{ if not .IsNightly }}v{{ end }}{{ .Version }}-arm64'
+  labels:
+    org.opencontainers.image.title: ledger
+    org.opencontainers.image.description: ledger
+    org.opencontainers.image.url: https://github.com/formancehq/ledger
+    org.opencontainers.image.source: https://github.com/formancehq/ledger
+    org.opencontainers.image.version: "{{ .Version }}"
+    org.opencontainers.image.created: "{{ time \"2006-01-02T15:04:05Z07:00\" }}"
+    org.opencontainers.image.revision: "{{ .FullCommit }}"
+    org.opencontainers.image.licenses: MIT

--- a/build.Dockerfile
+++ b/build.Dockerfile
@@ -5,7 +5,8 @@ ENV TZ=UTC
 ENV PATH=$PATH:/app
 SHELL ["/bin/bash", "-c"]
 WORKDIR /app
-COPY ledger-server .
-COPY ledgerctl .
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/ledger-server .
+COPY $TARGETPLATFORM/ledgerctl .
 RUN ./ledgerctl completion bash > /etc/bash_completion.d/ledgerctl
 ENTRYPOINT ["./ledger-server"]


### PR DESCRIPTION
## Summary

- Migrate `.goreleaser.yml` from the deprecated `dockers`/`docker_manifests` blocks to the unified `dockers_v2` config, fixing goreleaser 2.17's deprecation warnings (`dockers and docker_manifests are being phased out...`).
- `dockers_v2` builds and pushes the multi-arch manifest directly instead of pushing per-arch images and merging them afterward, so `build.Dockerfile` now reads binaries from the per-platform context layout (`$TARGETPLATFORM/<binary>`) that `dockers_v2` provides, instead of a flat binary layout.
- `sbom` is explicitly set to `false` since `dockers_v2` defaults it to `true`, which the old config never did — this avoids silently changing published image behavior.

## Behavior note

The per-arch `<version>-amd64`/`<version>-arm64` image tags that the old `docker_manifests` step pushed as a side effect are no longer published; only the multi-arch manifest tags (`v<version>`, `latest`) are. No CI workflow, docs, or scripts reference those per-arch tags, so this is not expected to be a regression.

## Test plan

- [x] `goreleaser check` passes with no deprecation warnings
- [x] `goreleaser release --snapshot --clean` run locally, successfully building both `linux/amd64` and `linux/arm64` images via buildx
- [x] Smoke-tested the built amd64 image (`ledger --help`, `ledgerctl completion bash` baked-in step) works correctly
- [x] `bash scripts/agent-check` passes