### PR TITLE
fix(tooling): bind native audit challenge digest

### DIFF
--- a/docs/technical/contributing/ai-audit-challenge.md
+++ b/docs/technical/contributing/ai-audit-challenge.md
@@ -42,8 +42,9 @@ Challenge runs are bound to the exact `head` recorded in the source audit report
 The launcher hashes the source report before the provider runs and verifies the
 same bytes remain afterward. It records that SHA-256 identity as
 `sourceAuditDigest` in the published qualified report so downstream consumers
-can verify the exact source artifact. The reasoning provider does not mint this
-provenance value.
+can verify the exact source artifact. The launcher supplies that trusted value
+to the reasoning provider and rejects the result unless it copies the value
+exactly; the provider does not determine its own provenance value.
 
 ## Mutation policy
 
@@ -67,7 +68,7 @@ A `CONFIRMED` result is suitable to become a backlog/Jira candidate after human 
 
 The qualified report is rejected unless every result reuses an original finding id exactly once and preserves that finding's severity and title. A challenge pass may change the status, not the priority or the subject of the original finding.
 
-The launcher adds the trusted source digest to a temporary file under
-`build/ai-audit/` and atomically renames the validated qualification to its final
-name. Provider failure or validation failure publishes nothing. The source
-report and tracked repository content are never written.
+The launcher validates the trusted source digest in a temporary file under
+`build/ai-audit/` and atomically renames the qualification to its final name.
+Provider failure or validation failure publishes nothing. The source report and
+tracked repository content are never written.

--- a/scripts/ai-audit-challenge
+++ b/scripts/ai-audit-challenge
@@ -100,10 +100,11 @@ Do not add new finding ids. Produce exactly one result for every original findin
 
 Do not modify the repository. Do not implement reproducers. Do not create issues, comments, commits, or patches. Refine reproduction plans only as instructions for a later phase.
 
-Copy audit_id and head exactly. Output only JSON matching the schema.
+Copy audit_id, head, and sourceAuditDigest exactly. Output only JSON matching the schema.
 EOF
 {
-    printf '\nTRUSTED TARGET\n- audit_id: %s\n- head: %s\n- source_report: %s\n' "$audit_id" "$audited_head" "$source_report"
+    printf '\nTRUSTED TARGET\n- audit_id: %s\n- head: %s\n- sourceAuditDigest: %s\n- source_report: %s\n' \
+        "$audit_id" "$audited_head" "$source_audit_digest" "$source_report"
 } >>"$prompt"
 
 (
@@ -119,6 +120,16 @@ EOF
 jq -e --arg id "$audit_id" --arg head "$audited_head" '
   type == "object" and .audit_id == $id and .head == $head
 ' "$provider_output" >/dev/null || { echo "ai-audit-challenge: result target mismatch" >&2; exit 1; }
+if ! jq -e '
+  .sourceAuditDigest | type == "string" and test("^sha256:[0-9a-f]{64}$")
+' "$provider_output" >/dev/null; then
+    echo "ai-audit-challenge: result must contain a valid sourceAuditDigest" >&2
+    exit 1
+fi
+if ! jq -e --arg digest "$source_audit_digest" '.sourceAuditDigest == $digest' "$provider_output" >/dev/null; then
+    echo "ai-audit-challenge: result sourceAuditDigest does not match the source audit report" >&2
+    exit 1
+fi
 source_ids=$(jq -c '[.findings[].id] | sort' "$source_report")
 result_ids=$(jq -c '[.results[].id] | sort' "$provider_output")
 [[ "$source_ids" == "$result_ids" ]] || { echo "ai-audit-challenge: result ids do not match source findings" >&2; exit 1; }
@@ -142,9 +153,10 @@ current_head=$(git rev-parse HEAD)
     echo "ai-audit-challenge: repository state changed during challenge; refusing result" >&2
     exit 1
 }
-# The runner adds source identity after provider validation. The final temporary
-# file shares a directory with the destination, so rename publishes atomically.
-jq --arg digest "$source_audit_digest" '. + {sourceAuditDigest: $digest}' "$provider_output" >"$qualified_output"
+# The provider copies source identity from the trusted target and the runner
+# verifies it above. The final temporary file shares a directory with the
+# destination, so rename publishes atomically.
+cp -- "$provider_output" "$qualified_output"
 rm -f -- "$provider_output"
 provider_output=""
 mv -f -- "$qualified_output" "$output"

--- a/scripts/aiauditchallenge/runner_test.go
+++ b/scripts/aiauditchallenge/runner_test.go
@@ -43,6 +43,25 @@ fi
 cp "$FAKE_CODEX_RESULT" "$output"
 `
 
+func TestChallengeSchemaRequiresEveryTopLevelProperty(t *testing.T) {
+	t.Parallel()
+
+	repository := repositoryRoot(t)
+	challengeSchema := readJSON(t, filepath.Join(repository, "scripts", "codex-audit-challenge.schema.json"))
+	properties := challengeSchema["properties"].(map[string]any)
+	requiredValues := challengeSchema["required"].([]any)
+	required := make([]string, 0, len(requiredValues))
+	for _, value := range requiredValues {
+		required = append(required, value.(string))
+	}
+
+	require.ElementsMatch(t, keys(properties), required)
+	require.Contains(t, required, "sourceAuditDigest")
+
+	auditSchema := readJSON(t, filepath.Join(repository, "scripts", "codex-audit.schema.json"))
+	require.NotContains(t, auditSchema["properties"].(map[string]any), "sourceAuditDigest")
+}
+
 func TestRunnerPublishesOneQualifiedResultPerOriginalFinding(t *testing.T) {
 	t.Parallel()
 
@@ -61,8 +80,72 @@ func TestRunnerPublishesOneQualifiedResultPerOriginalFinding(t *testing.T) {
 	require.Equal(t, fixture.head, published["head"])
 	require.Equal(t, fileDigest(t, fixture.sourceReport), published["sourceAuditDigest"])
 	results := published["results"].([]any)
-	require.Equal(t, firstFindingID, results[0].(map[string]any)["id"])
+	first := results[0].(map[string]any)
+	require.Equal(t, firstFindingID, first["id"])
+	require.Equal(t, "P2", first["severity"])
+	require.Equal(t, "Original title of "+firstFindingID, first["title"])
 	require.Equal(t, secondFindingID, results[1].(map[string]any)["id"])
+}
+
+func TestRunnerRejectsMissingSourceAuditDigest(t *testing.T) {
+	t.Parallel()
+
+	fixture := newFixture(t)
+	result := fixture.validResult()
+	delete(result, "sourceAuditDigest")
+
+	output, err := fixture.run(t, result)
+	require.Error(t, err)
+	require.Contains(t, output, "result must contain a valid sourceAuditDigest")
+	require.NoFileExists(t, fixture.outputPath)
+}
+
+func TestRunnerRejectsMalformedSourceAuditDigest(t *testing.T) {
+	t.Parallel()
+
+	fixture := newFixture(t)
+	result := fixture.validResult()
+	result["sourceAuditDigest"] = "sha256:not-a-digest"
+
+	output, err := fixture.run(t, result)
+	require.Error(t, err)
+	require.Contains(t, output, "result must contain a valid sourceAuditDigest")
+	require.NoFileExists(t, fixture.outputPath)
+}
+
+func TestRunnerRejectsSourceAuditDigestForAnotherReport(t *testing.T) {
+	t.Parallel()
+
+	fixture := newFixture(t)
+	result := fixture.validResult()
+	result["sourceAuditDigest"] = "sha256:" + strings.Repeat("0", 64)
+
+	output, err := fixture.run(t, result)
+	require.Error(t, err)
+	require.Contains(t, output, "sourceAuditDigest does not match the source audit report")
+	require.NoFileExists(t, fixture.outputPath)
+}
+
+func TestZeroFindingAuditCanBeChallenged(t *testing.T) {
+	t.Parallel()
+
+	fixture := newFixture(t)
+	audit := sourceReport(fixture.head)
+	audit["findings"] = []map[string]any{}
+
+	auditOutput, sourceReport, err := fixture.runAudit(t, audit)
+	require.NoError(t, err, auditOutput)
+	require.Contains(t, auditOutput, "AI_AUDIT_RESULT: "+sourceReport)
+
+	fixture.sourceReport = sourceReport
+	fixture.sourceDigest = fileDigest(t, sourceReport)
+	challengeOutput, err := fixture.run(t, fixture.result())
+	require.NoError(t, err, challengeOutput)
+	require.Contains(t, challengeOutput, "AI_AUDIT_CHALLENGE_RESULT: "+fixture.outputPath)
+
+	published := readJSON(t, fixture.outputPath)
+	require.Empty(t, published["results"])
+	require.Equal(t, fileDigest(t, sourceReport), published["sourceAuditDigest"])
 }
 
 func TestRunnerRejectsResultForAnotherAudit(t *testing.T) {
@@ -95,7 +178,7 @@ func TestRunnerRejectsOmittedFinding(t *testing.T) {
 	t.Parallel()
 
 	fixture := newFixture(t)
-	result := challengeResult(fixture.head, challengeOutcome(firstFindingID, "CONFIRMED"))
+	result := fixture.result(challengeOutcome(firstFindingID, "CONFIRMED"))
 
 	output, err := fixture.run(t, result)
 	require.Error(t, err)
@@ -107,7 +190,7 @@ func TestRunnerRejectsInventedFindingID(t *testing.T) {
 	t.Parallel()
 
 	fixture := newFixture(t)
-	result := challengeResult(fixture.head,
+	result := fixture.result(
 		challengeOutcome(firstFindingID, "CONFIRMED"),
 		challengeOutcome(secondFindingID, "REJECTED"),
 		challengeOutcome(testAuditID+"/invented-during-challenge", "CONFIRMED"),
@@ -126,7 +209,7 @@ func TestRunnerRejectsDuplicateFindingID(t *testing.T) {
 	t.Parallel()
 
 	fixture := newFixture(t)
-	result := challengeResult(fixture.head,
+	result := fixture.result(
 		challengeOutcome(firstFindingID, "CONFIRMED"),
 		challengeOutcome(firstFindingID, "REJECTED"),
 	)
@@ -143,7 +226,7 @@ func TestRunnerRejectsReprioritizedFinding(t *testing.T) {
 	fixture := newFixture(t)
 	reprioritized := challengeOutcome(firstFindingID, "CONFIRMED")
 	reprioritized["severity"] = "P3"
-	result := challengeResult(fixture.head, reprioritized, challengeOutcome(secondFindingID, "REJECTED"))
+	result := fixture.result(reprioritized, challengeOutcome(secondFindingID, "REJECTED"))
 
 	output, err := fixture.run(t, result)
 	require.Error(t, err)
@@ -157,7 +240,7 @@ func TestRunnerRejectsRetitledFinding(t *testing.T) {
 	fixture := newFixture(t)
 	retitled := challengeOutcome(secondFindingID, "REJECTED")
 	retitled["title"] = "A different subject for the same finding"
-	result := challengeResult(fixture.head, challengeOutcome(firstFindingID, "CONFIRMED"), retitled)
+	result := fixture.result(challengeOutcome(firstFindingID, "CONFIRMED"), retitled)
 
 	output, err := fixture.run(t, result)
 	require.Error(t, err)
@@ -208,6 +291,7 @@ type fixture struct {
 	fakeBin        string
 	head           string
 	sourceReport   string
+	sourceDigest   string
 	providerResult string
 	outputPath     string
 	dirtyFile      string
@@ -220,13 +304,36 @@ func newFixture(t *testing.T) *fixture {
 	checkout := filepath.Join(root, "checkout")
 	repository := repositoryRoot(t)
 	require.NoError(t, os.MkdirAll(filepath.Join(checkout, "scripts"), 0o700))
+	require.NoError(t, os.MkdirAll(filepath.Join(checkout, "docs", "technical", "audits"), 0o700))
 	require.NoError(t, os.MkdirAll(filepath.Join(checkout, "docs", "technical", "contributing"), 0o700))
+	copyFile(t, filepath.Join(repository, "scripts", "ai-audit"), filepath.Join(checkout, "scripts", "ai-audit"))
 	copyFile(t, filepath.Join(repository, "scripts", "ai-audit-challenge"), filepath.Join(checkout, "scripts", "ai-audit-challenge"))
+	copyFile(t, filepath.Join(repository, "scripts", "codex-audit.schema.json"), filepath.Join(checkout, "scripts", "codex-audit.schema.json"))
 	copyFile(t, filepath.Join(repository, "scripts", "codex-audit-challenge.schema.json"), filepath.Join(checkout, "scripts", "codex-audit-challenge.schema.json"))
 	copyFile(t, filepath.Join(repository, ".gitignore"), filepath.Join(checkout, ".gitignore"))
 	require.NoError(t, os.WriteFile(
+		filepath.Join(checkout, "docs", "technical", "contributing", "ai-audit.md"),
+		[]byte("# Audit contract\n"),
+		0o600,
+	))
+	require.NoError(t, os.WriteFile(
 		filepath.Join(checkout, "docs", "technical", "contributing", "ai-audit-challenge.md"),
 		[]byte("# Challenge contract\n"),
+		0o600,
+	))
+	manifest := fmt.Sprintf(`{
+		"id": %q,
+		"title": "Test audit",
+		"purpose": "Test the native audit chain",
+		"paths": ["scripts/**"],
+		"related_docs": [],
+		"invariants": ["Results are validated"],
+		"adversarial_questions": [],
+		"dynamic_checks_to_consider": []
+	}`, testAuditID)
+	require.NoError(t, os.WriteFile(
+		filepath.Join(checkout, "docs", "technical", "audits", testAuditID+".json"),
+		[]byte(manifest),
 		0o600,
 	))
 
@@ -251,6 +358,7 @@ func newFixture(t *testing.T) *fixture {
 	require.NoError(t, err)
 	built.outputPath = filepath.Join(physicalCheckout, "build", "ai-audit", testAuditID+"-"+built.head[:12]+"-qualified.json")
 	writeJSON(t, built.sourceReport, sourceReport(built.head))
+	built.sourceDigest = fileDigest(t, built.sourceReport)
 
 	return built
 }
@@ -274,11 +382,37 @@ func (f *fixture) run(t *testing.T, result map[string]any) (string, error) {
 	return string(output), err
 }
 
+func (f *fixture) runAudit(t *testing.T, result map[string]any) (string, string, error) {
+	t.Helper()
+
+	writeJSON(t, f.providerResult, result)
+	command := exec.Command("bash", filepath.Join(f.checkout, "scripts", "ai-audit"), testAuditID)
+	command.Dir = f.checkout
+	command.Env = testenv.Environment(
+		"FAKE_CODEX_RESULT="+f.providerResult,
+		"FAKE_CODEX_DIRTY_FILE=",
+		"HOME="+t.TempDir(),
+		"CODEX_HOME=",
+		"PATH="+f.fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	output, err := command.CombinedOutput()
+	sourceReport := filepath.Join(filepath.Dir(f.outputPath), testAuditID+"-"+f.head[:12]+".json")
+
+	return string(output), sourceReport, err
+}
+
 func (f *fixture) validResult() map[string]any {
-	return challengeResult(f.head,
+	return f.result(
 		challengeOutcome(firstFindingID, "CONFIRMED"),
 		challengeOutcome(secondFindingID, "REJECTED"),
 	)
+}
+
+func (f *fixture) result(results ...map[string]any) map[string]any {
+	result := challengeResult(f.head, results...)
+	result["sourceAuditDigest"] = f.sourceDigest
+
+	return result
 }
 
 func sourceReport(head string) map[string]any {
@@ -304,6 +438,10 @@ func sourceFinding(id string) map[string]any {
 }
 
 func challengeResult(head string, results ...map[string]any) map[string]any {
+	if results == nil {
+		results = []map[string]any{}
+	}
+
 	return map[string]any{
 		"audit_id":      testAuditID,
 		"head":          head,
@@ -370,6 +508,15 @@ func readJSON(t *testing.T, path string) map[string]any {
 	require.NoError(t, json.Unmarshal(contents, &decoded))
 
 	return decoded
+}
+
+func keys(values map[string]any) []string {
+	result := make([]string, 0, len(values))
+	for key := range values {
+		result = append(result, key)
+	}
+
+	return result
 }
 
 func runGit(t *testing.T, directory string, arguments ...string) {

--- a/scripts/codex-audit-challenge.schema.json
+++ b/scripts/codex-audit-challenge.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "additionalProperties": false,
-  "required": ["audit_id", "head", "summary", "results", "questions", "residual_risk"],
+  "required": ["audit_id", "head", "sourceAuditDigest", "summary", "results", "questions", "residual_risk"],
   "properties": {
     "audit_id": {"type": "string", "minLength": 1},
     "head": {"type": "string", "pattern": "^[0-9a-f]{40,64}$"},


### PR DESCRIPTION
DISCOVERY: NO_EXISTING_WORK
BEFORE_FIX: BUG_REPRODUCED
AFTER_FIX: PASS
BASELINE_CLASSIFICATION: ENVIRONMENTAL

## Summary

- require sourceAuditDigest in the Codex challenge output schema
- pass the launcher-computed digest as trusted target data and reject missing, malformed, or mismatched values
- preserve exact finding id, title, and severity checks
- cover a zero-finding ai-audit to ai-audit-challenge chain

## Root cause

The challenge schema declared sourceAuditDigest in properties but omitted it from required. Strict Codex structured outputs reject schemas unless every declared object property is required, so the challenge failed before provider analysis.

## Validation

- reproduced HTTP 400 invalid_json_schema against the preserved read-consistency audit artifact
- go test -race ./scripts/aiaudit ./scripts/aiauditchallenge ./scripts/aiauditjira
- live Codex schema validation with zero results
- live zero-finding ai-audit-challenge artifact; source digest matched exactly
- sensitivity: restoring the previous required list makes the focused schema regression fail
- bash scripts/agent-check
- GOFLAGS=-p=1 AI_REVIEW_BASE_SHA=b0fcefd07175a1ec6787df30b7b842129fc0bdab bash scripts/agent-check-pr
- git diff --check

The default-parallel agent-check-pr run encountered the unrelated existing scripts/rootguard TestRunnerComparesRootAfterCancellation timeout twice; the exact test and full package passed in isolation, and the same complete exact-base gate passed with Go package parallelism serialized.

No Jira publication, audit redesign, PR orchestration change, or product/runtime change. Do not merge automatically.