### PR TITLE
docs(ops): document resilience and upgrade boundaries

### DIFF
--- a/docs/ops/README.md
+++ b/docs/ops/README.md
@@ -7,9 +7,11 @@ Everything you need to deploy, monitor, and operate a Ledger v3 cluster.
 | Goal | Document |
 |------|----------|
 | Deploy and size a cluster | [deployment-profiles.md](./deployment-profiles.md) |
+| Plan HA, multi-region placement, and disaster recovery | [availability-and-recovery.md](./availability-and-recovery.md) |
 | Use the CLI (`ledgerctl`) | [cli.md](./cli.md) |
 | Monitor my cluster | [monitoring.md](./monitoring.md) |
 | Back up and restore data | [backup-restore.md](./backup-restore.md) |
+| Upgrade Ledger server binaries | [upgrades.md](./upgrades.md) |
 | Manage request signing | [signing.md](./signing.md) |
 | Enable maintenance mode | [maintenance-mode.md](./maintenance-mode.md) |
 | Manage cluster nodes | [cluster-operations.md](./cluster-operations.md) |

--- a/docs/ops/availability-and-recovery.md
+++ b/docs/ops/availability-and-recovery.md
@@ -1,0 +1,112 @@
+# Availability and Disaster Recovery
+
+Ledger v3 uses three separate mechanisms for operational resilience:
+
+- **Raft replication** keeps active nodes consistent and provides automatic
+  failover while a majority of voters remains available.
+- **Backups** provide a portable recovery source outside the cluster failure
+  domain.
+- **Cold storage** retains archived history; it does not replace a backup of
+  current state.
+
+Replication is not a backup. A valid Raft operation, operator mistake, or
+application-level deletion is replicated to every member.
+
+## Recommended Production Topology
+
+The default production topology is three voters on independent persistent
+volumes, spread across three failure domains in one low-latency region. It
+tolerates one unavailable voter. Five voters tolerate two unavailable voters,
+at the cost of additional replication traffic and quorum latency. See
+[Deployment Profiles](./deployment-profiles.md#choose-the-topology-first).
+
+Every committed mutation is synchronously replicated to a quorum. A caught-up
+follower or learner can serve a default live read locally after completing a
+quorum-backed `ReadIndex` barrier. This distributes normal read load, but it is
+not an independently available read replica: the barrier still needs a healthy
+quorum. An explicit stale read can bypass that barrier, but may return an older
+local view. Independently asynchronous indexes also have different guarantees;
+see
+[Safety and Availability During Partitions](../technical/architecture/subsystems/consensus/raft-consensus.md#safety-and-availability-during-partitions)
+and
+[Linearizable Reads via ReadIndex](../technical/architecture/subsystems/consensus/raft-consensus.md#linearizable-reads-via-readindex).
+
+## Multi-Region Options
+
+### Three local voters plus a remote learner
+
+A non-voting learner in a secondary region receives Raft log entries and
+snapshots and, once caught up, can serve reads while it can reach the active
+quorum. Because learner acknowledgements are not required to commit, its WAN
+latency is outside the write quorum.
+
+This is not automatic regional failover:
+
+- a learner cannot vote or become leader;
+- promoting it is a normal consensus operation and therefore requires an
+  active leader and quorum;
+- replication delay depends on the WAN, follower catch-up, and local apply
+  progress and is not a declared backup RPO;
+- automatic learner promotion must be disabled with
+  `--learner-promotion-threshold 0`, then the intended local voters must be
+  promoted manually. This is a cluster-wide control, not a per-node policy.
+
+The current operator does not expose a first-class "secondary-region read
+replica" topology. Treat a remote learner as an advanced, manually validated
+deployment, not as a substitute for off-cluster backups.
+
+### Voters stretched across regions
+
+Voters may be placed across regions, but every write waits for a voter majority.
+WAN latency therefore directly affects write latency and election behavior.
+
+A three-voter cluster split across two regions survives loss of the region that
+contains one voter, but not loss of the region that contains two. A five-voter
+cluster tolerates two unavailable voters, provided the surviving placement can
+still form a majority. Validate the exact region distribution, latency, and
+failure modes with a production-shaped test before adopting a stretched
+cluster.
+
+For most deployments, prefer three voters across zones in one region plus
+backups stored outside that region. Use a stretched topology only when its
+measured latency and failure-domain behavior satisfy the customer's SLOs.
+
+## Failure Scenarios
+
+| Scenario | Expected behavior | Operator action |
+|----------|-------------------|-----------------|
+| One follower voter fails in a three-voter cluster | The remaining majority continues; the failed node catches up automatically after restart. | Replace or restart the node, then verify catch-up with `ledgerctl cluster status`. |
+| The leader fails but a voter majority survives | The remaining voters elect a new leader; requests may fail transiently during election. | Let clients retry idempotently and verify the new leader. |
+| A network partition leaves a majority and a minority | Only the majority side can commit writes or complete default linearizable reads. | Restore connectivity; replicas synchronize automatically. |
+| Two voters are permanently lost and the surviving node still considers itself leader | Normal consensus cannot make progress. The leader can force-remove each permanently lost voter locally and continue as a one-node cluster. | Fence the lost nodes first, connect directly to the surviving leader, then use `ledgerctl cluster remove-node <id> --force` for each lost voter. Rebuild redundancy immediately. |
+| Two voters are lost and the surviving node is not the leader | It cannot elect itself under the old three-voter membership, and force-remove is leader-only. | Restore a fresh cluster from an off-cluster backup. There is no supported "re-bootstrap this follower's data directory" procedure. |
+| The entire cluster or its storage is lost | No replica remains. | Restore a fresh cluster from an off-cluster backup. |
+
+The force-remove path deliberately bypasses Raft consensus. It is safe only
+after every removed member has been permanently fenced and cannot run or
+rejoin. Using it during a reversible partition can create two independently
+writable histories. See
+[Force-Removing a Down Node](./cluster-operations.md#force-removing-a-down-node).
+
+Do not copy a surviving node's WAL or data directory and start it with
+`--bootstrap`. Those directories contain node identity and Raft membership and
+are not portable backup artifacts. Use the documented
+[Backup and Restore](./backup-restore.md) flow when the surviving replica cannot
+recover the existing cluster safely.
+
+## Disaster-Recovery Baseline
+
+1. Define RPO and RTO from customer requirements.
+2. Run full backups periodically and incremental backups at least as often as
+   the required RPO. Store them outside the cluster and region failure domain.
+3. Retain the credentials, encryption/signing material, and compatible Ledger
+   binary required by the restore procedure.
+4. Exercise `restore validate` and a full bootstrap of production-sized data.
+5. During an incident, fence the old cluster before force-removing members or
+   bringing up a replacement cluster.
+6. After recovery, add replacement nodes, wait for them to catch up, and verify
+   that the intended voter majority has been restored.
+
+See [Recovery Objectives](./deployment-profiles.md#recovery-objectives),
+[Backup and Restore](./backup-restore.md), and
+[Monitoring](./monitoring.md#alerting-recommendations).

--- a/docs/ops/availability-and-recovery.md
+++ b/docs/ops/availability-and-recovery.md
@@ -80,7 +80,7 @@ measured latency and failure-domain behavior satisfy the customer's SLOs.
 | A network partition leaves a majority and a minority | Only the majority side can commit writes or complete default linearizable reads. | Restore connectivity; replicas synchronize automatically. |
 | Two voters are permanently lost and the surviving node still considers itself leader | Normal consensus cannot make progress. The leader can force-remove each permanently lost voter locally and continue as a one-node cluster. | Fence the lost nodes first, connect directly to the surviving leader, then use `ledgerctl cluster remove-node <id> --force` for each lost voter. Rebuild redundancy immediately. |
 | Two voters are lost and the surviving node is not the leader | It cannot elect itself under the old three-voter membership, and force-remove is leader-only. | Restore a fresh cluster from an off-cluster backup. There is no supported "re-bootstrap this follower's data directory" procedure. |
-| The entire cluster or its storage is lost | No replica remains. | Restore a fresh cluster from an off-cluster backup. |
+| The entire cluster or its storage is lost | No replica remains. | Restore a fresh cluster from an off-cluster backup. If archived chapters existed, also restore or reconnect the separately protected cold-storage objects and configuration. |
 
 The force-remove path deliberately bypasses Raft consensus. It is safe only
 after every removed member has been permanently fenced and cannot run or
@@ -99,12 +99,18 @@ recover the existing cluster safely.
 1. Define RPO and RTO from customer requirements.
 2. Run full backups periodically and incremental backups at least as often as
    the required RPO. Store them outside the cluster and region failure domain.
-3. Retain the credentials, encryption/signing material, and compatible Ledger
-   binary required by the restore procedure.
-4. Exercise `restore validate` and a full bootstrap of production-sized data.
-5. During an incident, fence the old cluster before force-removing members or
+3. Place cold storage outside the same failure domain or replicate/archive it
+   separately. A Ledger backup does not include chapters archived before its
+   full checkpoint; the restored cluster still needs those cold-storage
+   objects for historical reads.
+4. Retain the credentials, encryption/signing material, cold-storage
+   configuration, and compatible Ledger binary required by the restore
+   procedure.
+5. Exercise `restore validate`, a full bootstrap of production-sized data, and
+   historical reads whose chapters live in cold storage.
+6. During an incident, fence the old cluster before force-removing members or
    bringing up a replacement cluster.
-6. After recovery, add replacement nodes, wait for them to catch up, and verify
+7. After recovery, add replacement nodes, wait for them to catch up, and verify
    that the intended voter majority has been restored.
 
 See [Recovery Objectives](./deployment-profiles.md#recovery-objectives),

--- a/docs/ops/backup-restore.md
+++ b/docs/ops/backup-restore.md
@@ -70,6 +70,13 @@ Test restoring every retention class. Retaining only a manifest, or only the
 checkpoint objects without all incremental segments referenced by that
 manifest, is not a usable backup.
 
+Ledger backups also do not copy cold storage wholesale. Chapters archived
+before the full checkpoint remain in their cold-storage objects, and the
+restored cluster needs those objects for historical reads. Protect cold storage
+outside the cluster and region failure domain, retain its configuration and
+credentials, and include archived-history reads in restore exercises. See
+[Relationship with Chapters and Cold Storage](#relationship-with-chapters-and-cold-storage).
+
 ### End-to-End Flow
 
 ```

--- a/docs/ops/backup-restore.md
+++ b/docs/ops/backup-restore.md
@@ -9,6 +9,10 @@ The ledger provides a two-tier backup and restore pipeline:
 
 A restore combines the latest checkpoint with any incremental exports to reconstruct the full state.
 
+For topology selection, region-loss behavior, and the distinction between a
+replica and a portable recovery source, see
+[Availability and Disaster Recovery](./availability-and-recovery.md).
+
 ### Storage Backends
 
 Backups and restores support two storage backends, selected with `--driver`:
@@ -17,6 +21,54 @@ Backups and restores support two storage backends, selected with `--driver`:
 - **`azure`** — Azure Blob Storage. Built with the `azure` build tag. Authenticates with an account key (`--azure-account-key`) or, when omitted, `DefaultAzureCredential` (managed identity, environment, etc.). Use `--azure-endpoint` to target a non-default Blob service URL — note that **Azurite requires the account name in the path** (e.g. `http://127.0.0.1:10000/devstoreaccount1`); a bare `http://127.0.0.1:10000` will yield 400/404 responses.
 
 All backup/restore commands accept the same provider flags; only the `--driver` value and the matching `--s3-*` / `--azure-*` flags differ.
+
+### Scheduling with the Kubernetes Operator
+
+The operator's `Backup` resource can schedule full and incremental S3 backups:
+
+```yaml
+apiVersion: ledger.formance.com/v1alpha1
+kind: Backup
+metadata:
+  name: production
+spec:
+  clusterRef: customer-ledger
+  destination:
+    driver: s3
+    bucketId: customer-production
+    s3:
+      bucket: customer-ledger-backups
+      region: eu-west-1
+  schedule:
+    full: "0 2 * * 0"
+    incremental: "0 * * * *"
+  successfulRunsHistoryLimit: 3
+  failedRunsHistoryLimit: 1
+```
+
+The run history limits retain Kubernetes `BackupRun` resources only. They do
+not retain historical backup artifacts or restore points in object storage.
+
+### Long-Term Retention
+
+One destination namespace -- the storage backend plus `bucket-id` -- contains
+one current restorable chain. Incremental backups append segments to that
+chain. A new full backup publishes a replacement checkpoint manifest with an
+empty incremental set, then prunes objects no longer referenced by the current
+manifest.
+
+The built-in backup pipeline does not retain multiple historical restore
+points in one namespace. For long-term retention, use a distinct `bucket-id`
+for each retained restore point and stop writing to that namespace after its
+final incremental, or implement an object-store versioning/archive procedure
+that preserves and can re-materialize the complete manifest and every object it
+references. The operator's scheduled `Backup` resource has a fixed `bucketId`,
+so rotating immutable retention points currently requires external
+orchestration.
+
+Test restoring every retention class. Retaining only a manifest, or only the
+checkpoint objects without all incremental segments referenced by that
+manifest, is not a usable backup.
 
 ### End-to-End Flow
 

--- a/docs/ops/cluster-operations.md
+++ b/docs/ops/cluster-operations.md
@@ -480,6 +480,18 @@ ledgerctl cluster remove-node 3 --force
 ledgerctl cluster status
 ```
 
+For a three-voter cluster that has permanently lost both followers, the same
+leader-only command may be run once for each lost voter. This restores a
+single-voter configuration without copying or re-bootstrapping the leader's
+data directory.
+
+This recovery is available only when the surviving node still considers itself
+leader. If the sole survivor is a follower or candidate, it
+cannot elect itself under the old three-voter membership and the force path
+rejects the request because it is leader-only. Restore a fresh cluster from an
+off-cluster backup instead. See
+[Availability and Disaster Recovery](./availability-and-recovery.md#failure-scenarios).
+
 **How it works:**
 
 1. `ForceRemoveNode` directly calls `rawNode.ApplyConfChange()` on the leader, bypassing the Raft log
@@ -498,6 +510,9 @@ ledgerctl cluster status
 - Only use for nodes that will **never rejoin** with their old state (e.g., PVCs will be deleted)
 - The force-removed node is not notified — if it somehow recovers, it will have stale cluster membership
 - Cannot force-remove the leader itself
+- Before force-removing any voter, permanently fence every removed member. If
+  another partition can still commit, force-removal can create divergent
+  histories.
 
 ## Cluster Configuration Updates
 
@@ -590,3 +605,4 @@ After the reset, the preloader falls back to Pebble reads (0xF1 zone) for all ca
 - [Deployment](./deployment.md) - Helm chart configuration, CLI flags
 - [CLI Reference](./cli.md) - `cluster add-learner`, `cluster promote-learner` commands
 - [Memory Management](./memory.md) - Cache rotation threshold memory impact
+- [Availability and Disaster Recovery](./availability-and-recovery.md) - Failure-domain placement and quorum-loss recovery

--- a/docs/ops/deployment-profiles.md
+++ b/docs/ops/deployment-profiles.md
@@ -207,6 +207,9 @@ See [Backup and Restore](./backup-restore.md) for the supported backup and resto
 flows. Cold storage retention and backups solve different problems and need
 separate schedules.
 
+See [Availability and Disaster Recovery](./availability-and-recovery.md) for
+multi-region topology trade-offs and the supported responses to quorum loss.
+
 ## Tune by Workload Signal
 
 | Customer need or observed signal | Parameter or action | Trade-off / guardrail |
@@ -477,5 +480,7 @@ Before go-live, verify:
 - [Performance Guidelines](./performance-tuning.md) — client and hot-path tuning
 - [Monitoring](./monitoring.md) — metrics, dashboards, and alerts
 - [Backup and Restore](./backup-restore.md) — RPO/RTO implementation
+- [Availability and Disaster Recovery](./availability-and-recovery.md) — multi-region placement and failure recovery
+- [Server Binary Upgrades](./upgrades.md) — pre-GA compatibility boundary and upgrade classes
 - [Authentication](./authentication.md) and [TLS Migration](./tls-migration.md)
 - [CLI Reference](./cli.md) — exhaustive server flag reference

--- a/docs/ops/upgrades.md
+++ b/docs/ops/upgrades.md
@@ -1,0 +1,77 @@
+# Server Binary Upgrades
+
+## Current v3 Support Boundary
+
+Ledger v3 is pre-GA and does not yet promise persisted-storage or wire-format
+compatibility between development revisions. Do not assume that an in-place,
+mixed-binary rolling upgrade is supported merely because Kubernetes can perform
+a rolling update.
+
+Every target revision must explicitly identify one of these upgrade classes:
+
+| Class | When it applies | Procedure |
+|-------|-----------------|-----------|
+| Rolling | The target revision explicitly supports mixed binaries and the existing storage schema. | Restart followers one at a time, wait for each to catch up, transfer leadership to an upgraded voter, then restart the old leader. |
+| Coordinated restart | The storage schema is compatible, but mixed binaries can apply a committed entry differently. | Enable maintenance mode, stop every node, replace all binaries, then restart the cluster without a mixed-version window. |
+| Rebuild or restore | Persisted or backup formats are incompatible. | Follow the revision-specific reset instructions and rebuild from the declared source of truth or a backup explicitly supported by the target revision. |
+
+If the target revision does not declare its class, stop and obtain a release
+decision. Do not guess from a successful single-node restart.
+
+The change-specific constraints currently documented under
+[Upgrading from pre-#400 clusters](./deployment.md#upgrading-from-pre-400-clusters)
+and
+[Upgrading across an FSM error-identity change](./deployment.md#upgrading-across-an-fsm-error-identity-change)
+take precedence over this general workflow.
+
+## Preflight
+
+Before any server upgrade:
+
+1. Read the target revision's release and deployment notes for storage, backup,
+   protobuf, audit-hash, and mixed-version restrictions.
+2. Verify the current cluster has the expected voter count, one leader, and no
+   lagging or syncing member with `ledgerctl cluster status`.
+3. Complete a backup and verify that its artifacts exist outside the cluster
+   failure domain. Confirm that the target revision can restore that backup
+   format.
+4. Confirm rollback semantics. Never start an older binary on storage already
+   opened by a newer binary unless that downgrade is explicitly supported.
+5. Ensure clients use stable idempotency keys for retries during leadership
+   changes or transient unavailability.
+
+## Rolling Procedure
+
+Use this only when the target revision explicitly permits mixed binaries:
+
+1. Record the current leader and voter set with `ledgerctl cluster status`.
+2. Restart one follower on the target binary.
+3. Wait until it reports normal, has caught up to the leader's commit index,
+   and can serve a health check.
+4. Repeat for the other followers, one at a time. Never take enough voters down
+   to lose quorum.
+5. Transfer leadership to an upgraded, caught-up voter with
+   `ledgerctl cluster transfer-leader <node-id>`.
+6. Restart the former leader on the target binary and wait for it to catch up.
+7. Re-run cluster status, health, representative reads and writes, and the
+   required integrity checks.
+
+For a change to replicated runtime configuration rather than the binary, use
+the separate
+[Cluster Configuration Updates](./cluster-operations.md#cluster-configuration-updates)
+procedure.
+
+## Coordinated Restart
+
+When persisted storage is compatible but mixed binaries are not:
+
+1. Enable [maintenance mode](./maintenance-mode.md) and verify writes are
+   rejected.
+2. Stop all nodes before starting any target binary.
+3. Replace every server binary or image.
+4. Start enough voters to form quorum, then start the remaining members.
+5. Verify cluster health and integrity before disabling maintenance mode.
+
+`ledgerctl upgrade` upgrades the `ledgerctl` client binary only. It does not
+upgrade Ledger servers or decide whether a server revision is storage- or
+wire-compatible.

--- a/docs/ops/upgrades.md
+++ b/docs/ops/upgrades.md
@@ -12,7 +12,7 @@ Every target revision must explicitly identify one of these upgrade classes:
 | Class | When it applies | Procedure |
 |-------|-----------------|-----------|
 | Rolling | The target revision explicitly supports mixed binaries and the existing storage schema. | Restart followers one at a time, wait for each to catch up, transfer leadership to an upgraded voter, then restart the old leader. |
-| Coordinated restart | The storage schema is compatible, but mixed binaries can apply a committed entry differently. | Enable maintenance mode, stop every node, replace all binaries, then restart the cluster without a mixed-version window. |
+| Coordinated restart | The storage schema is compatible, but mixed binaries can apply a committed entry differently. | Enable maintenance mode, wait for every voter to apply the maintenance barrier durably, stop every node, replace all binaries, then restart the cluster without a mixed-version window. |
 | Rebuild or restore | Persisted or backup formats are incompatible. | Follow the revision-specific reset instructions and rebuild from the declared source of truth or a backup explicitly supported by the target revision. |
 
 If the target revision does not declare its class, stop and obtain a release
@@ -67,10 +67,20 @@ When persisted storage is compatible but mixed binaries are not:
 
 1. Enable [maintenance mode](./maintenance-mode.md) and verify writes are
    rejected.
-2. Stop all nodes before starting any target binary.
-3. Replace every server binary or image.
-4. Start enough voters to form quorum, then start the remaining members.
-5. Verify cluster health and integrity before disabling maintenance mode.
+2. Query the leader with `ledgerctl cluster status --json` and record its
+   `raftStatus.commit` index after maintenance mode is visible. Call this
+   barrier `C`.
+3. Query every voter with
+   `ledgerctl cluster status --node-id <id> --json`. Before stopping any node,
+   require its sync status to be normal and
+   `raftStatus.lastPersistedIndex >= C`. This proves that every voter has
+   durably applied all entries through the maintenance barrier under the old
+   binary. Stop or finish any cluster-internal job that can still propose work,
+   then repeat the check if the leader's commit index advanced.
+4. Stop all nodes before starting any target binary.
+5. Replace every server binary or image.
+6. Start enough voters to form quorum, then start the remaining members.
+7. Verify cluster health and integrity before disabling maintenance mode.
 
 `ledgerctl upgrade` upgrades the `ledgerctl` client binary only. It does not
 upgrade Ledger servers or decide whether a server revision is storage- or


### PR DESCRIPTION
## Summary

- document multi-region topology trade-offs and the limits of remote learners
- make quorum-loss recovery explicit, including the leader-only force-remove boundary
- document scheduled backups, long-term retention semantics, and immutable restore points
- add the pre-GA server-binary upgrade decision tree and runbooks

## Validation

- `bash scripts/agent-check`
- `AI_REVIEW_BASE_SHA=6ca54e58cfdfa2e361e8b975e15e3afd66071a0e bash scripts/agent-check-pr`

Both pass.