### PR TITLE
fix(EN-1951): stop idle event GC rescans

### DIFF
--- a/docs/technical/architecture/subsystems/indexer/README.md
+++ b/docs/technical/architecture/subsystems/indexer/README.md
@@ -7,7 +7,7 @@ The background worker (`internal/application/indexbuilder`) that turns committed
 | Document | Description |
 |----------|-------------|
 | [indexes.md](indexes.md) | Index definition (`commonpb.Index`), per-replica `IndexVersionState`, on-demand statistics, and checker coverage. |
-| [indexer.md](indexer.md) | Indexer pipeline: builder loop, two-pass commit, handlers, read-store key layout, atomic switch, schema rewrite. |
+| [indexer.md](indexer.md) | Indexer pipeline: builder loop, two-pass commit, handlers, event-GC scheduling, read-store key layout, atomic switch, schema rewrite. |
 
 ## Related
 

--- a/docs/technical/architecture/subsystems/indexer/indexer.md
+++ b/docs/technical/architecture/subsystems/indexer/indexer.md
@@ -25,6 +25,14 @@ flowchart LR
 
 The ticker is intentional: an indexer that wakes only on signal would stall on signal-channel loss or under heavy GC pressure. The 100 ms cap bounds query-staleness even in the worst case.
 
+Event-history GC uses the same wakes but is edge-triggered rather than periodic.
+Each metadata (`0x01`) and entity-exists (`0x02`) zone records the stable
+`(lease-bounded watermark, committed write epoch)` tuple covered by its last
+complete traversal. Once both zones complete, idle ticks perform no event-zone
+iteration until the watermark advances or a successfully committed batch adds
+an event to the affected zone. The write epochs are per-zone, so a
+metadata-only event does not rescan entity existence.
+
 ### Goroutine ownership
 
 `Builder.Start()` wraps `Builder.loop(ctx)` in a `worker.New().RunCtx(...)` (`internal/pkg/worker`). The worker owns goroutine lifetime; `Builder.Stop()` cancels the worker's context and waits for the loop to drain. There is **no panic recovery** inside the loop — an indexer panic is a non-recoverable invariant violation (see `feedback_no_soft_wall_crash_on_invariant`).
@@ -74,6 +82,11 @@ flowchart TB
 - If the batch is non-empty (or a checkpoint action is pending), the progress cursor is **written into the same batch** and the batch is committed in one `batch.Commit()`. This makes "index writes" and "indexer progress" atomic — a crash mid-pass cannot leave the progress ahead of the data.
 - If the batch is **empty** (no log type in the range produced index writes), the Pebble batch is skipped entirely and the progress cursor is persisted lazily on the next non-empty batch (or via a small dedicated batch at loop exit). This reduces fsyncs to `O(1)` per active batch instead of `O(1)` per tick.
 - Query-checkpoint create/delete operations force a batch boundary so the checkpoint state is never persisted across two passes.
+- `WriteBatch` records which event zones actually received an event-key put.
+  The builder snapshots that mask before commit and advances the corresponding
+  in-memory GC write epochs only after `Flush` succeeds. Failed, cancelled,
+  no-op, progress-only, range-delete-only and switch-only batches therefore do
+  not publish event work that was not committed.
 
 A retype mutates its pending-version cache and task cursor optimistically so
 later logs in the same fold batch see the new version and reset. Those specific

--- a/docs/technical/architecture/subsystems/read-path/README.md
+++ b/docs/technical/architecture/subsystems/read-path/README.md
@@ -18,6 +18,7 @@ and the pipeline pages.
 | [query-pipeline.md](query-pipeline.md) | End-to-end read flow: ReadIndex barrier, min_log_sequence, Pebble snapshot, iterator algebra, pagination, streaming. |
 | [iterator-seek-contract.md](iterator-seek-contract.md) | Absolute SeekGE/SeekLE semantics across the iterator algebra, and the seekFloor/seekCeil exhaustion-proof cache. |
 | [read-snapshot-consistency.md](read-snapshot-consistency.md) | Single-snapshot rule for controller reads that stitch LedgerInfo with attribute data. |
+| [readstore-event-keys.md](readstore-event-keys.md) | Append-only metadata/existence event resolution, lease-bounded reclamation, and edge-triggered GC cycles. |
 | [prepared-queries.md](prepared-queries.md) | Named pre-validated query templates: lifecycle, filter DSL, execution, bloom acceleration. |
 | [query-checkpoints.md](query-checkpoints.md) | Point-in-time snapshots of main store and read index for historical queries. |
 | [typed-metadata.md](typed-metadata.md) | Typed values, immutable primary metadata, declared schemas, and versioned index coercion. |

--- a/docs/technical/architecture/subsystems/read-path/readstore-event-keys.md
+++ b/docs/technical/architecture/subsystems/read-path/readstore-event-keys.md
@@ -76,6 +76,35 @@ A reader racing a pass therefore either registers first (and is covered by the
 watermark the pass sweeps with) or arrives after (and is refused). Publishing
 the floor after the walk would reopen exactly that gap.
 
+### Edge-triggered cycles
+
+The indexbuilder keeps an in-memory cycle state independently for `0x01` and
+`0x02`. An inactive zone starts a full traversal only when it has never
+completed one, its effective lease-bounded watermark advanced, or its local
+committed write epoch advanced. A traversal remains budgeted to 4,096 keys per
+wake and captures one stable `(watermark, write epoch)` tuple at its start.
+Changes observed while that traversal is active schedule another full pass;
+they never widen the watermark of a prefix that was already scanned. This is
+what makes a historical event written behind the resume key visible to the
+follow-up pass.
+
+`WriteBatch` marks a zone only after an event-key put succeeds. The builder
+captures those marks before `Flush`, commits, and only then increments the
+affected zone epochs. A failed or cancelled commit advances no epoch. Normal
+live-fold and rewrite events are generally stamped at or above the current
+watermark, so an epoch-triggered full pass is deliberately conservative; it
+principally protects historical and late writers such as index backfills
+without coupling GC correctness to producer-specific sequence assumptions.
+
+Cycle state and epochs are not persisted because the read store is a
+rebuildable per-replica projection. After restart, the first positive watermark
+therefore performs a conservative full traversal. Watermark zero keeps the
+existing fast path and performs no scan. A failed slice retains its exact
+resume key and captured tuple for retry, while the other zone continues and
+may complete independently. Iterator failures abort before the current group is
+settled or the pending delete batch is committed, so a partial traversal can
+never be recorded as completed coverage.
+
 ## Version activation
 
 A schema rewrite builds a new version's keyspace and stamps **every** event it

--- a/internal/application/indexbuilder/backfill.go
+++ b/internal/application/indexbuilder/backfill.go
@@ -919,7 +919,7 @@ scan:
 		}
 	}
 
-	if err := b.wb.Flush(); err != nil {
+	if err := b.flushWriteBatch(); err != nil {
 		return false, fmt.Errorf("committing schema rewrite batch: %w", err)
 	}
 
@@ -996,7 +996,7 @@ func (b *Builder) tryCommitScanCompleteSwitch(
 		return false, fmt.Errorf("gc v_old keyspace: %w", err)
 	}
 
-	if err := b.wb.Flush(); err != nil {
+	if err := b.flushWriteBatch(); err != nil {
 		return false, fmt.Errorf("committing deferred schema-rewrite switch: %w", err)
 	}
 
@@ -1416,7 +1416,7 @@ func (b *Builder) processBackfill(ctx context.Context, stop <-chan struct{}, tas
 				return err
 			}
 
-			if err := b.wb.Flush(); err != nil {
+			if err := b.flushWriteBatch(); err != nil {
 				return err
 			}
 		} else {

--- a/internal/application/indexbuilder/backfill_postings.go
+++ b/internal/application/indexbuilder/backfill_postings.go
@@ -208,7 +208,7 @@ func (b *Builder) processBackfillPostings(ctx context.Context, stop <-chan struc
 				return err
 			}
 
-			if err := b.wb.Flush(); err != nil {
+			if err := b.flushWriteBatch(); err != nil {
 				return err
 			}
 		} else {

--- a/internal/application/indexbuilder/backfill_test.go
+++ b/internal/application/indexbuilder/backfill_test.go
@@ -1402,6 +1402,8 @@ func TestProcessSchemaRewriteCountsScannedKeysAgainstBudgetAndPersistsCursor(t *
 	assert.True(t, done)
 	assert.Equal(t, uint64(1), task.processedCount)
 	assert.Equal(t, matchingKey, task.rmapCursor)
+	assert.Positive(t, b.eventGCWriteEpoch[readstore.PrefixMetadataIndex], "schema rewrite commit dirties metadata events")
+	assert.Positive(t, b.eventGCWriteEpoch[readstore.PrefixEntityExists], "fresh pending row dirties exists events")
 
 	// Atomic switch GCs v_old in the same batch: the v=1 forward
 	// entry and the v=1 rmap row are gone; v=2 forward and rmap are
@@ -2123,6 +2125,8 @@ func TestAccountAssetBackfillLifecycle(t *testing.T) {
 	}
 
 	require.Empty(t, b.backfillTasks, "backfill task must be retired after catch-up")
+	assert.Zero(t, b.eventGCWriteEpoch[readstore.PrefixMetadataIndex], "postings-only backfill emits no metadata events")
+	assert.Zero(t, b.eventGCWriteEpoch[readstore.PrefixEntityExists], "postings-only backfill emits no exists events")
 
 	// Built: the atomic switch promoted current ← pending.
 	current, pending = b.versionFor(ledger, canonical)
@@ -2459,6 +2463,8 @@ func TestMetadataBackfillSkipsForeignLedgerLogs(t *testing.T) {
 	// passing vacuously on a backfill that indexed nothing at all.
 	taskRmap := readstore.ReverseMapPrefix(dal.NewKeyBuilder(), taskLedger, readstore.NamespaceAccount)
 	assert.NotZero(t, countKeysWithPrefix(t, b.readStore, taskRmap), "task ledger's rmap rows must be backfilled")
+	assert.Positive(t, b.eventGCWriteEpoch[readstore.PrefixMetadataIndex], "metadata backfill commit dirties metadata events")
+	assert.Positive(t, b.eventGCWriteEpoch[readstore.PrefixEntityExists], "fresh metadata backfill row dirties exists events")
 
 	// The foreign ledger's keyspace stayed untouched: it never indexed
 	// anything, so any row here is an orphan.

--- a/internal/application/indexbuilder/builder.go
+++ b/internal/application/indexbuilder/builder.go
@@ -67,9 +67,12 @@ type Builder struct {
 	// Max time budget per tick for backfill processing (default 50ms).
 	backfillBudget time.Duration
 
-	// Per-zone resume cursors for the incremental event GC (see
-	// runEventGC); nil resumes from the zone start.
-	eventGCResume map[byte][]byte
+	// Event GC scheduling is local and rebuildable. Each zone tracks the stable
+	// tuple covered by its active/completed cycle, while eventGCWriteEpoch moves
+	// only after a batch that appended events to that zone commits successfully.
+	eventGCCycles     map[byte]*eventGCCycleState
+	eventGCWriteEpoch map[byte]uint64
+	eventGCZone       eventGCZoneFunc
 
 	// Round-robin index for fair scheduling across backfill tasks.
 	nextBackfillIdx int

--- a/internal/application/indexbuilder/gc.go
+++ b/internal/application/indexbuilder/gc.go
@@ -237,8 +237,69 @@ func (b *Builder) purgeOrphanVersions() error {
 // times a second) while keeping each pass well under the tick interval.
 const eventGCKeyBudget = 4096
 
-// runEventGC advances the incremental reclamation of superseded metadata /
-// exists index events (readstore.GCEventZone) by one budgeted slice per zone.
+type eventGCZoneFunc func(zone byte, resume []byte, watermark uint64, budget int) (pruned int, next []byte, err error)
+
+type eventGCCycleState struct {
+	active    bool
+	completed bool
+	resume    []byte
+
+	cycleWatermark  uint64
+	cycleWriteEpoch uint64
+
+	completedWatermark  uint64
+	completedWriteEpoch uint64
+}
+
+func (b *Builder) gcEventZone(zone byte, resume []byte, watermark uint64, budget int) (int, []byte, error) {
+	if b.eventGCZone != nil {
+		return b.eventGCZone(zone, resume, watermark, budget)
+	}
+
+	return readstore.GCEventZone(b.readStore.DB(), zone, resume, watermark, budget)
+}
+
+func (b *Builder) eventGCCycle(zone byte) *eventGCCycleState {
+	if b.eventGCCycles == nil {
+		b.eventGCCycles = make(map[byte]*eventGCCycleState, 2)
+	}
+
+	state := b.eventGCCycles[zone]
+	if state == nil {
+		state = &eventGCCycleState{}
+		b.eventGCCycles[zone] = state
+	}
+
+	return state
+}
+
+// flushWriteBatch couples event-GC scheduling to the actual commit boundary:
+// zone dirtiness is captured before Flush resets the batch, but write epochs
+// advance only after that commit succeeds. Cancelled, failed and event-free
+// batches therefore cannot schedule a spurious sweep.
+func (b *Builder) flushWriteBatch() error {
+	eventZones := b.wb.EventZones()
+	if err := b.wb.Flush(); err != nil {
+		return err
+	}
+
+	if b.eventGCWriteEpoch == nil {
+		b.eventGCWriteEpoch = make(map[byte]uint64, 2)
+	}
+
+	for _, zone := range []byte{readstore.PrefixMetadataIndex, readstore.PrefixEntityExists} {
+		if eventZones.Has(zone) {
+			b.eventGCWriteEpoch[zone]++
+		}
+	}
+
+	return nil
+}
+
+// runEventGC advances edge-triggered reclamation of superseded metadata /
+// exists index events by one budgeted slice per active zone. A completed zone
+// stays idle until either the lease-bounded watermark or that zone's committed
+// write epoch advances.
 //
 // The fold cursor is only a proposal: BeginGC lowers it to the minimum live
 // pin and publishes the result as the registry's reclaim floor, under the
@@ -252,21 +313,41 @@ func (b *Builder) runEventGC(cursor uint64) {
 		return
 	}
 
-	if b.eventGCResume == nil {
-		b.eventGCResume = map[byte][]byte{}
-	}
-
 	for _, zone := range []byte{readstore.PrefixMetadataIndex, readstore.PrefixEntityExists} {
-		pruned, next, err := readstore.GCEventZone(b.readStore.DB(), zone, b.eventGCResume[zone], watermark, eventGCKeyBudget)
+		state := b.eventGCCycle(zone)
+		writeEpoch := b.eventGCWriteEpoch[zone]
+
+		if !state.active {
+			covered := state.completed &&
+				watermark <= state.completedWatermark &&
+				writeEpoch <= state.completedWriteEpoch
+			if covered {
+				continue
+			}
+
+			state.active = true
+			state.resume = nil
+			state.cycleWatermark = watermark
+			state.cycleWriteEpoch = writeEpoch
+		}
+
+		pruned, next, err := b.gcEventZone(zone, state.resume, state.cycleWatermark, eventGCKeyBudget)
 		if err != nil {
 			// One zone failing says nothing about the other; sweeping it is
-			// what keeps the surviving zone from growing without bound.
+			// what keeps the surviving zone from growing without bound. Keep
+			// this zone's exact cycle tuple and resume key for its retry.
 			b.logger.Errorf("event GC pass on zone %#x failed: %v", zone, err)
 
 			continue
 		}
 
-		b.eventGCResume[zone] = next
+		state.resume = next
+		if next == nil {
+			state.active = false
+			state.completed = true
+			state.completedWatermark = state.cycleWatermark
+			state.completedWriteEpoch = state.cycleWriteEpoch
+		}
 
 		if pruned > 0 {
 			b.logger.Debugf("event GC reclaimed %d events in zone %#x", pruned, zone)

--- a/internal/application/indexbuilder/gc_test.go
+++ b/internal/application/indexbuilder/gc_test.go
@@ -2,7 +2,9 @@ package indexbuilder
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -10,10 +12,344 @@ import (
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/domain/indexes"
 	"github.com/formancehq/ledger/v3/internal/infra/state"
+	"github.com/formancehq/ledger/v3/internal/pkg/signal"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 	"github.com/formancehq/ledger/v3/internal/storage/readstore"
 )
+
+func TestRunEventGC_StopsScanningAfterCompletedIdleCoverage(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	calls := 0
+	b.eventGCZone = func(_ byte, _ []byte, _ uint64, _ int) (int, []byte, error) {
+		calls++
+
+		return 0, nil, nil
+	}
+
+	b.runEventGC(10)
+	b.runEventGC(10)
+
+	require.Equal(t, 2, calls, "each zone must be scanned once, then remain idle")
+}
+
+func TestRunEventGC_TriggersOnWatermarkAndZoneWriteEpochEdges(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	b.eventGCWriteEpoch = make(map[byte]uint64)
+	calls := map[byte]int{}
+	b.eventGCZone = func(zone byte, _ []byte, _ uint64, _ int) (int, []byte, error) {
+		calls[zone]++
+
+		return 0, nil, nil
+	}
+
+	b.runEventGC(0)
+	require.Empty(t, calls, "zero watermark cannot reclaim any valid event")
+
+	b.runEventGC(10)
+	require.Equal(t, 1, calls[readstore.PrefixMetadataIndex])
+	require.Equal(t, 1, calls[readstore.PrefixEntityExists])
+
+	b.runEventGC(10)
+	require.Equal(t, 1, calls[readstore.PrefixMetadataIndex], "unchanged completed coverage stays idle")
+	require.Equal(t, 1, calls[readstore.PrefixEntityExists], "unchanged completed coverage stays idle")
+
+	b.runEventGC(20)
+	require.Equal(t, 2, calls[readstore.PrefixMetadataIndex], "higher watermark restarts metadata sweep")
+	require.Equal(t, 2, calls[readstore.PrefixEntityExists], "higher watermark restarts exists sweep")
+
+	b.eventGCWriteEpoch[readstore.PrefixMetadataIndex]++
+	b.runEventGC(20)
+	require.Equal(t, 3, calls[readstore.PrefixMetadataIndex], "zone write restarts that zone")
+	require.Equal(t, 2, calls[readstore.PrefixEntityExists], "metadata-only write does not restart exists sweep")
+}
+
+func TestRunEventGC_FreshSchedulerSweepsPositiveWatermarkAfterRestart(t *testing.T) {
+	t.Parallel()
+
+	original := newTestBuilderWithStore(t)
+	original.eventGCZone = func(_ byte, _ []byte, _ uint64, _ int) (int, []byte, error) {
+		return 0, nil, nil
+	}
+	original.runEventGC(10)
+
+	restarted := &Builder{
+		readStore: original.readStore,
+		logger:    original.logger,
+	}
+	calls := 0
+	restarted.eventGCZone = func(_ byte, _ []byte, _ uint64, _ int) (int, []byte, error) {
+		calls++
+
+		return 0, nil, nil
+	}
+	restarted.runEventGC(10)
+
+	require.Equal(t, 2, calls, "fresh in-memory state conservatively sweeps both zones")
+}
+
+func TestRunEventGC_UsesStableCycleTupleAndFollowsMidCycleChanges(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	b.eventGCWriteEpoch = make(map[byte]uint64)
+
+	type call struct {
+		zone      byte
+		resume    []byte
+		watermark uint64
+		epoch     uint64
+	}
+	var calls []call
+	metadataCalls := 0
+	b.eventGCZone = func(zone byte, resume []byte, watermark uint64, _ int) (int, []byte, error) {
+		calls = append(calls, call{
+			zone:      zone,
+			resume:    append([]byte(nil), resume...),
+			watermark: watermark,
+			epoch:     b.eventGCCycle(zone).cycleWriteEpoch,
+		})
+		if zone != readstore.PrefixMetadataIndex {
+			return 0, nil, nil
+		}
+
+		metadataCalls++
+		if metadataCalls == 1 {
+			// Model a historical event committed behind this slice's resume
+			// position while the stable (watermark=10, epoch=0) cycle is active.
+			b.eventGCWriteEpoch[zone] = 1
+
+			return 0, []byte{zone, 0x42}, nil
+		}
+
+		return 0, nil, nil
+	}
+
+	b.runEventGC(10)
+	b.runEventGC(20)
+	b.runEventGC(20)
+
+	var metadata []call
+	for _, got := range calls {
+		if got.zone == readstore.PrefixMetadataIndex {
+			metadata = append(metadata, got)
+		}
+	}
+	require.Equal(t, []call{
+		{zone: readstore.PrefixMetadataIndex, watermark: 10, epoch: 0},
+		{zone: readstore.PrefixMetadataIndex, resume: []byte{readstore.PrefixMetadataIndex, 0x42}, watermark: 10, epoch: 0},
+		{zone: readstore.PrefixMetadataIndex, watermark: 20, epoch: 1},
+	}, metadata, "mid-cycle edges schedule a later full sweep without widening the active prefix")
+}
+
+func TestRunEventGC_FollowUpCycleVisitsEventWrittenBehindResume(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	b.eventGCWriteEpoch = make(map[byte]uint64)
+	const (
+		ledger = "test"
+		key    = "status"
+	)
+	encoded := readstore.EncodeMetadataValue(nil, commonpb.NewStringValue("open"))
+	for _, entity := range []string{"a", "c", "d"} {
+		seedMetadataEvent(t, b, ledger, readstore.NamespaceAccount, key, 1, encoded, []byte(entity), 5, readstore.MetadataEventAdd)
+		seedMetadataEvent(t, b, ledger, readstore.NamespaceAccount, key, 1, encoded, []byte(entity), 6, readstore.MetadataEventDel)
+	}
+
+	behindAdd := cloneBytes(readstore.MetadataIndexEventKeyV(
+		b.kb, ledger, readstore.NamespaceAccount, key, 1, encoded, []byte("b"), 5, readstore.MetadataEventAdd,
+	))
+	behindDel := cloneBytes(readstore.MetadataIndexEventKeyV(
+		b.kb, ledger, readstore.NamespaceAccount, key, 1, encoded, []byte("b"), 6, readstore.MetadataEventDel,
+	))
+
+	metadataCalls := 0
+	b.eventGCZone = func(zone byte, resume []byte, watermark uint64, _ int) (int, []byte, error) {
+		pruned, next, err := readstore.GCEventZone(b.readStore.DB(), zone, resume, watermark, 2)
+		if err != nil || zone != readstore.PrefixMetadataIndex {
+			return pruned, next, err
+		}
+
+		metadataCalls++
+		if metadataCalls == 1 {
+			require.NotNil(t, next, "fixture must split before the late event's position")
+			late := b.readStore.NewBatch()
+			require.NoError(t, late.SetBytes(behindAdd, nil))
+			require.NoError(t, late.SetBytes(behindDel, nil))
+			require.NoError(t, late.Commit())
+			b.eventGCWriteEpoch[zone]++
+		}
+
+		return pruned, next, nil
+	}
+
+	for range 20 {
+		b.runEventGC(10)
+		state := b.eventGCCycle(readstore.PrefixMetadataIndex)
+		if state.completed && state.completedWriteEpoch == 0 && !state.active {
+			break
+		}
+	}
+	assertReadStoreValue(t, b, behindAdd, nil)
+	assertReadStoreValue(t, b, behindDel, nil)
+
+	for range 20 {
+		b.runEventGC(10)
+		state := b.eventGCCycle(readstore.PrefixMetadataIndex)
+		if state.completed && state.completedWriteEpoch == 1 && !state.active {
+			break
+		}
+	}
+	assertReadStoreMissing(t, b, behindAdd)
+	assertReadStoreMissing(t, b, behindDel)
+}
+
+func TestRunEventGC_RetriesFailedZoneWithoutBlockingOtherZone(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	calls := map[byte]int{}
+	resumeKey := []byte{readstore.PrefixMetadataIndex, 0x42}
+	b.eventGCZone = func(zone byte, resume []byte, watermark uint64, _ int) (int, []byte, error) {
+		calls[zone]++
+		if zone == readstore.PrefixMetadataIndex {
+			require.Equal(t, uint64(10), watermark, "failed slice retains its captured watermark")
+			switch calls[zone] {
+			case 1:
+				require.Nil(t, resume)
+
+				return 0, resumeKey, nil
+			case 2:
+				require.Equal(t, resumeKey, resume)
+
+				return 0, nil, errors.New("injected GC failure")
+			case 3:
+				require.Equal(t, resumeKey, resume, "failed slice retains its exact resume cursor")
+			}
+		}
+
+		return 0, nil, nil
+	}
+
+	b.runEventGC(10)
+	require.Equal(t, 1, calls[readstore.PrefixMetadataIndex])
+	require.Equal(t, 1, calls[readstore.PrefixEntityExists], "other zone still completes")
+
+	b.runEventGC(10)
+	require.Equal(t, 2, calls[readstore.PrefixMetadataIndex], "failed zone retries")
+	require.Equal(t, 1, calls[readstore.PrefixEntityExists], "completed zone stays idle during retry")
+
+	b.runEventGC(10)
+	require.Equal(t, 3, calls[readstore.PrefixMetadataIndex], "failed slice executes a real fail-then-success retry")
+
+	b.runEventGC(10)
+	require.Equal(t, 3, calls[readstore.PrefixMetadataIndex], "successful retry completes coverage")
+}
+
+func TestFlushWriteBatchAdvancesOnlyCommittedDirtyZoneEpochs(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	const (
+		ledger = "test"
+		key    = "status"
+		entity = "accounts:1"
+	)
+	reverseKey := readstore.AccountReverseMapKeyV(b.kb, ledger, entity, key, 1)
+	openValue := readstore.EncodeMetadataValue(nil, commonpb.NewStringValue("open"))
+	closedValue := readstore.EncodeMetadataValue(nil, commonpb.NewStringValue("closed"))
+
+	batch := b.readStore.NewBatch()
+	b.initBatch(batch)
+	b.wb.SetEventSequence(10)
+	require.NoError(t, b.wb.ReplaceMetadataIndexV(
+		b.kb, reverseKey, ledger, readstore.NamespaceAccount, key, 1,
+		openValue, nil, []byte(entity),
+	))
+	require.NoError(t, b.flushWriteBatch())
+	require.Equal(t, uint64(1), b.eventGCWriteEpoch[readstore.PrefixMetadataIndex])
+	require.Equal(t, uint64(1), b.eventGCWriteEpoch[readstore.PrefixEntityExists])
+
+	batch = b.readStore.NewBatch()
+	b.initBatch(batch)
+	b.wb.SetEventSequence(11)
+	require.NoError(t, b.wb.ReplaceMetadataIndexV(
+		b.kb, reverseKey, ledger, readstore.NamespaceAccount, key, 1,
+		closedValue, openValue, []byte(entity),
+	))
+	require.NoError(t, b.flushWriteBatch())
+	require.Equal(t, uint64(2), b.eventGCWriteEpoch[readstore.PrefixMetadataIndex])
+	require.Equal(t, uint64(1), b.eventGCWriteEpoch[readstore.PrefixEntityExists], "same null class emits no exists event")
+
+	batch = b.readStore.NewBatch()
+	b.initBatch(batch)
+	b.wb.SetEventSequence(12)
+	require.NoError(t, b.wb.ReplaceMetadataIndexV(
+		b.kb, reverseKey, ledger, readstore.NamespaceAccount, key, 1,
+		closedValue, closedValue, []byte(entity),
+	))
+	require.NoError(t, b.flushWriteBatch())
+	require.Equal(t, uint64(2), b.eventGCWriteEpoch[readstore.PrefixMetadataIndex], "no-op replacement advances no epoch")
+	require.Equal(t, uint64(1), b.eventGCWriteEpoch[readstore.PrefixEntityExists])
+
+	batch = b.readStore.NewBatch()
+	b.initBatch(batch)
+	b.wb.SetEventSequence(13)
+	require.NoError(t, b.wb.ReplaceMetadataIndexV(
+		b.kb, reverseKey, ledger, readstore.NamespaceAccount, key, 1,
+		openValue, closedValue, []byte(entity),
+	))
+	require.NoError(t, batch.Cancel())
+	b.wb.Reset()
+	require.Equal(t, uint64(2), b.eventGCWriteEpoch[readstore.PrefixMetadataIndex], "cancelled batch advances no epoch")
+	require.Equal(t, uint64(1), b.eventGCWriteEpoch[readstore.PrefixEntityExists])
+
+	batch = b.readStore.NewBatch()
+	b.initBatch(batch)
+	b.wb.SetEventSequence(14)
+	require.NoError(t, b.wb.ReplaceMetadataIndexV(
+		b.kb, reverseKey, ledger, readstore.NamespaceAccount, key, 1,
+		closedValue, openValue, []byte(entity),
+	))
+	// Consume the session first so the helper's own Flush deterministically
+	// returns an error without relying on filesystem fault injection.
+	require.NoError(t, batch.Commit())
+	require.Error(t, b.flushWriteBatch())
+	require.Equal(t, uint64(2), b.eventGCWriteEpoch[readstore.PrefixMetadataIndex], "failed Flush advances no epoch")
+	require.Equal(t, uint64(1), b.eventGCWriteEpoch[readstore.PrefixEntityExists])
+}
+
+func TestProcessLogsSuccessfulEventCommitAdvancesDirtyZoneEpochs(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	b.notifications = signal.NewNotifications()
+	b.batchSize = DefaultBatchSize
+
+	const (
+		ledger = "test"
+		key    = "status"
+	)
+	declareFieldType(t, b, ledger, key, commonpb.MetadataType_METADATA_TYPE_STRING)
+	id := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, key)
+	canonical := indexes.Canonical(id)
+	cfg := newLedgerIndexConfig()
+	cfg.byCanonical[canonical] = &commonpb.Index{Id: id}
+	b.indexConfig[ledger] = cfg
+	b.putVersionState(ledger, canonical, readstore.IndexVersionState{CurrentVersion: 1, HighWater: 1})
+
+	writeLogToFSM(t, b, makeSavedAccountMetadataLog(1, ledger, "accounts:1", key, "open"))
+	cursor, err := b.processLogs(context.Background(), 0, time.Time{})
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), cursor)
+	require.Equal(t, uint64(1), b.eventGCWriteEpoch[readstore.PrefixMetadataIndex])
+	require.Equal(t, uint64(1), b.eventGCWriteEpoch[readstore.PrefixEntityExists])
+}
 
 // TestGCVersionAt_PurgesForwardEidxAndRmap pins the single-version
 // cleanup primitive: forward + eidx ranges go via DeleteRange (cheap

--- a/internal/application/indexbuilder/process_logs.go
+++ b/internal/application/indexbuilder/process_logs.go
@@ -230,7 +230,7 @@ func (b *Builder) processLogs(ctx context.Context, cursor uint64, deadline time.
 				return cursor, err
 			}
 
-			if err := b.wb.Flush(); err != nil {
+			if err := b.flushWriteBatch(); err != nil {
 				b.logger.WithFields(map[string]any{
 					"batchSize": batchCount,
 					"lastSeq":   lastSeq,

--- a/internal/storage/readstore/event_gc.go
+++ b/internal/storage/readstore/event_gc.go
@@ -7,6 +7,14 @@ import (
 	"github.com/cockroachdb/pebble/v2"
 )
 
+type eventGCIterator interface {
+	First() bool
+	Valid() bool
+	Next() bool
+	Key() []byte
+	Error() error
+}
+
 // GCEventZone reclaims superseded events below the read-lease watermark
 // across one event zone (the metadata index 0x01 or the exists index 0x02),
 // walking at most budget keys from resume (nil = zone start) and stopping
@@ -43,6 +51,10 @@ func GCEventZone(db *pebble.DB, zone byte, resume []byte, watermark uint64, budg
 	}
 	defer func() { _ = iter.Close() }()
 
+	return gcEventZoneWithIterator(db, iter, watermark, budget)
+}
+
+func gcEventZoneWithIterator(db *pebble.DB, iter eventGCIterator, watermark uint64, budget int) (pruned int, next []byte, err error) {
 	batch := db.NewBatch()
 	defer func() { _ = batch.Close() }()
 
@@ -167,6 +179,13 @@ func GCEventZone(db *pebble.DB, zone byte, resume []byte, watermark uint64, budg
 
 		pendingBelow = append(pendingBelow[:0], key...)
 		pendingIsAdd = op == MetadataEventAdd
+	}
+
+	// !Valid means either clean exhaustion or an iterator failure. Settling the
+	// group and committing here without distinguishing them would turn a partial
+	// traversal into completed coverage and permanently strand unvisited keys.
+	if iterErr := iter.Error(); iterErr != nil {
+		return 0, nil, iterErr
 	}
 
 	if next == nil {

--- a/internal/storage/readstore/event_gc_test.go
+++ b/internal/storage/readstore/event_gc_test.go
@@ -1,10 +1,84 @@
 package readstore
 
 import (
+	"errors"
 	"testing"
 
+	"github.com/cockroachdb/pebble/v2"
 	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
+
+type failingEventGCIterator struct {
+	eventGCIterator
+
+	failOnNext int
+	nextCalls  int
+	failed     bool
+	err        error
+}
+
+func (i *failingEventGCIterator) Valid() bool {
+	return !i.failed && i.eventGCIterator.Valid()
+}
+
+func (i *failingEventGCIterator) Next() bool {
+	i.nextCalls++
+	if i.nextCalls == i.failOnNext {
+		i.failed = true
+
+		return false
+	}
+
+	return i.eventGCIterator.Next()
+}
+
+func (i *failingEventGCIterator) Error() error {
+	if i.failed {
+		return i.err
+	}
+
+	return i.eventGCIterator.Error()
+}
+
+func TestGCEventZone_IteratorFailureDiscardsPendingDeletes(t *testing.T) {
+	t.Parallel()
+
+	s, _ := eventFixture(t, "v",
+		ev{"a", 10, MetadataEventAdd},
+		ev{"a", 20, MetadataEventDel},
+		ev{"b", 10, MetadataEventAdd},
+	)
+
+	iter, err := s.DB().NewIter(&pebble.IterOptions{
+		LowerBound: []byte{PrefixMetadataIndex},
+		UpperBound: IncrementBytes([]byte{PrefixMetadataIndex}),
+	})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, iter.Close()) }()
+
+	injected := errors.New("injected iterator failure")
+	failing := &failingEventGCIterator{
+		eventGCIterator: iter,
+		failOnNext:      3,
+		err:             injected,
+	}
+	pruned, next, err := gcEventZoneWithIterator(s.DB(), failing, 30, 1<<20)
+	require.ErrorIs(t, err, injected)
+	require.Zero(t, pruned)
+	require.Nil(t, next)
+
+	kb := dal.NewKeyBuilder()
+	for _, key := range [][]byte{
+		MetadataIndexEventKeyV(kb, "l", NamespaceAccount, "k", 1, []byte("v"), []byte("a"), 10, MetadataEventAdd),
+		MetadataIndexEventKeyV(kb, "l", NamespaceAccount, "k", 1, []byte("v"), []byte("a"), 20, MetadataEventDel),
+	} {
+		_, closer, getErr := s.DB().Get(key)
+		require.NoError(t, getErr, "iterator failure must discard the whole pending delete batch")
+		require.NoError(t, closer.Close())
+	}
+}
 
 // The pruning rule: below the watermark, only a group's latest event may
 // survive, and only as an ADD. Resolution at any pin >= watermark must be

--- a/internal/storage/readstore/write_batch.go
+++ b/internal/storage/readstore/write_batch.go
@@ -12,6 +12,11 @@ type WriteBatch struct {
 	batch *dal.WriteSession
 	count int // number of operations buffered
 
+	// eventZones records which append-only event keyspaces this batch actually
+	// wrote. The indexbuilder snapshots it immediately before Flush and advances
+	// its in-memory GC write epochs only after the commit succeeds.
+	eventZones EventZoneMask
+
 	// rmapOverlay is a read-your-writes view of the reverse-map mutations made in
 	// the current (uncommitted) batch: reverseKey -> encoded value last written
 	// (nil = deleted). It is reset by Init so it always matches the bound batch,
@@ -25,6 +30,28 @@ type WriteBatch struct {
 	// the caller per folded log (SetEventSequence). Zero means unset — event
 	// writes fail loudly rather than stamping a stale or absent sequence.
 	eventSeq uint64
+}
+
+// EventZoneMask identifies append-only event keyspaces dirtied by a WriteBatch.
+// It is intentionally opaque: callers query membership by read-store prefix so
+// the bit representation cannot leak into scheduler state.
+type EventZoneMask uint8
+
+const (
+	eventZoneMetadataIndex EventZoneMask = 1 << iota
+	eventZoneEntityExists
+)
+
+// Has reports whether the batch appended an event in zone.
+func (m EventZoneMask) Has(zone byte) bool {
+	switch zone {
+	case PrefixMetadataIndex:
+		return m&eventZoneMetadataIndex != 0
+	case PrefixEntityExists:
+		return m&eventZoneEntityExists != 0
+	default:
+		return false
+	}
 }
 
 // SetEventSequence declares the raft sequence for subsequent metadata /
@@ -47,6 +74,13 @@ func (wb *WriteBatch) Init(batch *dal.WriteSession) {
 	wb.batch = batch
 	wb.rmapOverlay = make(map[string][]byte)
 	wb.eventSeq = 0
+	wb.eventZones = 0
+}
+
+// EventZones returns a read-only snapshot of the event keyspaces dirtied by
+// successful puts in the current batch.
+func (wb *WriteBatch) EventZones() EventZoneMask {
+	return wb.eventZones
 }
 
 // ReverseMapOverlay returns the encoded value this batch last wrote for
@@ -75,6 +109,7 @@ func (wb *WriteBatch) Reset() {
 	wb.count = 0
 	wb.rmapOverlay = nil
 	wb.eventSeq = 0
+	wb.eventZones = 0
 }
 
 // put sets a key-value pair in the batch.
@@ -134,6 +169,7 @@ func (wb *WriteBatch) Flush() error {
 	err := wb.batch.Commit()
 	wb.batch = nil
 	wb.count = 0
+	wb.eventZones = 0
 
 	return err
 }

--- a/internal/storage/readstore/write_batch_event_zones_test.go
+++ b/internal/storage/readstore/write_batch_event_zones_test.go
@@ -1,0 +1,108 @@
+package readstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+func TestWriteBatchEventZonesTrackActualEventPuts(t *testing.T) {
+	t.Parallel()
+
+	const (
+		ledger = "test"
+		key    = "status"
+		entity = "accounts:1"
+	)
+
+	newBatch := func(t *testing.T) (*WriteBatch, *dal.WriteSession) {
+		t.Helper()
+
+		store := newTestStore(t)
+		session := store.NewBatch()
+		wb := NewWriteBatch()
+		wb.Init(session)
+		wb.SetEventSequence(10)
+		t.Cleanup(func() { _ = session.Cancel() })
+
+		return wb, session
+	}
+
+	t.Run("fresh non-null value marks both zones", func(t *testing.T) {
+		t.Parallel()
+
+		wb, _ := newBatch(t)
+		encoded := EncodeMetadataValue(nil, commonpb.NewStringValue("open"))
+		reverseKey := AccountReverseMapKeyV(dal.NewKeyBuilder(), ledger, entity, key, 1)
+
+		require.NoError(t, wb.ReplaceMetadataIndexV(
+			dal.NewKeyBuilder(), reverseKey, ledger, NamespaceAccount, key, 1,
+			encoded, nil, []byte(entity),
+		))
+		require.True(t, wb.EventZones().Has(PrefixMetadataIndex))
+		require.True(t, wb.EventZones().Has(PrefixEntityExists))
+	})
+
+	t.Run("same null class marks metadata only", func(t *testing.T) {
+		t.Parallel()
+
+		wb, _ := newBatch(t)
+		oldEncoded := EncodeMetadataValue(nil, commonpb.NewStringValue("open"))
+		newEncoded := EncodeMetadataValue(nil, commonpb.NewStringValue("closed"))
+		reverseKey := AccountReverseMapKeyV(dal.NewKeyBuilder(), ledger, entity, key, 1)
+
+		require.NoError(t, wb.ReplaceMetadataIndexV(
+			dal.NewKeyBuilder(), reverseKey, ledger, NamespaceAccount, key, 1,
+			newEncoded, oldEncoded, []byte(entity),
+		))
+		require.True(t, wb.EventZones().Has(PrefixMetadataIndex))
+		require.False(t, wb.EventZones().Has(PrefixEntityExists))
+	})
+
+	t.Run("equal replacement marks no zone", func(t *testing.T) {
+		t.Parallel()
+
+		wb, _ := newBatch(t)
+		encoded := EncodeMetadataValue(nil, commonpb.NewStringValue("open"))
+		reverseKey := AccountReverseMapKeyV(dal.NewKeyBuilder(), ledger, entity, key, 1)
+
+		require.NoError(t, wb.ReplaceMetadataIndexV(
+			dal.NewKeyBuilder(), reverseKey, ledger, NamespaceAccount, key, 1,
+			encoded, encoded, []byte(entity),
+		))
+		require.False(t, wb.EventZones().Has(PrefixMetadataIndex))
+		require.False(t, wb.EventZones().Has(PrefixEntityExists))
+	})
+
+	t.Run("reset and flush clear the snapshot", func(t *testing.T) {
+		t.Parallel()
+
+		wb, _ := newBatch(t)
+		encoded := EncodeMetadataValue(nil, commonpb.NewStringValue("open"))
+		reverseKey := AccountReverseMapKeyV(dal.NewKeyBuilder(), ledger, entity, key, 1)
+		require.NoError(t, wb.ReplaceMetadataIndexV(
+			dal.NewKeyBuilder(), reverseKey, ledger, NamespaceAccount, key, 1,
+			encoded, nil, []byte(entity),
+		))
+
+		require.NoError(t, wb.Flush())
+		require.False(t, wb.EventZones().Has(PrefixMetadataIndex))
+		require.False(t, wb.EventZones().Has(PrefixEntityExists))
+
+		store := newTestStore(t)
+		resetSession := store.NewBatch()
+		wb.Init(resetSession)
+		wb.SetEventSequence(11)
+		require.NoError(t, wb.ReplaceMetadataIndexV(
+			dal.NewKeyBuilder(), reverseKey, ledger, NamespaceAccount, key, 1,
+			encoded, nil, []byte(entity),
+		))
+		require.NoError(t, resetSession.Cancel())
+		wb.Reset()
+		require.False(t, wb.EventZones().Has(PrefixMetadataIndex))
+		require.False(t, wb.EventZones().Has(PrefixEntityExists))
+	})
+}

--- a/internal/storage/readstore/write_batch_events.go
+++ b/internal/storage/readstore/write_batch_events.go
@@ -50,7 +50,13 @@ func (wb *WriteBatch) appendMetadataIndexEvent(
 		return err
 	}
 
-	return wb.put(MetadataIndexEventKeyV(kb, ledgerName, ns, metadataKey, version, encodedValue, entityID, seq, op), nil)
+	if err := wb.put(MetadataIndexEventKeyV(kb, ledgerName, ns, metadataKey, version, encodedValue, entityID, seq, op), nil); err != nil {
+		return err
+	}
+
+	wb.eventZones |= eventZoneMetadataIndex
+
+	return nil
 }
 
 func (wb *WriteBatch) appendEntityExistsEvent(
@@ -67,5 +73,11 @@ func (wb *WriteBatch) appendEntityExistsEvent(
 		return err
 	}
 
-	return wb.put(EntityExistsEventKeyV(kb, ledgerName, ns, metaKey, version, isNull, entityID, seq, op), nil)
+	if err := wb.put(EntityExistsEventKeyV(kb, ledgerName, ns, metaKey, version, isNull, entityID, seq, op), nil); err != nil {
+		return err
+	}
+
+	wb.eventZones |= eventZoneEntityExists
+
+	return nil
 }


### PR DESCRIPTION
## What changed

The read-store event GC now stops scanning after a zone fully covers an unchanged watermark/write-epoch tuple. Per-zone committed write epochs restart only the affected zone, including for historical backfill writes, while active cycles keep a stable watermark and retry errors without publishing false coverage.

The change also makes `GCEventZone` propagate iterator failures before settling groups or committing pending deletes.

## Why

An otherwise idle Ledger v3 node spent 3.83 CPU-minutes out of 5.15 total CPU-minutes over a 30-minute profile in `runEventGC`. Completed zones returned a nil resume cursor, which the next 100 ms tick interpreted as “start again”, continuously reading and decompressing the same Pebble SSTables.

Jira: [EN-1951](https://formance-team.atlassian.net/browse/EN-1951)

## Bugfix evidence

DISCOVERY: DIRECT_FIX  
BEFORE_FIX: BUG_REPRODUCED  
AFTER_FIX: PASS

Before the fix, the focused idle regression expected one call per event zone over two unchanged ticks but observed four calls. After the fix, it observes only the initial two calls and no repeated scan. The review-discovered iterator-error regression also failed before the follow-up fix and now proves the pending delete batch is discarded and the error propagated.

## Product / operational motivation

Need: idle replicas must not continuously spend CPU and read-store I/O proving that no new event history is reclaimable.

Current limitation: every completed GC traversal immediately restarted, accounting for about 74% of process CPU in the captured idle profile.

Requirement / constraint: completed zones remain idle until their lease-bounded watermark or successfully committed zone-specific write epoch advances, without weakening pinned-read reclamation safety, backfill cleanup, failure retry, or bounded per-tick work.

Evidence: EN-1951; the additive idle regression reproduces four zone calls over two unchanged ticks before the fix and requires only the initial two afterward.

Durable repository evidence: `docs/technical/architecture/subsystems/read-path/readstore-event-keys.md` and `docs/technical/architecture/subsystems/indexer/indexer.md`.

## Technical decision

Decision: keep explicit in-memory cycle coverage per event zone, capture a stable watermark/write-epoch tuple at cycle start, and advance per-zone epochs only after a batch that actually appended that zone’s events commits successfully.

Why now / why proportionate: the scheduler state is peer-local and rebuildable; one conservative pass after restart avoids new persistence or migration while eliminating permanent polling. Zone-specific epochs prevent metadata-only changes from needlessly rescanning entity-existence data.

Alternatives considered: cursor-only gating misses lease-release and historical-backfill work; a fixed cooldown only reduces the symptom and adds arbitrary latency; a global epoch causes avoidable cross-zone rescans; persisted scheduler state adds unnecessary recovery complexity.

## Risk

**MEDIUM** — this changes when event-history reclamation runs. Stable cycle tuples, real behind-resume writes, per-zone commit tracking, iterator-error aborts, retry/isolation, restart, and existing resolution/lease contracts are covered by focused race tests.

## Validation

- [x] `bash scripts/agent-check`
- [x] `go test -race ./internal/application/indexbuilder ./internal/storage/readstore -count=1`
- [x] `AI_REVIEW_BASE_SHA=b0fcefd07175a1ec6787df30b7b842129fc0bdab bash scripts/agent-check-pr`
- [x] Adversarial worktree review: approved after one P2 iterator-error finding was reproduced, fixed, and re-reviewed
- [x] Final exact-commit re-review after rebasing onto current `release/v3.0`: approved

The observable requirement is proven by the idle call-count regression: after initial coverage, repeated unchanged ticks issue no further `GCEventZone` calls.

## Architecture / behavior impact

Peer-local, rebuildable read-store scheduling only. No FSM/Raft apply change, persisted format, protobuf/API change, migration, compatibility path, or new dependency. Restart conservatively forgets scheduling coverage and performs the first sweep at a positive watermark.

## Review focus

Please focus on stable mid-cycle watermark/write-epoch handling, commit-before-epoch ordering across all five production flush paths, and iterator failures aborting before group settlement or batch commit.

## Known concerns

A representative deployed idle re-profile was not available locally. The code-level iterator call-count regression proves repeated idle scans stop; CI remains the broad validation boundary.

[EN-1951]: https://formance-team.atlassian.net/browse/EN-1951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ