### PR TITLE
feat(reads): certify projection Raft progress (EN-1946)

### DIFF
--- a/docs/ops/backup-restore.md
+++ b/docs/ops/backup-restore.md
@@ -175,11 +175,12 @@ The temporary checkpoint is removed from the leader's filesystem after the backu
 Backup preparation is performed on the **restore side** (during `FinalizeRestore` or `store bootstrap`), not during backup. It resets cluster-local and checkpoint-era zones and leaves the attribute zone **byte-for-byte intact** — there is no attribute compaction, because each canonical key holds exactly one Pebble entry (no per-index history to fold):
 
 1. **Preserve lastAppliedIndex as the genesis boundary**: The checkpoint's applied index is kept (a genesis checkpoint at index 0 gets the fallback boundary 1; MaxUint64 is refused). The restored bootstrap plants its WAL snapshot at this index, so the new log starts just above it and any fresh peer is routed through the snapshot → checkpoint-sync path (plain log replay from index 1 would land on an empty store and miss the restored state). The boundary labels the new log's start — it is NOT the restored state's provenance: incremental exports are sequence-keyed and never advance it, so after a full + incremental restore the state is newer than the boundary.
-2. **Remove persisted config**: Node and cluster IDs are stripped for portability.
-3. **Wipe the cluster-transient zone**: In-flight-only tracking (e.g. running backup jobs) has no meaning on the restored cluster.
-4. **Drop persisted bloom blocks**: Stale bloom blocks are cleared so the booting node rebuilds the bloom from a full attribute scan using its own config.
-5. **Drop persisted Raft peers**: Cluster membership is local to the source cluster; the booting node reseeds membership from its own config.
-6. **Clear the cache zone**: Checkpoint-era cache rows predate the delta replayed into the attribute zone; the restored node boots with a cold cache and re-seeds from the rebuilt attribute zone on first touch.
+2. **Mark query-checkpoint metadata as restored**: Physical query-checkpoint directories are not part of the restored Pebble store. Surviving rows are marked `restored_from_backup`; rows rebuilt from incremental logs receive the same marker. The read-index builder uses it to keep source-cluster Raft indexes out of destination-cluster progress certificates.
+3. **Remove persisted config**: Node and cluster IDs are stripped for portability.
+4. **Wipe the cluster-transient zone**: In-flight-only tracking (e.g. running backup jobs) has no meaning on the restored cluster.
+5. **Drop persisted bloom blocks**: Stale bloom blocks are cleared so the booting node rebuilds the bloom from a full attribute scan using its own config.
+6. **Drop persisted Raft peers**: Cluster membership is local to the source cluster; the booting node reseeds membership from its own config.
+7. **Clear the cache zone**: Checkpoint-era cache rows predate the delta replayed into the attribute zone; the restored node boots with a cold cache and re-seeds from the rebuilt attribute zone on first touch.
 
 **File**: `internal/infra/attributes/prepare.go` — `PrepareForBackup()`
 

--- a/docs/technical/architecture/subsystems/backup/incremental-restore-contract.md
+++ b/docs/technical/architecture/subsystems/backup/incremental-restore-contract.md
@@ -40,8 +40,11 @@ consumer that coordinates rebuildable local projections against such a record
 must bind its wait and published certificate to the restored store's captured
 applied index. Query-checkpoint materialization follows this rule: the audit
 projection certifies the complete restored audit head at the new genesis
-boundary, and the normal index builder never waits for or publishes the
-checkpoint log's larger source-cluster index.
+boundary, while `PrepareForBackup` and `RebuildDelta` mark surviving checkpoint
+rows with explicit restore provenance. The normal index builder uses that marker
+rather than numeric ordering between unrelated Raft domains; it never publishes
+an intermediate source-cluster index, even when the destination domain has
+already overtaken that number.
 
 Before changing an audited order, an FSM handler, a persisted projection, or a
 delete/purge cascade, classify every affected value:

--- a/docs/technical/architecture/subsystems/backup/incremental-restore-contract.md
+++ b/docs/technical/architecture/subsystems/backup/incremental-restore-contract.md
@@ -34,6 +34,15 @@ audit-entry, audit-item, and applied-proposal rows. `ApplyExports` restores thos
 rows, then `RebuildDelta` reconstructs the derived state that the live FSM wrote
 after the checkpoint.
 
+Raft applied indexes embedded in rebuilt business records remain source-cluster
+provenance, not certificates in the restored cluster's new Raft domain. A
+consumer that coordinates rebuildable local projections against such a record
+must bind its wait and published certificate to the restored store's captured
+applied index. Query-checkpoint materialization follows this rule: the audit
+projection certifies the complete restored audit head at the new genesis
+boundary, and the normal index builder never waits for or publishes the
+checkpoint log's larger source-cluster index.
+
 Before changing an audited order, an FSM handler, a persisted projection, or a
 delete/purge cascade, classify every affected value:
 

--- a/docs/technical/architecture/subsystems/indexer/README.md
+++ b/docs/technical/architecture/subsystems/indexer/README.md
@@ -1,6 +1,11 @@
 # Indexer
 
-The background worker (`internal/application/indexbuilder`) that turns committed audit logs into the inverted, queryable keyspaces consumed by the read API. Runs on every node — leader and followers — independently. Decoupled from the FSM hot path: the FSM commits and signals; the indexer reads from its own Pebble read handle and writes to the read store.
+The background workers (`internal/application/indexbuilder` and
+`internal/application/auditindexer`) that turn committed main-store logs and
+audit entries into queryable read-store keyspaces. They run independently on
+every leader and follower and remain outside the FSM hot path. Both retain a
+native resume cursor and publish a separate Raft applied-index certificate for
+cross-store read alignment.
 
 ## Documents
 

--- a/docs/technical/architecture/subsystems/indexer/indexer.md
+++ b/docs/technical/architecture/subsystems/indexer/indexer.md
@@ -211,14 +211,24 @@ Two adjacent versions share the same prefix up to the `version` field, so a sing
 
 ## Progress Cursors
 
-Two cursors live under the internal prefix:
+Native fold cursors and causal certificates live under the internal prefix:
 
 | Cursor | Key | Encoding |
 |--------|-----|----------|
 | Main log progress | `[0xFE][0x01]` | `uint64` big-endian — the highest log sequence whose effects are fully written to the read store. |
 | AppliedProposal progress | `[0xFE][0x02]` | `uint64` big-endian — paired cursor used for transient-account filtering. |
+| Audit native progress | `[0xFE][0x06]` | `uint64` big-endian — highest audit sequence folded. |
+| Read projection Raft progress | `[0xFE][0x07]` | `uint64` big-endian — fixed main-store applied index fully covered by the normal read projection. |
+| Audit projection Raft progress | `[0xFE][0x08]` | `uint64` big-endian — fixed main-store applied index fully covered by the audit projection. |
 
-Both are written **inside the same Pebble batch** as the index writes they certify. `LastIndexedSequence()` reads the main cursor on boot; `NotifyProgress()` broadcasts the new value to readers waiting on a `min_log_sequence` barrier.
+Native cursors resume folds and preserve the event-history/trimming contract.
+They are not interchangeable with Raft certificates: an applied entry can emit
+zero, one, or several native records. Each indexer captures one fixed main-store
+snapshot and its applied index `H`. Intermediate batches may advance only the
+native cursor. The target-completing batch writes its final projection changes,
+native cursor, and Raft certificate `H` atomically. If the bounded snapshot has
+no native work, a standalone certificate write records `H`. `NotifyProgress()`
+wakes readers waiting for either certificate.
 
 ## Backfill — Atomic Switch
 

--- a/docs/technical/architecture/subsystems/indexer/indexer.md
+++ b/docs/technical/architecture/subsystems/indexer/indexer.md
@@ -71,7 +71,7 @@ flowchart TB
 
 ### Pass 1 — iterate + dispatch
 
-- Opens a direct Pebble read handle on the **main store** (`query.ReadLogsSince(ctx, handle, cursor, ...)`).
+- Opens a Pebble snapshot on the **main store** (`query.ReadLogsSince(ctx, handle, cursor, ...)`) so the native sequence and Raft horizon are captured atomically.
 - Iterates committed logs starting at `cursor + 1`.
 - For each log entry, calls `b.indexPayload(kb, cfg, ledger, payload, excludedVolumes)`, which switches on the payload type and dispatches to the matching handler.
 - Handlers buffer their key/value writes into a single `readstore.WriteBatch` (`b.wb`) that wraps an underlying `dal.WriteSession`; they never `Commit()` themselves.

--- a/docs/technical/architecture/subsystems/read-path/query-checkpoints.md
+++ b/docs/technical/architecture/subsystems/read-path/query-checkpoints.md
@@ -25,6 +25,13 @@ Checkpoint IDs are assigned sequentially by the FSM (1, 2, 3, ...).
 5. The index builder detects the `CreatedQueryCheckpointLog`, publishes the
    normal read projection certificate `H` with the batch that crosses the log,
    and waits for the audit projection certificate to cover the same `H`.
+   After a cross-cluster incremental restore, the log still carries its
+   source-cluster `H`, while the restored store starts a new Raft index domain
+   at the full backup's genesis boundary. In that case the builder clamps the
+   projection wait and certificate to its captured restored-store applied
+   index. The audit indexer certifies that boundary only after folding the
+   complete restored audit head, so the checkpoint remains complete without
+   publishing or waiting on an unrelated source-cluster index.
 6. Only after every promised projection covers `H`, the builder flushes the
    WAL-less read store and materializes `{dataDir}/query-checkpoints/{id}/readindex/`.
    The flush is required: otherwise newly committed memtable-only rows and

--- a/docs/technical/architecture/subsystems/read-path/query-checkpoints.md
+++ b/docs/technical/architecture/subsystems/read-path/query-checkpoints.md
@@ -23,15 +23,16 @@ Checkpoint IDs are assigned sequentially by the FSM (1, 2, 3, ...).
    Pebble, including the entry's Raft applied index `H`.
 4. The Applier creates a physical Pebble checkpoint of the main store at `{dataDir}/query-checkpoints/{id}/main/`.
 5. The index builder detects the `CreatedQueryCheckpointLog`, publishes the
-   normal read projection certificate `H` with the batch that crosses the log,
-   and waits for the audit projection certificate to cover the same `H`.
-   After a cross-cluster incremental restore, the log still carries its
-   source-cluster `H`, while the restored store starts a new Raft index domain
-   at the full backup's genesis boundary. In that case the builder clamps the
-   projection wait and certificate to its captured restored-store applied
-   index. The audit indexer certifies that boundary only after folding the
-   complete restored audit head, so the checkpoint remains complete without
-   publishing or waiting on an unrelated source-cluster index.
+   normal read projection certificate `H` with the batch that crosses a live
+   checkpoint log, and waits for the audit projection certificate to cover the
+   same `H`. Cross-cluster restore explicitly marks every surviving
+   `QueryCheckpointState` as `restored_from_backup`: `PrepareForBackup` marks
+   rows carried by the full checkpoint and `RebuildDelta` marks rows rebuilt
+   from incremental logs. The builder consumes that durable provenance instead
+   of comparing unrelated source- and destination-cluster Raft numbers. It
+   withholds an intermediate normal certificate for a restored checkpoint and
+   only publishes the captured restored-store target after folding its complete
+   log head; the audit wait is clamped to that target as well.
 6. Only after every promised projection covers `H`, the builder flushes the
    WAL-less read store and materializes `{dataDir}/query-checkpoints/{id}/readindex/`.
    The flush is required: otherwise newly committed memtable-only rows and
@@ -69,12 +70,12 @@ The read index materializes asynchronously and **per-replica** (step 5). Readine
    caller's deadline/cancellation ends its marker wait. Unfiltered or
    sequence-only live audit reads remain independent of the audit index, but a
    checkpoint promises the complete projection set.
-  A steady-state audit indexing failure is also advertised as transiently
-  rebuilding to admission, while the checkpoint already in flight is left
-  unavailable and the normal builder continues past its log. The audit worker
-  keeps retrying and restores readiness after a successful fold; because there
-  is no checkpoint reconciler, the failed checkpoint is deleted and recreated
-  through the normal client/operator recovery path.
+  An audit indexing failure during boot or steady state is also advertised as
+  transiently rebuilding to admission, while the checkpoint already in flight
+  is left unavailable and the normal builder continues past its log. The audit
+  worker keeps retrying and restores readiness after a successful fold; because
+  there is no checkpoint reconciler, the failed checkpoint is deleted and
+  recreated through the normal client/operator recovery path.
 - **A read on a node that has not yet materialized the checkpoint returns a typed, retryable error.** Checkpoint reads are served locally on whichever node receives the request (no leader routing). On a node whose builder has not yet crossed the checkpoint log, `openCheckpointStores` finds no `.ready` marker but sees the checkpoint in the replicated `QueryCheckpointState` registry, and returns `ErrCheckpointNotReady` — reason `CHECKPOINT_NOT_READY`, mapped to gRPC `Unavailable`. This mirrors the per-replica `INDEX_BUILDING → Unavailable` pattern for metadata indexes: clients retry until that node materializes the checkpoint inline. The read never returns partial state.
 - **A read for a checkpoint id that does not exist returns `NotFound`.** If there is no `.ready` marker *and* no `QueryCheckpointState` entry for the id, `openCheckpointStores` returns `NotFound` (permanent) so clients stop retrying — distinct from the retryable `Unavailable` above.
 - **Unrecoverable checkpoints degrade to `NotFound`, not wrong data.** There is no historical reconstruction: inline materialization is already exactly point-in-time. If a node crashes between the atomic rename and the marker, that node will never have a `.ready` marker for the checkpoint. Since the checkpoint is still registered, reads there return the retryable `Unavailable` and never self-heal — the operator/client recreates the checkpoint (aligned with the existing `AcquireCheckpoint` client workaround, which deletes-and-recreates on timeout). Deleting the checkpoint then makes reads return `NotFound`.
@@ -88,7 +89,7 @@ The number of *live* query checkpoints is bounded by the Raft-replicated cluster
 - **`CreateQueryCheckpoint`** is rejected with `ErrCheckpointLimitReached` (`CHECKPOINT_LIMIT_REACHED`) when the live count is already at the limit. Creation never evicts; an operator deletes a checkpoint to free a slot. A limit of `0` (the unset default before any policy is committed) means uncapped — write readiness holds business writes until a policy is committed, so a real create sees a configured limit.
 - **`DeleteQueryCheckpoint`** is rejected with `ErrCheckpointNotFound` (`CHECKPOINT_NOT_FOUND`) for an id that is not live, and with `ErrCheckpointIDRequired` for id `0`.
 
-The live-id set is deterministic FSM state (`FSMState.LiveQueryCheckpointIDs`), rehydrated at boot by scanning the `SubGlobQueryCheckpoint` rows and updated by the create/delete handlers, so apply enforces the cap and existence without a Pebble read. The rows are a checker-verified projection: `compareQueryCheckpoints` re-derives the live set (with each row's `max_sequence` / `created_at`) from the `CreatedQueryCheckpoint` / `DeletedQueryCheckpoint` logs and diffs it against the stored rows, and the audit-rebuild path recreates the rows from those logs.
+The live-id set is deterministic FSM state (`FSMState.LiveQueryCheckpointIDs`), rehydrated at boot by scanning the `SubGlobQueryCheckpoint` rows and updated by the create/delete handlers, so apply enforces the cap and existence without a Pebble read. The rows are a checker-verified projection: `compareQueryCheckpoints` re-derives the live set (with each row's `max_sequence`, `created_at`, and `applied_index`) from the `CreatedQueryCheckpoint` / `DeletedQueryCheckpoint` logs and diffs it against the stored rows, and the audit-rebuild path recreates the rows from those logs.
 
 Because enforcement sits after the idempotency gate, a keyed retry replays the first apply's frozen outcome: a create that filled the cap replays its original success, and a create that hit the limit replays that rejection (`ErrCheckpointLimitReached` is a definitive, freezable outcome) even after a slot later frees — one outcome per idempotency key.
 
@@ -188,7 +189,7 @@ ledgerctl query-checkpoint get-schedule
 
 | Prefix | Key | Value |
 |--------|-----|-------|
-| `0xE2` | `[KeyPrefixQueryCheckpoint][checkpointID BE]` | `QueryCheckpointState` protobuf (`max_sequence`, `created_at`, `applied_index`) |
+| `0xE2` | `[KeyPrefixQueryCheckpoint][checkpointID BE]` | `QueryCheckpointState` protobuf (`max_sequence`, `created_at`, `applied_index`, plus technical `restored_from_backup` provenance) |
 | `0xE3` | `[KeyPrefixNextQueryCheckpointID]` | `uint64` — next checkpoint ID counter |
 | `0xE4` | `[KeyPrefixQueryCheckpointSchedule]` | Cron expression string (empty = disabled) |
 

--- a/docs/technical/architecture/subsystems/read-path/query-checkpoints.md
+++ b/docs/technical/architecture/subsystems/read-path/query-checkpoints.md
@@ -57,18 +57,24 @@ The read index materializes asynchronously and **per-replica** (step 5). Readine
   scheduler all fail explicitly with `ErrIndexBuilding` while the local audit
   projection is disabled or rebuilding. An enabled projection starts in the
   rebuilding state and only becomes ready after boot has classified its
-  persisted cursor and completed the initial rebuild/catch-up. A failed rebuild
-  remains in rebuilding state until a later successful rebuild/catch-up; it
-  cannot advertise a false readiness window. An already-proposed create waits
+   persisted cursor and completed the initial rebuild/catch-up. A failed rebuild
+   remains in rebuilding state until a later successful rebuild/catch-up; it
+   cannot advertise a false readiness window. An already-proposed create waits
   through a transient rebuild and resumes only after the replacement projection
   is ready and has certified `H`. A rebuild racing after that wait is detected
   by an audit lifecycle generation captured before the snapshot and checked
   atomically with `.ready` publication; a changed generation leaves the marker
   absent and retries materialization from a clean directory. A disabled
-  projection leaves the checkpoint unavailable. In every waiting case the
-  caller's deadline/cancellation ends its marker wait. Unfiltered or
-  sequence-only live audit reads remain independent of the audit index, but a
-  checkpoint promises the complete projection set.
+   projection leaves the checkpoint unavailable. In every waiting case the
+   caller's deadline/cancellation ends its marker wait. Unfiltered or
+   sequence-only live audit reads remain independent of the audit index, but a
+   checkpoint promises the complete projection set.
+  A steady-state audit indexing failure is also advertised as transiently
+  rebuilding to admission, while the checkpoint already in flight is left
+  unavailable and the normal builder continues past its log. The audit worker
+  keeps retrying and restores readiness after a successful fold; because there
+  is no checkpoint reconciler, the failed checkpoint is deleted and recreated
+  through the normal client/operator recovery path.
 - **A read on a node that has not yet materialized the checkpoint returns a typed, retryable error.** Checkpoint reads are served locally on whichever node receives the request (no leader routing). On a node whose builder has not yet crossed the checkpoint log, `openCheckpointStores` finds no `.ready` marker but sees the checkpoint in the replicated `QueryCheckpointState` registry, and returns `ErrCheckpointNotReady` — reason `CHECKPOINT_NOT_READY`, mapped to gRPC `Unavailable`. This mirrors the per-replica `INDEX_BUILDING → Unavailable` pattern for metadata indexes: clients retry until that node materializes the checkpoint inline. The read never returns partial state.
 - **A read for a checkpoint id that does not exist returns `NotFound`.** If there is no `.ready` marker *and* no `QueryCheckpointState` entry for the id, `openCheckpointStores` returns `NotFound` (permanent) so clients stop retrying — distinct from the retryable `Unavailable` above.
 - **Unrecoverable checkpoints degrade to `NotFound`, not wrong data.** There is no historical reconstruction: inline materialization is already exactly point-in-time. If a node crashes between the atomic rename and the marker, that node will never have a `.ready` marker for the checkpoint. Since the checkpoint is still registered, reads there return the retryable `Unavailable` and never self-heal — the operator/client recreates the checkpoint (aligned with the existing `AcquireCheckpoint` client workaround, which deletes-and-recreates on timeout). Deleting the checkpoint then makes reads return `NotFound`.

--- a/docs/technical/architecture/subsystems/read-path/query-checkpoints.md
+++ b/docs/technical/architecture/subsystems/read-path/query-checkpoints.md
@@ -19,16 +19,49 @@ Checkpoint IDs are assigned sequentially by the FSM (1, 2, 3, ...).
 
 1. Client sends `CreateQueryCheckpoint` request (via ClusterService RPC or BucketService Apply).
 2. The request is proposed through Raft consensus.
-3. The FSM commits pending state and records `QueryCheckpointState` metadata in Pebble.
+3. The FSM commits pending state and records `QueryCheckpointState` metadata in
+   Pebble, including the entry's Raft applied index `H`.
 4. The Applier creates a physical Pebble checkpoint of the main store at `{dataDir}/query-checkpoints/{id}/main/`.
-5. The index builder detects the `CreatedQueryCheckpointLog` and, **at the exact moment it crosses that log**, materializes the read index checkpoint at `{dataDir}/query-checkpoints/{id}/readindex/`. Because the builder breaks its batch on the checkpoint log, the live read index at that instant reflects precisely `MaxSequence` — the checkpoint's point-in-time. The read index runs without a WAL, so a Pebble checkpoint of it carries only flushed SSTs; the builder flushes the memtable before checkpointing so every row folded up to that instant is in the frozen index. Materialization is **per-replica** (every node's builder does this independently) and **atomic**: it builds into a sibling `readindex.tmp/`, fsyncs, atomically renames into place, then writes the `.ready` marker **last**. A crash before the marker leaves no `.ready` file, so the checkpoint is never observed half-built. Pebble hard-links SST files last, so a checkpoint can fail mid-link (a concurrent compaction removing an SST); the builder retries the checkpoint on a `link ... no such file or directory` error, cleaning the temp directory between attempts.
-6. Both stores are opened read-only when a query specifies `checkpoint_id`.
+5. The index builder detects the `CreatedQueryCheckpointLog`, publishes the
+   normal read projection certificate `H` with the batch that crosses the log,
+   and waits for the audit projection certificate to cover the same `H`.
+6. Only after every promised projection covers `H`, the builder flushes the
+   WAL-less read store and materializes `{dataDir}/query-checkpoints/{id}/readindex/`.
+   The flush is required: otherwise newly committed memtable-only rows and
+   certificates have no WAL or SST for Pebble to link. Materialization is
+   **per-replica** and **atomic**: build into `readindex.tmp/`, fsync, rename,
+   then write `.ready` last. The independently maintained audit projection may
+   already contain rows newer than `H`; checkpoint audit reads trim every
+   compiled candidate to the audit sequence visible in the frozen main store.
+   A crash before the marker never exposes a partial checkpoint.
+   Link/compaction races are retried from a clean temp directory.
+7. Both stores are opened read-only when a query specifies `checkpoint_id`.
 
 ## Readiness and Error Contract
 
 The read index materializes asynchronously and **per-replica** (step 5). Readiness on a node is signalled solely by the local `.ready` marker; there is **no** cross-node readiness map and **no** background reconciler.
 
 - **`CreateQueryCheckpoint` blocks on the creator node's marker.** The handler waits (`readStore.WaitForCheckpoint`) for the local `.ready` marker before returning, so an immediate read at the returned `checkpoint_id` **routed back to the creator node succeeds**. It waits on the marker, not on the index-builder progress cursor — the cursor fast path was the EN-1460 root cause: the cursor is persisted in the batch that *precedes* the physical checkpoint creation, so it reaches the target sequence ~100-150 ms before the directory exists.
+- **Audit is part of the readiness promise.** The checkpoint log carries `H`.
+  The normal builder does not publish `.ready` until the audit projection has
+  certified `H`, so a filtered audit query cannot be frozen against an
+  incomplete audit index. Every creation trigger passes through a shared
+  admission preflight, so public `Apply`, the cluster RPC and the automatic
+  scheduler all fail explicitly with `ErrIndexBuilding` while the local audit
+  projection is disabled or rebuilding. An enabled projection starts in the
+  rebuilding state and only becomes ready after boot has classified its
+  persisted cursor and completed the initial rebuild/catch-up. A failed rebuild
+  remains in rebuilding state until a later successful rebuild/catch-up; it
+  cannot advertise a false readiness window. An already-proposed create waits
+  through a transient rebuild and resumes only after the replacement projection
+  is ready and has certified `H`. A rebuild racing after that wait is detected
+  by an audit lifecycle generation captured before the snapshot and checked
+  atomically with `.ready` publication; a changed generation leaves the marker
+  absent and retries materialization from a clean directory. A disabled
+  projection leaves the checkpoint unavailable. In every waiting case the
+  caller's deadline/cancellation ends its marker wait. Unfiltered or
+  sequence-only live audit reads remain independent of the audit index, but a
+  checkpoint promises the complete projection set.
 - **A read on a node that has not yet materialized the checkpoint returns a typed, retryable error.** Checkpoint reads are served locally on whichever node receives the request (no leader routing). On a node whose builder has not yet crossed the checkpoint log, `openCheckpointStores` finds no `.ready` marker but sees the checkpoint in the replicated `QueryCheckpointState` registry, and returns `ErrCheckpointNotReady` — reason `CHECKPOINT_NOT_READY`, mapped to gRPC `Unavailable`. This mirrors the per-replica `INDEX_BUILDING → Unavailable` pattern for metadata indexes: clients retry until that node materializes the checkpoint inline. The read never returns partial state.
 - **A read for a checkpoint id that does not exist returns `NotFound`.** If there is no `.ready` marker *and* no `QueryCheckpointState` entry for the id, `openCheckpointStores` returns `NotFound` (permanent) so clients stop retrying — distinct from the retryable `Unavailable` above.
 - **Unrecoverable checkpoints degrade to `NotFound`, not wrong data.** There is no historical reconstruction: inline materialization is already exactly point-in-time. If a node crashes between the atomic rename and the marker, that node will never have a `.ready` marker for the checkpoint. Since the checkpoint is still registered, reads there return the retryable `Unavailable` and never self-heal — the operator/client recreates the checkpoint (aligned with the existing `AcquireCheckpoint` client workaround, which deletes-and-recreates on timeout). Deleting the checkpoint then makes reads return `NotFound`.
@@ -142,7 +175,7 @@ ledgerctl query-checkpoint get-schedule
 
 | Prefix | Key | Value |
 |--------|-----|-------|
-| `0xE2` | `[KeyPrefixQueryCheckpoint][checkpointID BE]` | `QueryCheckpointState` protobuf |
+| `0xE2` | `[KeyPrefixQueryCheckpoint][checkpointID BE]` | `QueryCheckpointState` protobuf (`max_sequence`, `created_at`, `applied_index`) |
 | `0xE3` | `[KeyPrefixNextQueryCheckpointID]` | `uint64` — next checkpoint ID counter |
 | `0xE4` | `[KeyPrefixQueryCheckpointSchedule]` | Cron expression string (empty = disabled) |
 

--- a/internal/adapter/grpc/server_bucket.go
+++ b/internal/adapter/grpc/server_bucket.go
@@ -905,16 +905,11 @@ func (impl *BucketServiceServerImpl) ListAuditEntries(req *servicepb.ListAuditEn
 			_ = mainStore.Close()
 		}()
 
-		// Known limitation (tracked as a follow-up): CreateQueryCheckpoint waits
-		// for the log-index builder (readStore.WaitForSequence) before snapshotting
-		// the readstore, but NOT for the separate async audit indexer. If the
-		// audit index lagged its zone at snapshot time, a *filtered* checkpoint
-		// read can omit audit entries that do exist in the checkpoint's audit
-		// zone, and — the checkpoint being frozen — it never catches up. The
-		// unfiltered checkpoint read is unaffected (it scans the zone directly).
-		// The proper fix belongs in the checkpoint-creation path (make the audit
-		// indexer catch up before the readstore checkpoint, mirroring the
-		// log-index WaitForSequence); it is out of scope here.
+		// Checkpoint publication certifies both the normal and audit projections
+		// at the checkpoint's fixed Raft horizon before writing .ready. The audit
+		// projection may already be ahead of the frozen main store, so the local
+		// controller also trims compiled candidates to the checkpoint's audit
+		// sequence.
 		c, err = impl.localCtrl.ListAuditEntriesFrom(ctx, mainStore, readIdx, fetchSize, afterSeq, opts.GetFilter(), opts.GetReverse())
 	} else {
 		minLogSeq := opts.GetRead().GetMinLogSequence()

--- a/internal/application/admission/admission.go
+++ b/internal/application/admission/admission.go
@@ -62,6 +62,9 @@ type Admission struct {
 	numscriptCache  *numscript.NumscriptCache
 	authEnabled     bool
 	waitLeaderReady func(context.Context) error
+	// auditProjectionState is node-local admission state. It may reject a
+	// checkpoint proposal before Raft, but never affects deterministic apply.
+	auditProjectionState func() (disabled, rebuilding bool)
 
 	// clusterPolicyCommitted latches once the replicated cluster policy is
 	// observed committed (revision > 0). The steady-state write path then skips
@@ -129,6 +132,15 @@ func WithMetrics() func(*Admission) {
 func WithAuthEnabled() func(*Admission) {
 	return func(a *Admission) {
 		a.authEnabled = true
+	}
+}
+
+// WithAuditProjectionState prevents every admission trigger (public Apply,
+// ClusterService and the automatic scheduler) from committing a query
+// checkpoint whose audit projection cannot be materialized on this node.
+func WithAuditProjectionState(state func() (disabled, rebuilding bool)) func(*Admission) {
+	return func(a *Admission) {
+		a.auditProjectionState = state
 	}
 }
 
@@ -534,6 +546,10 @@ func (a *Admission) Admit(ctx context.Context, req *servicepb.ApplyRequest) (log
 		return nil, ErrMaintenanceMode
 	}
 
+	if err := a.checkQueryCheckpointProjectionReady(batch.requests); err != nil {
+		return nil, err
+	}
+
 	// Hold business writes until the replicated cluster policy is committed. The
 	// policy is the cluster-wide configuration a business write applies against —
 	// it carries the query-checkpoint limit and idempotency TTL — so a write
@@ -844,6 +860,32 @@ func (a *Admission) Admit(ctx context.Context, req *servicepb.ApplyRequest) (log
 	}
 
 	return logs, err
+}
+
+func (a *Admission) checkQueryCheckpointProjectionReady(reqs []*servicepb.Request) error {
+	if a.auditProjectionState == nil {
+		return nil
+	}
+
+	for _, req := range reqs {
+		if req.GetCreateQueryCheckpoint() == nil {
+			continue
+		}
+
+		disabled, rebuilding := a.auditProjectionState()
+		if !disabled && !rebuilding {
+			return nil
+		}
+
+		state := "disabled"
+		if rebuilding {
+			state = "rebuilding"
+		}
+
+		return &domain.BusinessError{Err: &domain.ErrIndexBuilding{Index: "audit (" + state + ")"}}
+	}
+
+	return nil
 }
 
 // Barrier proposes a no-op command through Raft and waits for it to be applied.

--- a/internal/application/admission/query_checkpoint_readiness_test.go
+++ b/internal/application/admission/query_checkpoint_readiness_test.go
@@ -1,0 +1,63 @@
+package admission
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+)
+
+func TestCheckQueryCheckpointProjectionReady(t *testing.T) {
+	t.Parallel()
+
+	checkpoint := &servicepb.Request{Type: &servicepb.Request_CreateQueryCheckpoint{
+		CreateQueryCheckpoint: &servicepb.CreateQueryCheckpointRequest{},
+	}}
+	nonCheckpoint := &servicepb.Request{Type: &servicepb.Request_CreateLedger{
+		CreateLedger: &servicepb.CreateLedgerRequest{Name: "ledger"},
+	}}
+
+	for _, tc := range []struct {
+		name       string
+		reqs       []*servicepb.Request
+		disabled   bool
+		rebuilding bool
+		wantErr    bool
+	}{
+		{name: "ready", reqs: []*servicepb.Request{checkpoint}},
+		{name: "disabled", reqs: []*servicepb.Request{checkpoint}, disabled: true, wantErr: true},
+		{name: "rebuilding", reqs: []*servicepb.Request{checkpoint}, rebuilding: true, wantErr: true},
+		{name: "mixed batch", reqs: []*servicepb.Request{nonCheckpoint, checkpoint}, disabled: true, wantErr: true},
+		{name: "unrelated request", reqs: []*servicepb.Request{nonCheckpoint}, disabled: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			a := &Admission{auditProjectionState: func() (bool, bool) {
+				return tc.disabled, tc.rebuilding
+			}}
+			err := a.checkQueryCheckpointProjectionReady(tc.reqs)
+			if !tc.wantErr {
+				require.NoError(t, err)
+
+				return
+			}
+
+			var building *domain.ErrIndexBuilding
+			require.ErrorAs(t, err, &building)
+			require.Contains(t, building.Index, "audit")
+		})
+	}
+}
+
+func TestWithAuditProjectionStateConfiguresAdmission(t *testing.T) {
+	t.Parallel()
+
+	a := &Admission{}
+	WithAuditProjectionState(func() (bool, bool) { return true, false })(a)
+	disabled, rebuilding := a.auditProjectionState()
+	require.True(t, disabled)
+	require.False(t, rebuilding)
+}

--- a/internal/application/admission/query_checkpoint_readiness_test.go
+++ b/internal/application/admission/query_checkpoint_readiness_test.go
@@ -1,11 +1,14 @@
 package admission
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/infra/health"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
 
@@ -60,4 +63,27 @@ func TestWithAuditProjectionStateConfiguresAdmission(t *testing.T) {
 	disabled, rebuilding := a.auditProjectionState()
 	require.True(t, disabled)
 	require.False(t, rebuilding)
+}
+
+func TestAdmitRejectsCheckpointWhenAuditProjectionIsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+	a, _ := createTestAdmission(t, store)
+	writeGate := health.NewMockWriteGate(gomock.NewController(t))
+	writeGate.EXPECT().CheckWritesAllowed().Return(nil)
+	a.writeGate = writeGate
+	WithAuditProjectionState(func() (bool, bool) { return false, true })(a)
+
+	_, err := a.Admit(context.Background(), &servicepb.ApplyRequest{
+		Variant: &servicepb.ApplyRequest_Unsigned{Unsigned: &servicepb.ApplyBatch{Requests: []*servicepb.Request{{
+			Type: &servicepb.Request_CreateQueryCheckpoint{
+				CreateQueryCheckpoint: &servicepb.CreateQueryCheckpointRequest{},
+			},
+		}}}},
+	})
+
+	var building *domain.ErrIndexBuilding
+	require.ErrorAs(t, err, &building)
+	require.Contains(t, building.Index, "audit")
 }

--- a/internal/application/auditindexer/indexer.go
+++ b/internal/application/auditindexer/indexer.go
@@ -71,6 +71,12 @@ func New(cfg Config, store *dal.Store, rs *readstore.Store, logger logging.Logge
 		batchSize = DefaultBatchSize
 	}
 
+	// An enabled projection starts conservatively unavailable. Boot must first
+	// classify the persisted cursor and complete its initial rebuild/catch-up;
+	// otherwise checkpoint admission could race the asynchronous boot task and
+	// commit a checkpoint whose audit projection can never be certified.
+	rs.SetAuditProjectionState(cfg.Disabled, !cfg.Disabled)
+
 	return &Indexer{
 		cfg:       cfg,
 		store:     store,
@@ -100,6 +106,21 @@ func (i *Indexer) ProcessOnce(ctx context.Context) (uint64, error) {
 		return 0, fmt.Errorf("reading audit progress: %w", err)
 	}
 
+	handle, err := i.store.NewDirectReadHandle()
+	if err != nil {
+		return cursor, fmt.Errorf("opening audit target snapshot: %w", err)
+	}
+	defer func() { _ = handle.Close() }()
+
+	targetAppliedIndex, err := query.ReadLastAppliedIndex(handle)
+	if err != nil {
+		return cursor, fmt.Errorf("reading audit target applied index: %w", err)
+	}
+	targetAuditSequence, err := query.ReadLastAuditSequence(handle)
+	if err != nil {
+		return cursor, fmt.Errorf("reading audit target sequence: %w", err)
+	}
+
 	for {
 		// Honor shutdown between batches: worker.Stop() blocks on this loop
 		// returning, so without this check draining a large backlog (or a
@@ -109,7 +130,7 @@ func (i *Indexer) ProcessOnce(ctx context.Context) (uint64, error) {
 			return cursor, err
 		}
 
-		next, advanced, err := i.processBatch(ctx, cursor)
+		next, advanced, err := i.processBatch(ctx, handle, cursor, targetAuditSequence, targetAppliedIndex)
 		if err != nil {
 			return cursor, err
 		}
@@ -121,6 +142,7 @@ func (i *Indexer) ProcessOnce(ctx context.Context) (uint64, error) {
 	}
 
 	i.lastIndexed.Store(cursor)
+	i.readStore.SetAuditProjectionState(false, false)
 
 	return cursor, nil
 }
@@ -128,6 +150,7 @@ func (i *Indexer) ProcessOnce(ctx context.Context) (uint64, error) {
 // Rebuild drops the audit index and the cursor, then replays from the earliest
 // surviving audit entry. Used by ledgerctl and by boot auto-rebuild.
 func (i *Indexer) Rebuild(ctx context.Context) error {
+	i.readStore.SetAuditProjectionState(false, true)
 	// Drop the index and reset the cursor in a single batch so the operation is
 	// crash-atomic: a torn write leaves either (old index, old cursor) or (empty
 	// index, cursor 0). The latter deterministically re-triggers boot rebuild
@@ -141,14 +164,21 @@ func (i *Indexer) Rebuild(ctx context.Context) error {
 	if err := i.readStore.WriteAuditProgress(batch, 0); err != nil {
 		return err
 	}
+	if err := i.readStore.WriteAuditRaftProgress(batch, 0); err != nil {
+		return err
+	}
 	if err := batch.Commit(); err != nil {
 		return fmt.Errorf("resetting audit index: %w", err)
 	}
 	i.lastIndexed.Store(0)
 
-	_, err := i.ProcessOnce(ctx)
+	if _, err := i.ProcessOnce(ctx); err != nil {
+		return err
+	}
 
-	return err
+	i.readStore.SetAuditProjectionState(false, false)
+
+	return nil
 }
 
 // shouldRebuildOnBoot reports whether boot should drop+rebuild instead of an
@@ -169,13 +199,13 @@ func (i *Indexer) shouldRebuildOnBoot(cursor, last uint64) bool {
 // processBatch indexes up to batchSize audit entries whose sequence is strictly
 // greater than after, commits a single readstore batch, and returns the new
 // cursor and whether at least one entry was processed.
-func (i *Indexer) processBatch(ctx context.Context, after uint64) (uint64, bool, error) {
-	handle, err := i.store.NewDirectReadHandle()
-	if err != nil {
-		return after, false, fmt.Errorf("opening read handle: %w", err)
-	}
-	defer func() { _ = handle.Close() }()
-
+func (i *Indexer) processBatch(
+	ctx context.Context,
+	handle dal.PebbleReader,
+	after uint64,
+	targetAuditSequence uint64,
+	targetAppliedIndex uint64,
+) (uint64, bool, error) {
 	cur, err := query.ReadAuditEntries(ctx, handle, &after)
 	if err != nil {
 		return after, false, fmt.Errorf("reading audit entries after %d: %w", after, err)
@@ -218,11 +248,32 @@ func (i *Indexer) processBatch(ctx context.Context, after uint64) (uint64, bool,
 	}
 
 	if count == 0 {
+		if after >= targetAuditSequence {
+			progress, err := i.readStore.ReadAuditRaftProgress()
+			if err != nil {
+				return after, false, fmt.Errorf("reading audit Raft progress: %w", err)
+			}
+			if progress < targetAppliedIndex {
+				if err := i.readStore.WriteAuditRaftProgress(batch, targetAppliedIndex); err != nil {
+					return after, false, fmt.Errorf("writing audit Raft progress: %w", err)
+				}
+				if err := batch.Commit(); err != nil {
+					return after, false, fmt.Errorf("committing audit Raft progress: %w", err)
+				}
+				i.readStore.NotifyProgress()
+			}
+		}
+
 		return after, false, nil
 	}
 
 	if err := i.readStore.WriteAuditProgress(batch, cursor); err != nil {
 		return after, false, fmt.Errorf("writing audit progress %d: %w", cursor, err)
+	}
+	if cursor >= targetAuditSequence {
+		if err := i.readStore.WriteAuditRaftProgress(batch, targetAppliedIndex); err != nil {
+			return after, false, fmt.Errorf("writing audit Raft progress %d: %w", targetAppliedIndex, err)
+		}
 	}
 
 	if err := batch.Commit(); err != nil {
@@ -284,25 +335,29 @@ func (i *Indexer) Stop() {
 
 // boot runs once before the tail loop: it seeds the audit-head gauge and, when
 // the persisted cursor is missing with entries present (fresh index over a
-// populated audit zone), performs a full drop+rebuild. A cursor read error
-// aborts the loop (returned to tailworker, which logs and stops); a rebuild
-// error is logged and swallowed so steady-state indexing still starts.
+// populated audit zone), performs a full drop+rebuild. Otherwise it completes
+// the initial incremental catch-up. Readiness remains conservative until one
+// of those paths succeeds; a boot error aborts the worker rather than exposing
+// a projection whose persisted state has not been classified.
 func (i *Indexer) boot(ctx context.Context) error {
 	cursor, err := i.readStore.ReadAuditProgress()
 	if err != nil {
 		return fmt.Errorf("read audit cursor: %w", err)
 	}
-	if last, err := i.lastAuditSequence(); err == nil {
-		i.auditLast.Store(last)
-		if i.shouldRebuildOnBoot(cursor, last) {
-			i.logger.WithFields(map[string]any{"cursor": cursor, "last": last}).Infof("Audit index rebuild on boot")
-			if err := i.Rebuild(ctx); err != nil && !errors.Is(err, context.Canceled) {
-				i.logger.Errorf("audit index boot rebuild: %v", err)
-			}
-		}
+	last, err := i.lastAuditSequence()
+	if err != nil {
+		return fmt.Errorf("read audit head: %w", err)
+	}
+	i.auditLast.Store(last)
+	if i.shouldRebuildOnBoot(cursor, last) {
+		i.logger.WithFields(map[string]any{"cursor": cursor, "last": last}).Infof("Audit index rebuild on boot")
+
+		return i.Rebuild(ctx)
 	}
 
-	return nil
+	_, err = i.ProcessOnce(ctx)
+
+	return err
 }
 
 // processTick runs one steady-state iteration: refresh the audit-head gauge and

--- a/internal/application/auditindexer/indexer.go
+++ b/internal/application/auditindexer/indexer.go
@@ -343,9 +343,17 @@ func (i *Indexer) Stop() {
 // the persisted cursor is missing with entries present (fresh index over a
 // populated audit zone), performs a full drop+rebuild. Otherwise it completes
 // the initial incremental catch-up. Readiness remains conservative until one
-// of those paths succeeds. TailWorker retries transient boot errors while the
-// projection remains unavailable, so readiness can recover without a restart.
-func (i *Indexer) boot(ctx context.Context) error {
+// of those paths succeeds. A non-cancellation failure is published so the
+// normal index builder can leave an in-flight checkpoint unavailable and keep
+// processing; TailWorker still retries boot in the background, and a later
+// successful catch-up restores readiness without a restart.
+func (i *Indexer) boot(ctx context.Context) (retErr error) {
+	defer func() {
+		if retErr != nil && ctx.Err() == nil {
+			i.readStore.SetAuditProjectionFailed()
+		}
+	}()
+
 	cursor, err := i.readStore.ReadAuditProgress()
 	if err != nil {
 		return fmt.Errorf("read audit cursor: %w", err)

--- a/internal/application/auditindexer/indexer.go
+++ b/internal/application/auditindexer/indexer.go
@@ -227,6 +227,10 @@ func (i *Indexer) processBatch(
 	count := 0
 
 	for count < i.batchSize {
+		if err := ctx.Err(); err != nil {
+			return after, false, err
+		}
+
 		entry, err := cur.Next()
 		if err != nil {
 			if errors.Is(err, io.EOF) {

--- a/internal/application/auditindexer/indexer.go
+++ b/internal/application/auditindexer/indexer.go
@@ -106,7 +106,7 @@ func (i *Indexer) ProcessOnce(ctx context.Context) (uint64, error) {
 		return 0, fmt.Errorf("reading audit progress: %w", err)
 	}
 
-	handle, err := i.store.NewDirectReadHandle()
+	handle, err := i.store.NewReadHandle()
 	if err != nil {
 		return cursor, fmt.Errorf("opening audit target snapshot: %w", err)
 	}
@@ -121,7 +121,9 @@ func (i *Indexer) ProcessOnce(ctx context.Context) (uint64, error) {
 		return cursor, fmt.Errorf("reading audit target sequence: %w", err)
 	}
 
-	for {
+	// Run at least one batch even when the native cursor is already at the
+	// target: a Raft entry can advance the certificate without emitting audit.
+	for first := true; first || cursor < targetAuditSequence; first = false {
 		// Honor shutdown between batches: worker.Stop() blocks on this loop
 		// returning, so without this check draining a large backlog (or a
 		// sustained write stream, where advanced stays true) would stall

--- a/internal/application/auditindexer/indexer.go
+++ b/internal/application/auditindexer/indexer.go
@@ -337,8 +337,8 @@ func (i *Indexer) Stop() {
 // the persisted cursor is missing with entries present (fresh index over a
 // populated audit zone), performs a full drop+rebuild. Otherwise it completes
 // the initial incremental catch-up. Readiness remains conservative until one
-// of those paths succeeds; a boot error aborts the worker rather than exposing
-// a projection whose persisted state has not been classified.
+// of those paths succeeds. TailWorker retries transient boot errors while the
+// projection remains unavailable, so readiness can recover without a restart.
 func (i *Indexer) boot(ctx context.Context) error {
 	cursor, err := i.readStore.ReadAuditProgress()
 	if err != nil {

--- a/internal/application/auditindexer/indexer.go
+++ b/internal/application/auditindexer/indexer.go
@@ -371,11 +371,20 @@ func (i *Indexer) boot(ctx context.Context) error {
 // persisted cursor never overtakes the audit head at runtime — there is no
 // rollback to detect and self-heal from here (see shouldRebuildOnBoot).
 func (i *Indexer) processTick(ctx context.Context) error {
-	if last, err := i.lastAuditSequence(); err == nil {
-		i.auditLast.Store(last)
-	}
+	last, err := i.lastAuditSequence()
+	if err != nil {
+		if ctx.Err() == nil {
+			i.readStore.SetAuditProjectionFailed()
+		}
 
-	_, err := i.ProcessOnce(ctx)
+		return err
+	}
+	i.auditLast.Store(last)
+
+	_, err = i.ProcessOnce(ctx)
+	if err != nil && ctx.Err() == nil {
+		i.readStore.SetAuditProjectionFailed()
+	}
 
 	return err
 }

--- a/internal/application/auditindexer/indexer_test.go
+++ b/internal/application/auditindexer/indexer_test.go
@@ -11,6 +11,7 @@ import (
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
+	"github.com/formancehq/ledger/v3/internal/infra/state"
 	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
@@ -30,6 +31,14 @@ func writeAuditEntry(t *testing.T, store *dal.Store, entry *auditpb.AuditEntry) 
 		kb.PutZonePrefix(dal.ZoneHistory, dal.SubHistoryAudit).PutUint64(entry.GetSequence()).Build(),
 		val,
 	))
+	require.NoError(t, batch.Commit())
+}
+
+func setAppliedIndex(t *testing.T, store *dal.Store, appliedIndex uint64) {
+	t.Helper()
+
+	batch := store.OpenWriteSession()
+	require.NoError(t, state.SetAppliedIndex(batch, appliedIndex))
 	require.NoError(t, batch.Commit())
 }
 
@@ -87,6 +96,87 @@ func TestRebuildYieldsIdenticalIndex(t *testing.T) {
 	cursor, err := rs.ReadAuditProgress()
 	require.NoError(t, err)
 	require.Equal(t, uint64(5), cursor)
+	disabled, rebuilding := rs.AuditProjectionState()
+	require.False(t, disabled)
+	require.False(t, rebuilding)
+}
+
+func TestFailedRebuildRemainsNotReady(t *testing.T) {
+	t.Parallel()
+
+	idx, _, rs := newIndexerForTest(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorIs(t, idx.Rebuild(ctx), context.Canceled)
+	disabled, rebuilding := rs.AuditProjectionState()
+	require.False(t, disabled)
+	require.True(t, rebuilding)
+}
+
+func TestBootKeepsProjectionUnavailableUntilInitialCatchUp(t *testing.T) {
+	t.Parallel()
+
+	idx, mainStore, rs := newIndexerForTest(t)
+	disabled, rebuilding := rs.AuditProjectionState()
+	require.False(t, disabled)
+	require.True(t, rebuilding, "an enabled projection must start conservatively unavailable")
+
+	writeAuditEntry(t, mainStore, &auditpb.AuditEntry{
+		Sequence: 1, ProposalId: 1, Timestamp: &commonpb.Timestamp{Data: 1_000_000},
+		Outcome: &auditpb.AuditEntry_Success{Success: &auditpb.AuditSuccess{}},
+		Ledgers: []string{"main"},
+	})
+	setAppliedIndex(t, mainStore, 7)
+
+	require.NoError(t, idx.boot(context.Background()))
+	disabled, rebuilding = rs.AuditProjectionState()
+	require.False(t, disabled)
+	require.False(t, rebuilding, "successful boot rebuild/catch-up may publish readiness")
+	progress, err := rs.ReadAuditRaftProgress()
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), progress)
+}
+
+func TestDisabledIndexerKeepsProjectionUnavailableWithoutFolding(t *testing.T) {
+	t.Parallel()
+
+	idx, mainStore, rs := newIndexerForTest(t)
+	disabledIndexer := New(Config{Disabled: true}, mainStore, rs, idx.logger, idx.meter)
+	disabled, rebuilding := rs.AuditProjectionState()
+	require.True(t, disabled)
+	require.False(t, rebuilding)
+
+	batch := rs.NewBatch()
+	require.NoError(t, rs.WriteAuditProgress(batch, 7))
+	require.NoError(t, batch.Commit())
+
+	cursor, err := disabledIndexer.ProcessOnce(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, uint64(7), cursor)
+
+	disabledIndexer.Start()
+	disabledIndexer.Stop()
+}
+
+func TestBootMarksAlreadyCaughtUpProjectionReady(t *testing.T) {
+	t.Parallel()
+
+	idx, mainStore, rs := newIndexerForTest(t)
+	writeAuditEntry(t, mainStore, &auditpb.AuditEntry{
+		Sequence: 1, ProposalId: 1, Timestamp: &commonpb.Timestamp{Data: 1_000_000},
+		Outcome: &auditpb.AuditEntry_Success{Success: &auditpb.AuditSuccess{}},
+		Ledgers: []string{"main"},
+	})
+	setAppliedIndex(t, mainStore, 7)
+	_, err := idx.ProcessOnce(context.Background())
+	require.NoError(t, err)
+
+	rs.SetAuditProjectionState(false, true)
+	require.NoError(t, idx.boot(context.Background()))
+	disabled, rebuilding := rs.AuditProjectionState()
+	require.False(t, disabled)
+	require.False(t, rebuilding, "boot must publish readiness after validating an already caught-up cursor")
 }
 
 // TestShouldRebuildOnBoot covers the sole retained rebuild trigger: a missing
@@ -156,6 +246,68 @@ func TestIndexerCatchUpAndResume(t *testing.T) {
 	seqs, err = rs.AuditSeqsByString(readstore.AuditFieldLedger, "main")
 	require.NoError(t, err)
 	require.Equal(t, []uint64{1, 2}, seqs)
+}
+
+func TestProcessOncePublishesFixedRaftHorizonOnlyWithTerminalBatch(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	idx, mainStore, rs := newIndexerForTest(t)
+	idx.batchSize = 1
+
+	for sequence := uint64(1); sequence <= 3; sequence++ {
+		writeAuditEntry(t, mainStore, &auditpb.AuditEntry{
+			Sequence: sequence, ProposalId: sequence,
+			Timestamp: &commonpb.Timestamp{Data: sequence * 1_000_000},
+			Outcome:   &auditpb.AuditEntry_Success{Success: &auditpb.AuditSuccess{}},
+			Ledgers:   []string{"main"},
+		})
+	}
+	setAppliedIndex(t, mainStore, 11)
+
+	handle, err := mainStore.NewDirectReadHandle()
+	require.NoError(t, err)
+	defer func() { _ = handle.Close() }()
+
+	cursor, advanced, err := idx.processBatch(ctx, handle, 0, 3, 11)
+	require.NoError(t, err)
+	require.True(t, advanced)
+	require.Equal(t, uint64(1), cursor)
+	progress, err := rs.ReadAuditRaftProgress()
+	require.NoError(t, err)
+	require.Zero(t, progress, "an intermediate native batch must not certify the target")
+
+	cursor, advanced, err = idx.processBatch(ctx, handle, cursor, 3, 11)
+	require.NoError(t, err)
+	require.True(t, advanced)
+	require.Equal(t, uint64(2), cursor)
+	progress, err = rs.ReadAuditRaftProgress()
+	require.NoError(t, err)
+	require.Zero(t, progress, "a crash between batches must leave the Raft target unpublished")
+
+	cursor, advanced, err = idx.processBatch(ctx, handle, cursor, 3, 11)
+	require.NoError(t, err)
+	require.True(t, advanced)
+	require.Equal(t, uint64(3), cursor)
+	progress, err = rs.ReadAuditRaftProgress()
+	require.NoError(t, err)
+	require.Equal(t, uint64(11), progress, "the final index writes and certificate commit atomically")
+}
+
+func TestProcessOnceCertifiesAppliedEntryWithoutAuditMovement(t *testing.T) {
+	t.Parallel()
+
+	idx, mainStore, rs := newIndexerForTest(t)
+	setAppliedIndex(t, mainStore, 17)
+
+	cursor, err := idx.ProcessOnce(context.Background())
+	require.NoError(t, err)
+	require.Zero(t, cursor)
+
+	progress, err := rs.ReadAuditRaftProgress()
+	require.NoError(t, err)
+	require.Equal(t, uint64(17), progress,
+		"a Raft entry that emits no audit item must still advance the causal certificate")
 }
 
 // TestProcessOnceWakesAuditWaiters verifies the indexer wakes readers blocked in

--- a/internal/application/auditindexer/indexer_test.go
+++ b/internal/application/auditindexer/indexer_test.go
@@ -390,6 +390,34 @@ func TestStartStopIndexes(t *testing.T) {
 	}, 5*time.Second, 20*time.Millisecond)
 }
 
+func TestProcessTickPublishesFailureThenRecoversReadiness(t *testing.T) {
+	t.Parallel()
+
+	idx, mainStore, rs := newIndexerForTest(t)
+	batch := mainStore.OpenWriteSession()
+	key := dal.NewKeyBuilder().PutZonePrefix(dal.ZoneHistory, dal.SubHistoryAudit).PutUint64(1).Build()
+	require.NoError(t, batch.SetBytes(key, []byte{0xff}))
+	require.NoError(t, state.SetAppliedIndex(batch, 7))
+	require.NoError(t, batch.Commit())
+
+	require.Error(t, idx.processTick(context.Background()))
+	disabled, rebuilding := rs.AuditProjectionState()
+	require.False(t, disabled)
+	require.True(t, rebuilding, "a steady-state fold failure must withdraw readiness")
+	require.ErrorIs(t, rs.WaitForAuditRaftProgress(context.Background(), 7), readstore.ErrAuditProjectionFailed)
+
+	writeAuditEntry(t, mainStore, &auditpb.AuditEntry{
+		Sequence: 1, ProposalId: 1, Timestamp: &commonpb.Timestamp{Data: 1_000_000},
+		Outcome: &auditpb.AuditEntry_Success{Success: &auditpb.AuditSuccess{}},
+		Ledgers: []string{"main"},
+	})
+	require.NoError(t, idx.processTick(context.Background()))
+	disabled, rebuilding = rs.AuditProjectionState()
+	require.False(t, disabled)
+	require.False(t, rebuilding, "the next successful fold must restore readiness without restart")
+	require.NoError(t, rs.WaitForAuditRaftProgress(context.Background(), 7))
+}
+
 // TestProcessOnceHonorsContextCancellation asserts the drain loop checks the
 // context before entries and between batches: with a backlog present and an
 // already-cancelled context, ProcessOnce must abort immediately (returning context.Canceled)

--- a/internal/application/auditindexer/indexer_test.go
+++ b/internal/application/auditindexer/indexer_test.go
@@ -265,7 +265,7 @@ func TestProcessOncePublishesFixedRaftHorizonOnlyWithTerminalBatch(t *testing.T)
 	}
 	setAppliedIndex(t, mainStore, 11)
 
-	handle, err := mainStore.NewDirectReadHandle()
+	handle, err := mainStore.NewReadHandle()
 	require.NoError(t, err)
 	defer func() { _ = handle.Close() }()
 
@@ -276,6 +276,15 @@ func TestProcessOncePublishesFixedRaftHorizonOnlyWithTerminalBatch(t *testing.T)
 	progress, err := rs.ReadAuditRaftProgress()
 	require.NoError(t, err)
 	require.Zero(t, progress, "an intermediate native batch must not certify the target")
+
+	// A later commit must remain outside this ProcessOnce-equivalent snapshot.
+	// Otherwise sustained writes can keep boot in rebuilding indefinitely.
+	writeAuditEntry(t, mainStore, &auditpb.AuditEntry{
+		Sequence: 4, ProposalId: 4, Timestamp: &commonpb.Timestamp{Data: 4_000_000},
+		Outcome: &auditpb.AuditEntry_Success{Success: &auditpb.AuditSuccess{}},
+		Ledgers: []string{"main"},
+	})
+	setAppliedIndex(t, mainStore, 19)
 
 	cursor, advanced, err = idx.processBatch(ctx, handle, cursor, 3, 11)
 	require.NoError(t, err)
@@ -292,6 +301,11 @@ func TestProcessOncePublishesFixedRaftHorizonOnlyWithTerminalBatch(t *testing.T)
 	progress, err = rs.ReadAuditRaftProgress()
 	require.NoError(t, err)
 	require.Equal(t, uint64(11), progress, "the final index writes and certificate commit atomically")
+
+	cursor, advanced, err = idx.processBatch(ctx, handle, cursor, 3, 11)
+	require.NoError(t, err)
+	require.False(t, advanced)
+	require.Equal(t, uint64(3), cursor, "the pinned target must exclude entries committed after capture")
 }
 
 func TestProcessOnceCertifiesAppliedEntryWithoutAuditMovement(t *testing.T) {

--- a/internal/application/auditindexer/indexer_test.go
+++ b/internal/application/auditindexer/indexer_test.go
@@ -179,6 +179,34 @@ func TestBootMarksAlreadyCaughtUpProjectionReady(t *testing.T) {
 	require.False(t, rebuilding, "boot must publish readiness after validating an already caught-up cursor")
 }
 
+func TestBootPublishesFailureThenRecoversReadiness(t *testing.T) {
+	t.Parallel()
+
+	idx, mainStore, rs := newIndexerForTest(t)
+	batch := mainStore.OpenWriteSession()
+	key := dal.NewKeyBuilder().PutZonePrefix(dal.ZoneHistory, dal.SubHistoryAudit).PutUint64(1).Build()
+	require.NoError(t, batch.SetBytes(key, []byte{0xff}))
+	require.NoError(t, state.SetAppliedIndex(batch, 7))
+	require.NoError(t, batch.Commit())
+
+	require.Error(t, idx.boot(context.Background()))
+	disabled, rebuilding := rs.AuditProjectionState()
+	require.False(t, disabled)
+	require.True(t, rebuilding, "a boot fold failure must withdraw readiness")
+	require.ErrorIs(t, rs.WaitForAuditRaftProgress(context.Background(), 7), readstore.ErrAuditProjectionFailed)
+
+	writeAuditEntry(t, mainStore, &auditpb.AuditEntry{
+		Sequence: 1, ProposalId: 1, Timestamp: &commonpb.Timestamp{Data: 1_000_000},
+		Outcome: &auditpb.AuditEntry_Success{Success: &auditpb.AuditSuccess{}},
+		Ledgers: []string{"main"},
+	})
+	require.NoError(t, idx.boot(context.Background()))
+	disabled, rebuilding = rs.AuditProjectionState()
+	require.False(t, disabled)
+	require.False(t, rebuilding, "a later successful boot retry must restore readiness")
+	require.NoError(t, rs.WaitForAuditRaftProgress(context.Background(), 7))
+}
+
 // TestShouldRebuildOnBoot covers the sole retained rebuild trigger: a missing
 // cursor (0) with entries present (fresh index over a populated audit zone).
 // The audit chain is append-only and monotone, so a "cursor ahead of head"

--- a/internal/application/auditindexer/indexer_test.go
+++ b/internal/application/auditindexer/indexer_test.go
@@ -391,8 +391,8 @@ func TestStartStopIndexes(t *testing.T) {
 }
 
 // TestProcessOnceHonorsContextCancellation asserts the drain loop checks the
-// context between batches: with a backlog present and an already-cancelled
-// context, ProcessOnce must abort immediately (returning context.Canceled)
+// context before entries and between batches: with a backlog present and an
+// already-cancelled context, ProcessOnce must abort immediately (returning context.Canceled)
 // instead of draining to completion, so worker.Stop() cannot hang on a large
 // backlog or sustained write stream during shutdown.
 func TestProcessOnceHonorsContextCancellation(t *testing.T) {

--- a/internal/application/check/checker.go
+++ b/internal/application/check/checker.go
@@ -1059,6 +1059,11 @@ func (c *Checker) compareMirrorV2LogID(reader dal.PebbleReader, chainBound *chai
 //   - a row whose key id, max_sequence, applied_index, or created_at diverges from the
 //     audit-derived value — content corruption.
 //
+// restored_from_backup is technical lifecycle provenance, not business intent:
+// restore marks it because physical query-checkpoint directories are deliberately
+// absent. The checker still verifies every audit-derived field above; the marker
+// can only make the local index builder withhold an intermediate certificate.
+//
 // The audit-rebuild path recreates the rows (including max_sequence,
 // created_at, and applied_index)
 // from the logs, so a missing row is corruption, never a legitimate restore

--- a/internal/application/check/checker.go
+++ b/internal/application/check/checker.go
@@ -1056,10 +1056,11 @@ func (c *Checker) compareMirrorV2LogID(reader dal.PebbleReader, chainBound *chai
 //   - a stored row absent from the audit set (never created, or later deleted) —
 //     a phantom or stale row;
 //   - an audit-live checkpoint with no stored row — a lost or dropped projection;
-//   - a row whose key id, max_sequence, or created_at diverges from the
+//   - a row whose key id, max_sequence, applied_index, or created_at diverges from the
 //     audit-derived value — content corruption.
 //
-// The audit-rebuild path recreates the rows (and their max_sequence / created_at)
+// The audit-rebuild path recreates the rows (including max_sequence,
+// created_at, and applied_index)
 // from the logs, so a missing row is corruption, never a legitimate restore
 // artifact. Stored rows are keyed by the Pebble key id, not the payload.
 func (c *Checker) compareQueryCheckpoints(reader dal.PebbleReader, derived map[uint64]*commonpb.CreatedQueryCheckpointLog, callback func(*servicepb.CheckStoreEvent)) error {
@@ -1108,6 +1109,10 @@ func (c *Checker) compareQueryCheckpoints(reader dal.PebbleReader, derived map[u
 
 			if row.GetCreatedAt().GetData() != want.GetCreatedAt().GetData() {
 				emit(fmt.Sprintf("query checkpoint %d created_at %d does not match the audit chain %d", id, row.GetCreatedAt().GetData(), want.GetCreatedAt().GetData()))
+			}
+
+			if row.GetAppliedIndex() != want.GetAppliedIndex() {
+				emit(fmt.Sprintf("query checkpoint %d applied_index %d does not match the audit chain %d", id, row.GetAppliedIndex(), want.GetAppliedIndex()))
 			}
 		}
 	}

--- a/internal/application/check/checker_query_checkpoint_test.go
+++ b/internal/application/check/checker_query_checkpoint_test.go
@@ -16,17 +16,17 @@ import (
 )
 
 // writeQueryCheckpointRow persists a query-checkpoint row (max_sequence = id*10,
-// created_at = id*100) directly at its ZoneGlobal/SubGlobQueryCheckpoint key,
+// created_at = id*100, applied_index = id*1000) directly at its ZoneGlobal/SubGlobQueryCheckpoint key,
 // matching the on-disk layout the FSM writes.
 func writeQueryCheckpointRow(t *testing.T, store *dal.Store, id uint64) {
 	t.Helper()
-	writeQueryCheckpointRowKeyed(t, store, id, id, id*10, id*100)
+	writeQueryCheckpointRowKeyed(t, store, id, id, id*10, id*100, id*1000)
 }
 
 // writeQueryCheckpointRowKeyed persists a row at key keyID carrying a payload
 // with checkpoint_id=payloadID, the given max_sequence and created_at, so tests
 // can build the corrupted key≠payload and content-mismatch cases.
-func writeQueryCheckpointRowKeyed(t *testing.T, store *dal.Store, keyID, payloadID, maxSeq, createdAt uint64) {
+func writeQueryCheckpointRowKeyed(t *testing.T, store *dal.Store, keyID, payloadID, maxSeq, createdAt, appliedIndex uint64) {
 	t.Helper()
 
 	batch := store.OpenWriteSession()
@@ -35,17 +35,19 @@ func writeQueryCheckpointRowKeyed(t *testing.T, store *dal.Store, keyID, payload
 		CheckpointId: payloadID,
 		MaxSequence:  maxSeq,
 		CreatedAt:    &commonpb.Timestamp{Data: createdAt},
+		AppliedIndex: appliedIndex,
 	}))
 	require.NoError(t, batch.Commit())
 }
 
 // derivedLog is the audit-derived value for one checkpoint id (max_sequence =
-// id*10, created_at = id*100), matching writeQueryCheckpointRow.
+// id*10, created_at = id*100, applied_index = id*1000), matching writeQueryCheckpointRow.
 func derivedLog(id uint64) *commonpb.CreatedQueryCheckpointLog {
 	return &commonpb.CreatedQueryCheckpointLog{
 		CheckpointId: id,
 		MaxSequence:  id * 10,
 		CreatedAt:    &commonpb.Timestamp{Data: id * 100},
+		AppliedIndex: id * 1000,
 	}
 }
 
@@ -107,7 +109,7 @@ func TestCompareQueryCheckpoints_KeyAuthoritative(t *testing.T) {
 	t.Parallel()
 
 	store := createTestStore(t)
-	writeQueryCheckpointRowKeyed(t, store, 99, 5, 50, 500)
+	writeQueryCheckpointRowKeyed(t, store, 99, 5, 50, 500, 5000)
 
 	events := collectQueryCheckpointEvents(t, store, map[uint64]*commonpb.CreatedQueryCheckpointLog{5: derivedLog(5)})
 	require.Len(t, events, 2)
@@ -135,11 +137,11 @@ func TestCompareQueryCheckpoints_MaxSequenceMismatch(t *testing.T) {
 	t.Parallel()
 
 	store := createTestStore(t)
-	writeQueryCheckpointRowKeyed(t, store, 5, 5, 50, 500)
+	writeQueryCheckpointRowKeyed(t, store, 5, 5, 50, 500, 5000)
 
 	// Audit says max_sequence 99, store holds 50 (created_at matches).
 	events := collectQueryCheckpointEvents(t, store, map[uint64]*commonpb.CreatedQueryCheckpointLog{
-		5: {CheckpointId: 5, MaxSequence: 99, CreatedAt: &commonpb.Timestamp{Data: 500}},
+		5: {CheckpointId: 5, MaxSequence: 99, CreatedAt: &commonpb.Timestamp{Data: 500}, AppliedIndex: 5000},
 	})
 	require.Len(t, events, 1)
 	require.Contains(t, events[0].GetMessage(), "max_sequence")
@@ -151,14 +153,27 @@ func TestCompareQueryCheckpoints_CreatedAtMismatch(t *testing.T) {
 	t.Parallel()
 
 	store := createTestStore(t)
-	writeQueryCheckpointRowKeyed(t, store, 5, 5, 50, 500)
+	writeQueryCheckpointRowKeyed(t, store, 5, 5, 50, 500, 5000)
 
 	// Audit says created_at 999, store holds 500 (max_sequence matches).
 	events := collectQueryCheckpointEvents(t, store, map[uint64]*commonpb.CreatedQueryCheckpointLog{
-		5: {CheckpointId: 5, MaxSequence: 50, CreatedAt: &commonpb.Timestamp{Data: 999}},
+		5: {CheckpointId: 5, MaxSequence: 50, CreatedAt: &commonpb.Timestamp{Data: 999}, AppliedIndex: 5000},
 	})
 	require.Len(t, events, 1)
 	require.Contains(t, events[0].GetMessage(), "created_at")
+}
+
+func TestCompareQueryCheckpoints_AppliedIndexMismatch(t *testing.T) {
+	t.Parallel()
+
+	store := createTestStore(t)
+	writeQueryCheckpointRowKeyed(t, store, 5, 5, 50, 500, 4999)
+
+	events := collectQueryCheckpointEvents(t, store, map[uint64]*commonpb.CreatedQueryCheckpointLog{
+		5: {CheckpointId: 5, MaxSequence: 50, CreatedAt: &commonpb.Timestamp{Data: 500}, AppliedIndex: 5000},
+	})
+	require.Len(t, events, 1)
+	require.Contains(t, events[0].GetMessage(), "applied_index")
 }
 
 // TestCompareQueryCheckpoints_PayloadIDMismatch: a present row whose payload
@@ -168,7 +183,7 @@ func TestCompareQueryCheckpoints_PayloadIDMismatch(t *testing.T) {
 
 	store := createTestStore(t)
 	// Keyed 5, payload says 6, matching max_sequence and created_at.
-	writeQueryCheckpointRowKeyed(t, store, 5, 6, 50, 500)
+	writeQueryCheckpointRowKeyed(t, store, 5, 6, 50, 500, 5000)
 
 	events := collectQueryCheckpointEvents(t, store, map[uint64]*commonpb.CreatedQueryCheckpointLog{5: derivedLog(5)})
 	require.Len(t, events, 1)

--- a/internal/application/check/checker_test.go
+++ b/internal/application/check/checker_test.go
@@ -503,6 +503,8 @@ func (s *scopeImpl) GetLastAuditHash() []byte { return nil }
 
 func (s *scopeImpl) ForOrder(_, _ []byte) processing.Scope { return s }
 
+func (s *scopeImpl) GetRaftIndex() uint64 { return 0 }
+
 // CheckCoverage is a no-op for the test scopeImpl: there is no coverage
 // to enforce, every read is admitted.
 func (s *scopeImpl) CheckCoverage(_ byte, _ processing.CoverageKey) error { return nil }

--- a/internal/application/ctrl/controller_default.go
+++ b/internal/application/ctrl/controller_default.go
@@ -1689,7 +1689,6 @@ func (ctrl *DefaultController) ListAuditEntriesFrom(ctx context.Context, store *
 	if err != nil {
 		return nil, fmt.Errorf("creating read handle: %w", err)
 	}
-
 	closeHandle := true
 
 	defer func() {
@@ -1712,7 +1711,6 @@ func (ctrl *DefaultController) ListAuditEntriesFrom(ctx context.Context, store *
 	if err != nil {
 		return nil, err
 	}
-
 	if hiSeq > mainAuditSequence {
 		hiSeq = mainAuditSequence
 	}

--- a/internal/application/ctrl/controller_default_audit_horizon_test.go
+++ b/internal/application/ctrl/controller_default_audit_horizon_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/metric/noop"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
@@ -64,5 +66,5 @@ func TestListAuditEntriesTrimsProjectionAheadOfMainSnapshot(t *testing.T) {
 	require.Equal(t, uint64(1), entries[0].GetSequence())
 
 	_, err = ctrl.ListAuditEntriesFrom(context.Background(), store, rs, 10, 0, &commonpb.QueryFilter{}, false)
-	require.Error(t, err, "a malformed filter must fail without leaking its main-store read handle")
+	require.Equal(t, codes.InvalidArgument, status.Code(err), "a malformed filter must fail in audit-filter compilation")
 }

--- a/internal/application/ctrl/controller_default_audit_horizon_test.go
+++ b/internal/application/ctrl/controller_default_audit_horizon_test.go
@@ -41,7 +41,6 @@ func TestListAuditEntriesTrimsProjectionAheadOfMainSnapshot(t *testing.T) {
 	rs, err := readstore.New(t.TempDir(), logger, readstore.DefaultConfig())
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = rs.Close() })
-
 	indexBatch := rs.NewBatch()
 	kb := dal.NewKeyBuilder()
 	require.NoError(t, indexBatch.SetBytes(readstore.AuditIndexStringKey(kb, readstore.AuditFieldLedger, "main", 1), nil))
@@ -54,7 +53,6 @@ func TestListAuditEntriesTrimsProjectionAheadOfMainSnapshot(t *testing.T) {
 			Value: &commonpb.StringCondition_Hardcoded{Hardcoded: "main"},
 		}},
 	}}}
-
 	ctrl := NewDefaultController(nil, store, logger, attributes.New(), rs, nil, meter)
 
 	c, err := ctrl.ListAuditEntriesFrom(context.Background(), store, rs, 10, 0, filter, false)
@@ -64,4 +62,7 @@ func TestListAuditEntriesTrimsProjectionAheadOfMainSnapshot(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, entries, 1, "audit candidates beyond the main-store audit head must be trimmed before materialization")
 	require.Equal(t, uint64(1), entries[0].GetSequence())
+
+	_, err = ctrl.ListAuditEntriesFrom(context.Background(), store, rs, 10, 0, &commonpb.QueryFilter{}, false)
+	require.Error(t, err, "a malformed filter must fail without leaking its main-store read handle")
 }

--- a/internal/application/indexbuilder/builder.go
+++ b/internal/application/indexbuilder/builder.go
@@ -80,6 +80,15 @@ type Builder struct {
 	// AppliedProposal sync for transient-account filtering.
 	lastAppliedProposalSeq uint64
 
+	// projectionTarget is the fixed main-store snapshot horizon currently being
+	// folded. It survives deadline-driven yields so a busy store cannot turn a
+	// multi-batch fold into a chase of the moving head. The target is local
+	// worker state only: after a restart the durable native cursor is resumed and
+	// a new fixed target is captured before any Raft certificate is published.
+	projectionTargetActive       bool
+	projectionTargetSequence     uint64
+	projectionTargetAppliedIndex uint64
+
 	// Reusable scratch objects to reduce allocations in the hot loop.
 	kb       *dal.KeyBuilder
 	wb       *readstore.WriteBatch
@@ -728,25 +737,23 @@ func (b *Builder) loop(ctx context.Context) {
 		case <-ticker.C:
 		}
 
-		// Fast path: skip Pebble iterator + batch commit when the FSM
-		// hasn't advanced past our cursor.
-		logsProcessed := false
-
-		if cached := b.notifications.LastSequence.Load(); cached == 0 || cached > cursor {
-			// When background tasks are active, cap normal processing so they
-			// get their fair share of each tick.
-			var logDeadline time.Time
-			if len(b.backfillTasks) > 0 || len(b.schemaRewriteTasks) > 0 {
-				logDeadline = time.Now().Add(b.backfillBudget)
-			}
-
-			prevCursor := cursor
-			if cursor, err = b.processLogs(ctx, cursor, logDeadline); err != nil {
-				b.logger.Errorf("Error processing logs: %v", err)
-			}
-
-			logsProcessed = cursor > prevCursor
+		// The Raft applied index can advance without the native log sequence
+		// moving (no-op, technical-only, or rejected proposal). processLogs must
+		// therefore sample the main snapshot on every wake/tick; its zero-log
+		// path cheaply publishes the fixed causal horizon when needed.
+		// When background tasks are active, cap normal processing so they
+		// get their fair share of each tick.
+		var logDeadline time.Time
+		if len(b.backfillTasks) > 0 || len(b.schemaRewriteTasks) > 0 {
+			logDeadline = time.Now().Add(b.backfillBudget)
 		}
+
+		prevCursor := cursor
+		if cursor, err = b.processLogs(ctx, cursor, logDeadline); err != nil {
+			b.logger.Errorf("Error processing logs: %v", err)
+		}
+
+		logsProcessed := cursor > prevCursor
 
 		// When processLogs had nothing to do (cluster idle), give backfills
 		// a much larger budget — the full tick interval instead of just 50ms.

--- a/internal/application/indexbuilder/checkpoint_test.go
+++ b/internal/application/indexbuilder/checkpoint_test.go
@@ -47,7 +47,7 @@ func TestCreateReadIndexCheckpointWritesReadyMarker(t *testing.T) {
 	b := newCheckpointTestBuilder(t)
 
 	const cpID = uint64(7)
-	require.NoError(t, b.createReadIndexCheckpoint(cpID))
+	require.NoError(t, b.createReadIndexCheckpoint(cpID, 0))
 
 	dir := b.pebbleStore.QueryCheckpointReadIndexDir(cpID)
 	require.True(t, readstore.CheckpointDirReady(dir), "readiness marker must exist after creation")
@@ -75,7 +75,7 @@ func TestCreateReadIndexCheckpointRebuildsUnmarkedDir(t *testing.T) {
 	require.False(t, readstore.CheckpointDirReady(dir))
 
 	// Recreation must succeed and produce a ready, openable checkpoint.
-	require.NoError(t, b.createReadIndexCheckpoint(cpID))
+	require.NoError(t, b.createReadIndexCheckpoint(cpID, 0))
 	require.True(t, readstore.CheckpointDirReady(dir))
 
 	// The stale file must be gone (directory was rebuilt from scratch).
@@ -96,7 +96,7 @@ func TestCreateReadIndexCheckpointLeavesNoTempDir(t *testing.T) {
 	b := newCheckpointTestBuilder(t)
 
 	const cpID = uint64(13)
-	require.NoError(t, b.createReadIndexCheckpoint(cpID))
+	require.NoError(t, b.createReadIndexCheckpoint(cpID, 0))
 
 	finalDir := b.pebbleStore.QueryCheckpointReadIndexDir(cpID)
 	require.True(t, readstore.CheckpointDirReady(finalDir))
@@ -113,13 +113,13 @@ func TestCreateReadIndexCheckpointNoopWhenReady(t *testing.T) {
 	b := newCheckpointTestBuilder(t)
 
 	const cpID = uint64(17)
-	require.NoError(t, b.createReadIndexCheckpoint(cpID))
+	require.NoError(t, b.createReadIndexCheckpoint(cpID, 0))
 
 	dir := b.pebbleStore.QueryCheckpointReadIndexDir(cpID)
 	// Drop a sentinel; a no-op second call must leave it untouched.
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "sentinel"), nil, 0o640))
 
-	require.NoError(t, b.createReadIndexCheckpoint(cpID))
+	require.NoError(t, b.createReadIndexCheckpoint(cpID, 0))
 
 	_, err := os.Stat(filepath.Join(dir, "sentinel"))
 	require.NoError(t, err, "ready checkpoint must not be rebuilt on a redundant call")
@@ -142,7 +142,7 @@ func TestCreateReadIndexCheckpointClearsStaleTempDir(t *testing.T) {
 	require.NoError(t, os.MkdirAll(tmpDir, 0o750))
 	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, "partial.sst"), []byte("x"), 0o640))
 
-	require.NoError(t, b.createReadIndexCheckpoint(cpID))
+	require.NoError(t, b.createReadIndexCheckpoint(cpID, 0))
 	require.True(t, readstore.CheckpointDirReady(finalDir))
 
 	_, err := os.Stat(tmpDir)
@@ -157,7 +157,7 @@ func TestDeleteReadIndexCheckpoint(t *testing.T) {
 	b := newCheckpointTestBuilder(t)
 
 	const cpID = uint64(23)
-	require.NoError(t, b.createReadIndexCheckpoint(cpID))
+	require.NoError(t, b.createReadIndexCheckpoint(cpID, 0))
 
 	dir := b.pebbleStore.QueryCheckpointReadIndexDir(cpID)
 	require.True(t, readstore.CheckpointDirReady(dir))

--- a/internal/application/indexbuilder/process_logs.go
+++ b/internal/application/indexbuilder/process_logs.go
@@ -111,12 +111,13 @@ func (b *Builder) processLogs(ctx context.Context, cursor uint64, deadline time.
 
 	for cursor < targetSequence {
 		var (
-			batchCount               int
-			lastSeq                  uint64
-			eof                      bool
-			pendingCheckpointCreate  uint64
-			pendingCheckpointHorizon uint64
-			pendingCheckpointDelete  uint64
+			batchCount                int
+			lastSeq                   uint64
+			eof                       bool
+			pendingCheckpointCreate   uint64
+			pendingCheckpointHorizon  uint64
+			pendingCheckpointRestored bool
+			pendingCheckpointDelete   uint64
 		)
 
 		// Create a batch up front so write methods have a valid target.
@@ -179,6 +180,7 @@ func (b *Builder) processLogs(ctx context.Context, cursor uint64, deadline time.
 			// read index at this exact point.
 			if cqc, ok := log.GetPayload().GetType().(*commonpb.LogPayload_CreatedQueryCheckpoint); ok {
 				pendingCheckpointCreate = cqc.CreatedQueryCheckpoint.GetCheckpointId()
+				pendingCheckpointRestored = cqc.CreatedQueryCheckpoint.GetAppliedIndex() > targetAppliedIndex
 				pendingCheckpointHorizon = min(
 					cqc.CreatedQueryCheckpoint.GetAppliedIndex(),
 					targetAppliedIndex,
@@ -267,7 +269,7 @@ func (b *Builder) processLogs(ctx context.Context, cursor uint64, deadline time.
 			certifiedHorizon := uint64(0)
 			if completesTarget {
 				certifiedHorizon = targetAppliedIndex
-			} else if pendingCheckpointHorizon > 0 {
+			} else if pendingCheckpointHorizon > 0 && !pendingCheckpointRestored {
 				certifiedHorizon = pendingCheckpointHorizon
 			}
 			if certifiedHorizon > 0 {

--- a/internal/application/indexbuilder/process_logs.go
+++ b/internal/application/indexbuilder/process_logs.go
@@ -180,11 +180,24 @@ func (b *Builder) processLogs(ctx context.Context, cursor uint64, deadline time.
 			// read index at this exact point.
 			if cqc, ok := log.GetPayload().GetType().(*commonpb.LogPayload_CreatedQueryCheckpoint); ok {
 				pendingCheckpointCreate = cqc.CreatedQueryCheckpoint.GetCheckpointId()
-				pendingCheckpointRestored = cqc.CreatedQueryCheckpoint.GetAppliedIndex() > targetAppliedIndex
-				pendingCheckpointHorizon = min(
-					cqc.CreatedQueryCheckpoint.GetAppliedIndex(),
-					targetAppliedIndex,
-				)
+				checkpointState, err := query.ReadQueryCheckpoint(handle, pendingCheckpointCreate)
+				if err != nil {
+					_ = batch.Cancel()
+
+					return cursor, fmt.Errorf("reading query checkpoint %d restore provenance: %w", pendingCheckpointCreate, err)
+				}
+				// The fixed target snapshot can already contain a later delete. In that
+				// case there is no live checkpoint to certify, so conservatively withhold
+				// an intermediate certificate until the complete target is folded.
+				pendingCheckpointRestored = checkpointState == nil || checkpointState.GetRestoredFromBackup()
+				if pendingCheckpointRestored {
+					// A restored checkpoint's source Raft number has no ordering in the
+					// destination domain. Wait for the fixed destination target, whose
+					// audit certificate covers the complete restored audit head.
+					pendingCheckpointHorizon = targetAppliedIndex
+				} else {
+					pendingCheckpointHorizon = cqc.CreatedQueryCheckpoint.GetAppliedIndex()
+				}
 
 				break
 			}

--- a/internal/application/indexbuilder/process_logs.go
+++ b/internal/application/indexbuilder/process_logs.go
@@ -28,11 +28,14 @@ import (
 //   - Fold logs and buffer their index mutations into WriteBatch. Metadata
 //     replacements and deletes resolve their old encoding through the reverse
 //     map; known-absent transaction inserts skip that lookup.
-//   - If the batch produced writes, append progress to the same Pebble batch
-//     and Flush it atomically.
+//   - Persist the native cursor in the same Pebble batch. Only the batch that
+//     reaches the fixed source snapshot's final native sequence also publishes
+//     that snapshot's Raft applied-index certificate, atomically with its final
+//     projection writes.
 //
-// When a batch produces no index writes, the Pebble batch is skipped
-// entirely. Progress is persisted once at the end, reducing fsyncs to O(1).
+// Native progress for runs that produce no projection writes is coalesced until
+// the end. Raft progress can still advance without native movement when the
+// fixed source snapshot contains only no-op, failed, or technical Raft entries.
 func (b *Builder) processLogs(ctx context.Context, cursor uint64, deadline time.Time) (uint64, error) {
 	defer b.rollbackFoldBatch()
 
@@ -42,6 +45,23 @@ func (b *Builder) processLogs(ctx context.Context, cursor uint64, deadline time.
 	}
 
 	defer func() { _ = handle.Close() }()
+
+	if !b.projectionTargetActive {
+		targetAppliedIndex, err := query.ReadLastAppliedIndex(handle)
+		if err != nil {
+			return cursor, fmt.Errorf("reading target applied index: %w", err)
+		}
+		targetSequence, err := query.ReadLastSequence(handle)
+		if err != nil {
+			return cursor, fmt.Errorf("reading target log sequence: %w", err)
+		}
+
+		b.projectionTargetAppliedIndex = targetAppliedIndex
+		b.projectionTargetSequence = targetSequence
+		b.projectionTargetActive = true
+	}
+	targetAppliedIndex := b.projectionTargetAppliedIndex
+	targetSequence := b.projectionTargetSequence
 
 	// Per-batch schema resolver: memoizes LedgerInfo lookups for the
 	// duration of this processLogs call. Hot-path encode sites read from
@@ -89,21 +109,30 @@ func (b *Builder) processLogs(ctx context.Context, cursor uint64, deadline time.
 		return nil
 	}
 
-	for {
+	for cursor < targetSequence {
 		var (
-			batchCount              int
-			lastSeq                 uint64
-			eof                     bool
-			pendingCheckpointCreate uint64
-			pendingCheckpointDelete uint64
+			batchCount               int
+			lastSeq                  uint64
+			eof                      bool
+			pendingCheckpointCreate  uint64
+			pendingCheckpointHorizon uint64
+			pendingCheckpointDelete  uint64
 		)
 
 		// Create a batch up front so write methods have a valid target.
 		batch := b.readStore.NewBatch()
 		b.initFoldBatch(batch)
 
+		// Native log sequences are contiguous. Bound this batch to the fixed
+		// target so later commits visible through a newly-opened continuation
+		// snapshot cannot pull the target forward between deadline-driven calls.
+		batchLimit := b.batchSize
+		if remaining := targetSequence - cursor; remaining < uint64(batchLimit) {
+			batchLimit = int(remaining)
+		}
+
 		// Iterate logs from Pebble and buffer index writes into the batch.
-		for batchCount < b.batchSize {
+		for batchCount < batchLimit {
 			log, err := logsCursor.Next()
 			if err != nil {
 				if errors.Is(err, io.EOF) {
@@ -150,6 +179,7 @@ func (b *Builder) processLogs(ctx context.Context, cursor uint64, deadline time.
 			// read index at this exact point.
 			if cqc, ok := log.GetPayload().GetType().(*commonpb.LogPayload_CreatedQueryCheckpoint); ok {
 				pendingCheckpointCreate = cqc.CreatedQueryCheckpoint.GetCheckpointId()
+				pendingCheckpointHorizon = cqc.CreatedQueryCheckpoint.GetAppliedIndex()
 
 				break
 			}
@@ -215,7 +245,8 @@ func (b *Builder) processLogs(ctx context.Context, cursor uint64, deadline time.
 
 		// Commit the batch if there are index writes or a checkpoint action pending.
 		hasCheckpointAction := pendingCheckpointCreate > 0 || pendingCheckpointDelete > 0
-		if !b.wb.Empty() || hasCheckpointAction {
+		completesTarget := lastSeq >= targetSequence
+		if !b.wb.Empty() || hasCheckpointAction || completesTarget {
 			// Write progress into the same batch before Flush commits it.
 			if err := b.readStore.WriteProgress(batch, lastSeq); err != nil {
 				_ = batch.Cancel()
@@ -228,6 +259,20 @@ func (b *Builder) processLogs(ctx context.Context, cursor uint64, deadline time.
 				_ = batch.Cancel()
 
 				return cursor, err
+			}
+
+			certifiedHorizon := uint64(0)
+			if completesTarget {
+				certifiedHorizon = targetAppliedIndex
+			} else if pendingCheckpointHorizon > 0 {
+				certifiedHorizon = pendingCheckpointHorizon
+			}
+			if certifiedHorizon > 0 {
+				if err := b.readStore.WriteRaftProgress(batch, certifiedHorizon); err != nil {
+					_ = batch.Cancel()
+
+					return cursor, fmt.Errorf("writing read projection Raft progress: %w", err)
+				}
 			}
 
 			if err := b.flushWriteBatch(); err != nil {
@@ -251,18 +296,48 @@ func (b *Builder) processLogs(ctx context.Context, cursor uint64, deadline time.
 		}
 
 		// Materialize a query checkpoint inline, at the exact moment the builder
-		// crosses the CreatedQueryCheckpoint log — so the live read index
+		// crosses the CreatedQueryCheckpoint log — so the normal read projection
 		// reflects precisely MaxSequence (the checkpoint's point-in-time). The
-		// materialization is atomic (temp dir + fsync + rename + .ready marker
+		// independently maintained audit projection may already be ahead; audit
+		// queries trim its candidates to the main checkpoint's audit sequence.
+		// The materialization is atomic (temp dir + fsync + rename + .ready marker
 		// last), so a reader never observes a partial checkpoint. There is no
-		// reconciler: this inline point is already exactly point-in-time. A
+		// reconciler: this inline point is already exactly point-in-time. A live
+		// audit rebuild is waited through here, and a lifecycle transition during
+		// materialization retries the snapshot under the new ready generation. A
 		// node that crashes between rename and marker will never have a marker
 		// for this checkpoint; the checkpoint stays registered, so reads there
 		// return the retryable ErrCheckpointNotReady (Unavailable) until the
 		// client deletes and recreates it (see openCheckpointStores).
 		if cpID := pendingCheckpointCreate; cpID > 0 {
-			if err := b.createReadIndexCheckpoint(cpID); err != nil {
-				return cursor, err
+			for {
+				err := b.readStore.WaitForAuditRaftProgress(ctx, pendingCheckpointHorizon)
+				if errors.Is(err, readstore.ErrAuditProjectionUnavailable) {
+					b.logger.WithFields(map[string]any{
+						"checkpointID": cpID,
+						"horizon":      pendingCheckpointHorizon,
+						"auditState":   "disabled",
+					}).Infof("Query checkpoint remains unavailable because the audit projection is disabled")
+
+					break
+				}
+				if err != nil {
+					return cursor, fmt.Errorf("waiting for audit projection before query checkpoint %d: %w", cpID, err)
+				}
+
+				_, _, auditGeneration := b.readStore.AuditProjectionStateWithGeneration()
+				if err := b.createReadIndexCheckpoint(cpID, auditGeneration); errors.Is(err, readstore.ErrAuditProjectionUnavailable) {
+					b.logger.WithFields(map[string]any{
+						"checkpointID": cpID,
+						"horizon":      pendingCheckpointHorizon,
+					}).Infof("Audit projection changed during query checkpoint materialization; retrying")
+
+					continue
+				} else if err != nil {
+					return cursor, err
+				}
+
+				break
 			}
 		}
 
@@ -296,6 +371,9 @@ func (b *Builder) processLogs(ctx context.Context, cursor uint64, deadline time.
 		if eof {
 			break
 		}
+		if cursor >= targetSequence {
+			break
+		}
 
 		// Yield to backfills when a deadline is set.
 		if !deadline.IsZero() && time.Now().After(deadline) {
@@ -319,11 +397,42 @@ func (b *Builder) processLogs(ctx context.Context, cursor uint64, deadline time.
 			return cursor, fmt.Errorf("writing applied proposal progress: %w", err)
 		}
 
+		if cursor >= targetSequence {
+			if err := b.readStore.WriteRaftProgress(batch, targetAppliedIndex); err != nil {
+				_ = batch.Cancel()
+
+				return cursor, fmt.Errorf("writing read projection Raft progress: %w", err)
+			}
+		}
+
 		if err := batch.Commit(); err != nil {
 			_ = batch.Cancel()
 
 			return cursor, fmt.Errorf("committing progress: %w", err)
 		}
+	}
+
+	// Raft can advance without producing a system log (no-op, rejected, or
+	// technical-only entries). Publish that fixed snapshot horizon even when
+	// there was no native cursor movement.
+	if cursor >= targetSequence {
+		progress, err := b.readStore.ReadRaftProgress()
+		if err != nil {
+			return cursor, fmt.Errorf("reading read projection Raft progress: %w", err)
+		}
+		if progress < targetAppliedIndex {
+			batch := b.readStore.NewBatch()
+			defer func() { _ = batch.Cancel() }()
+			if err := b.readStore.WriteRaftProgress(batch, targetAppliedIndex); err != nil {
+				return cursor, fmt.Errorf("writing read projection Raft progress: %w", err)
+			}
+			if err := batch.Commit(); err != nil {
+				return cursor, fmt.Errorf("committing read projection Raft progress: %w", err)
+			}
+			b.readStore.NotifyProgress()
+		}
+
+		b.projectionTargetActive = false
 	}
 
 	return cursor, nil
@@ -386,7 +495,7 @@ const checkpointLinkRetries = 5
 // under the final path. Called only from the inline indexing path, at the moment
 // the builder crosses the CreatedQueryCheckpoint log (so the snapshot is exactly
 // MaxSequence). There is no background reconciler.
-func (b *Builder) createReadIndexCheckpoint(checkpointID uint64) (err error) {
+func (b *Builder) createReadIndexCheckpoint(checkpointID, auditGeneration uint64) (err error) {
 	finalDir := b.pebbleStore.QueryCheckpointReadIndexDir(checkpointID)
 
 	// Already materialized on this replica (redundant call). Nothing to do.
@@ -471,8 +580,12 @@ func (b *Builder) createReadIndexCheckpoint(checkpointID uint64) (err error) {
 	// atomically-renamed directory. (tmpDir is already renamed away, so the
 	// deferred cleanup is a no-op if this fails; the markerless finalDir is then
 	// treated as not-ready and rebuilt on the next attempt.)
-	if err = readstore.MarkCheckpointReady(finalDir); err != nil {
+	ready, err := b.readStore.MarkCheckpointReadyAtAuditGeneration(finalDir, auditGeneration)
+	if err != nil {
 		return fmt.Errorf("marking read index checkpoint %d ready: %w", checkpointID, err)
+	}
+	if !ready {
+		return readstore.ErrAuditProjectionUnavailable
 	}
 
 	b.logger.WithFields(map[string]any{

--- a/internal/application/indexbuilder/process_logs.go
+++ b/internal/application/indexbuilder/process_logs.go
@@ -39,7 +39,7 @@ import (
 func (b *Builder) processLogs(ctx context.Context, cursor uint64, deadline time.Time) (uint64, error) {
 	defer b.rollbackFoldBatch()
 
-	handle, err := b.pebbleStore.NewDirectReadHandle()
+	handle, err := b.pebbleStore.NewReadHandle()
 	if err != nil {
 		return cursor, fmt.Errorf("creating read handle for log processing: %w", err)
 	}
@@ -315,12 +315,17 @@ func (b *Builder) processLogs(ctx context.Context, cursor uint64, deadline time.
 		if cpID := pendingCheckpointCreate; cpID > 0 {
 			for {
 				err := b.readStore.WaitForAuditRaftProgress(ctx, pendingCheckpointHorizon)
-				if errors.Is(err, readstore.ErrAuditProjectionUnavailable) {
+				if errors.Is(err, readstore.ErrAuditProjectionUnavailable) ||
+					errors.Is(err, readstore.ErrAuditProjectionFailed) {
+					auditState := "disabled"
+					if errors.Is(err, readstore.ErrAuditProjectionFailed) {
+						auditState = "failed"
+					}
 					b.logger.WithFields(map[string]any{
 						"checkpointID": cpID,
 						"horizon":      pendingCheckpointHorizon,
-						"auditState":   "disabled",
-					}).Infof("Query checkpoint remains unavailable because the audit projection is disabled")
+						"auditState":   auditState,
+					}).Infof("Query checkpoint remains unavailable because the audit projection cannot certify it")
 
 					break
 				}

--- a/internal/application/indexbuilder/process_logs.go
+++ b/internal/application/indexbuilder/process_logs.go
@@ -179,7 +179,10 @@ func (b *Builder) processLogs(ctx context.Context, cursor uint64, deadline time.
 			// read index at this exact point.
 			if cqc, ok := log.GetPayload().GetType().(*commonpb.LogPayload_CreatedQueryCheckpoint); ok {
 				pendingCheckpointCreate = cqc.CreatedQueryCheckpoint.GetCheckpointId()
-				pendingCheckpointHorizon = cqc.CreatedQueryCheckpoint.GetAppliedIndex()
+				pendingCheckpointHorizon = min(
+					cqc.CreatedQueryCheckpoint.GetAppliedIndex(),
+					targetAppliedIndex,
+				)
 
 				break
 			}

--- a/internal/application/indexbuilder/process_logs_progress_test.go
+++ b/internal/application/indexbuilder/process_logs_progress_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/formancehq/ledger/v3/internal/infra/state"
 	"github.com/formancehq/ledger/v3/internal/pkg/signal"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 	"github.com/formancehq/ledger/v3/internal/query"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 	"github.com/formancehq/ledger/v3/internal/storage/readstore"
@@ -28,6 +29,22 @@ func seedLogTarget(t *testing.T, b *Builder, appliedIndex uint64, count int) {
 		require.NoError(t, state.AppendLogs(batch, logs))
 	}
 	require.NoError(t, state.SetAppliedIndex(batch, appliedIndex))
+	require.NoError(t, batch.Commit())
+}
+
+func seedQueryCheckpointState(t *testing.T, b *Builder, checkpointID, appliedIndex uint64, restored bool) {
+	t.Helper()
+
+	batch := b.pebbleStore.OpenWriteSession()
+	key := dal.NewKeyBuilder().
+		PutZonePrefix(dal.ZoneGlobal, dal.SubGlobQueryCheckpoint).
+		PutUint64(checkpointID).
+		Build()
+	require.NoError(t, batch.SetProto(key, &raftcmdpb.QueryCheckpointState{
+		CheckpointId:       checkpointID,
+		AppliedIndex:       appliedIndex,
+		RestoredFromBackup: restored,
+	}))
 	require.NoError(t, batch.Commit())
 }
 
@@ -162,6 +179,7 @@ func TestProcessLogsWaitsForAuditBeforeFreezingQueryCheckpoint(t *testing.T) {
 	}}))
 	require.NoError(t, state.SetAppliedIndex(batch, horizon))
 	require.NoError(t, batch.Commit())
+	seedQueryCheckpointState(t, b, checkpointID, horizon, false)
 
 	type result struct {
 		cursor uint64
@@ -230,6 +248,7 @@ func TestProcessLogsWaitsWhenAuditStartsRebuilding(t *testing.T) {
 	}}))
 	require.NoError(t, state.SetAppliedIndex(batch, horizon))
 	require.NoError(t, batch.Commit())
+	seedQueryCheckpointState(t, b, checkpointID, horizon, false)
 
 	type result struct {
 		cursor uint64
@@ -302,6 +321,7 @@ func TestProcessLogsLeavesCheckpointUnavailableWhenAuditIsDisabled(t *testing.T)
 	}}))
 	require.NoError(t, state.SetAppliedIndex(batch, horizon))
 	require.NoError(t, batch.Commit())
+	seedQueryCheckpointState(t, b, checkpointID, horizon, false)
 
 	cursor, err := b.processLogs(context.Background(), 0, time.Time{})
 	require.NoError(t, err)
@@ -337,6 +357,7 @@ func TestProcessLogsContinuesPastCheckpointWhenAuditFails(t *testing.T) {
 	}))
 	require.NoError(t, state.SetAppliedIndex(batch, horizon))
 	require.NoError(t, batch.Commit())
+	seedQueryCheckpointState(t, b, checkpointID, horizon, false)
 
 	cursor, err := b.processLogs(context.Background(), 0, time.Time{})
 	require.NoError(t, err)
@@ -373,6 +394,7 @@ func TestProcessLogsCertifiesCheckpointHorizonBeforeLaterTarget(t *testing.T) {
 	}))
 	require.NoError(t, state.SetAppliedIndex(batch, targetHorizon))
 	require.NoError(t, batch.Commit())
+	seedQueryCheckpointState(t, b, checkpointID, checkpointHorizon, false)
 
 	auditBatch := b.readStore.NewBatch()
 	require.NoError(t, b.readStore.WriteAuditRaftProgress(auditBatch, checkpointHorizon))
@@ -395,7 +417,7 @@ func TestProcessLogsCertifiesCheckpointHorizonBeforeLaterTarget(t *testing.T) {
 	require.Equal(t, targetHorizon, progress)
 }
 
-func TestProcessLogsClampsRestoredCheckpointHorizonToCurrentRaftDomain(t *testing.T) {
+func TestProcessLogsUsesRestoreProvenanceAfterNewRaftOvertakesSourceCheckpoint(t *testing.T) {
 	t.Parallel()
 
 	b := newTestBuilderWithStore(t)
@@ -403,13 +425,14 @@ func TestProcessLogsClampsRestoredCheckpointHorizonToCurrentRaftDomain(t *testin
 	b.batchSize = 1
 
 	// Incremental restore rebuilds the checkpoint log with its source-cluster
-	// applied index, while the restored main store keeps the full backup's
-	// applied index as the new cluster's genesis boundary. The two numeric Raft
-	// domains are unrelated after restore.
+	// applied index, while the restored node enters a new Raft domain. The new
+	// domain may already have overtaken that numeric source index before the
+	// read-index builder catches up, so numeric ordering cannot identify restore
+	// provenance.
 	const (
 		checkpointID            = uint64(45)
-		restoredTargetHorizon   = uint64(100)
-		sourceCheckpointHorizon = uint64(10_000)
+		sourceCheckpointHorizon = uint64(110)
+		restoredTargetHorizon   = uint64(120)
 	)
 	batch := b.pebbleStore.OpenWriteSession()
 	require.NoError(t, state.AppendLogs(batch, []*commonpb.Log{
@@ -427,6 +450,7 @@ func TestProcessLogsClampsRestoredCheckpointHorizonToCurrentRaftDomain(t *testin
 	}))
 	require.NoError(t, state.SetAppliedIndex(batch, restoredTargetHorizon))
 	require.NoError(t, batch.Commit())
+	seedQueryCheckpointState(t, b, checkpointID, sourceCheckpointHorizon, true)
 
 	auditBatch := b.readStore.NewBatch()
 	require.NoError(t, b.readStore.WriteAuditRaftProgress(auditBatch, restoredTargetHorizon))

--- a/internal/application/indexbuilder/process_logs_progress_test.go
+++ b/internal/application/indexbuilder/process_logs_progress_test.go
@@ -412,16 +412,19 @@ func TestProcessLogsClampsRestoredCheckpointHorizonToCurrentRaftDomain(t *testin
 		sourceCheckpointHorizon = uint64(10_000)
 	)
 	batch := b.pebbleStore.OpenWriteSession()
-	require.NoError(t, state.AppendLogs(batch, []*commonpb.Log{{
-		Sequence: 1,
-		Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_CreatedQueryCheckpoint{
-			CreatedQueryCheckpoint: &commonpb.CreatedQueryCheckpointLog{
-				CheckpointId: checkpointID,
-				MaxSequence:  1,
-				AppliedIndex: sourceCheckpointHorizon,
+	require.NoError(t, state.AppendLogs(batch, []*commonpb.Log{
+		{
+			Sequence: 1,
+			Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_CreatedQueryCheckpoint{
+				CreatedQueryCheckpoint: &commonpb.CreatedQueryCheckpointLog{
+					CheckpointId: checkpointID,
+					MaxSequence:  1,
+					AppliedIndex: sourceCheckpointHorizon,
+				},
 			},
-		}},
-	}}))
+			}},
+		{Sequence: 2},
+	}))
 	require.NoError(t, state.SetAppliedIndex(batch, restoredTargetHorizon))
 	require.NoError(t, batch.Commit())
 
@@ -429,13 +432,22 @@ func TestProcessLogsClampsRestoredCheckpointHorizonToCurrentRaftDomain(t *testin
 	require.NoError(t, b.readStore.WriteAuditRaftProgress(auditBatch, restoredTargetHorizon))
 	require.NoError(t, auditBatch.Commit())
 
-	cursor, err := b.processLogs(context.Background(), 0, time.Time{})
+	cursor, err := b.processLogs(context.Background(), 0, time.Unix(1, 0))
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cursor,
-		"restored indexing must reach the tail without waiting for new-cluster writes")
+		"the restored checkpoint must not wait for new-cluster writes")
 	require.True(t, readstore.CheckpointDirReady(b.pebbleStore.QueryCheckpointReadIndexDir(checkpointID)))
 
 	progress, err := b.readStore.ReadRaftProgress()
+	require.NoError(t, err)
+	require.Zero(t, progress,
+		"crossing a restored checkpoint must not certify later restored logs")
+
+	cursor, err = b.processLogs(context.Background(), cursor, time.Unix(1, 0))
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), cursor,
+		"restored indexing must reach the tail without additional writes")
+	progress, err = b.readStore.ReadRaftProgress()
 	require.NoError(t, err)
 	require.Equal(t, restoredTargetHorizon, progress,
 		"the read projection must never publish a source-cluster Raft index")

--- a/internal/application/indexbuilder/process_logs_progress_test.go
+++ b/internal/application/indexbuilder/process_logs_progress_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/formancehq/ledger/v3/internal/infra/state"
 	"github.com/formancehq/ledger/v3/internal/pkg/signal"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/query"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 	"github.com/formancehq/ledger/v3/internal/storage/readstore"
 )
@@ -61,6 +62,27 @@ func TestProcessLogsRejectsCorruptTargetLog(t *testing.T) {
 
 	_, err := b.processLogs(context.Background(), 0, time.Time{})
 	require.ErrorContains(t, err, "reading target log sequence")
+}
+
+func TestProjectionTargetSnapshotExcludesCommitBetweenReads(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	seedLogTarget(t, b, 9, 0)
+
+	handle, err := b.pebbleStore.NewReadHandle()
+	require.NoError(t, err)
+	defer func() { _ = handle.Close() }()
+
+	appliedIndex, err := query.ReadLastAppliedIndex(handle)
+	require.NoError(t, err)
+	require.Equal(t, uint64(9), appliedIndex)
+
+	seedLogTarget(t, b, 10, 1)
+	sequence, err := query.ReadLastSequence(handle)
+	require.NoError(t, err)
+	require.Zero(t, sequence,
+		"the target sequence read must share the snapshot captured before the concurrent commit")
 }
 
 func TestProcessLogsPublishesRaftHorizonOnlyAfterFinalNativeBatch(t *testing.T) {
@@ -284,6 +306,42 @@ func TestProcessLogsLeavesCheckpointUnavailableWhenAuditIsDisabled(t *testing.T)
 	cursor, err := b.processLogs(context.Background(), 0, time.Time{})
 	require.NoError(t, err)
 	require.Equal(t, uint64(1), cursor)
+	require.False(t, readstore.CheckpointDirReady(b.pebbleStore.QueryCheckpointReadIndexDir(checkpointID)))
+}
+
+func TestProcessLogsContinuesPastCheckpointWhenAuditFails(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	b.notifications = signal.NewNotifications()
+	b.batchSize = 1
+	b.readStore.SetAuditProjectionFailed()
+
+	const (
+		checkpointID = uint64(46)
+		horizon      = uint64(36)
+	)
+	batch := b.pebbleStore.OpenWriteSession()
+	require.NoError(t, state.AppendLogs(batch, []*commonpb.Log{
+		{
+			Sequence: 1,
+			Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_CreatedQueryCheckpoint{
+				CreatedQueryCheckpoint: &commonpb.CreatedQueryCheckpointLog{
+					CheckpointId: checkpointID,
+					MaxSequence:  1,
+					AppliedIndex: horizon,
+				},
+			}},
+		},
+		{Sequence: 2},
+	}))
+	require.NoError(t, state.SetAppliedIndex(batch, horizon))
+	require.NoError(t, batch.Commit())
+
+	cursor, err := b.processLogs(context.Background(), 0, time.Time{})
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), cursor,
+		"a failed audit projection must not park all subsequent normal projection progress")
 	require.False(t, readstore.CheckpointDirReady(b.pebbleStore.QueryCheckpointReadIndexDir(checkpointID)))
 }
 

--- a/internal/application/indexbuilder/process_logs_progress_test.go
+++ b/internal/application/indexbuilder/process_logs_progress_test.go
@@ -336,3 +336,49 @@ func TestProcessLogsCertifiesCheckpointHorizonBeforeLaterTarget(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, targetHorizon, progress)
 }
+
+func TestProcessLogsClampsRestoredCheckpointHorizonToCurrentRaftDomain(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	b.notifications = signal.NewNotifications()
+	b.batchSize = 1
+
+	// Incremental restore rebuilds the checkpoint log with its source-cluster
+	// applied index, while the restored main store keeps the full backup's
+	// applied index as the new cluster's genesis boundary. The two numeric Raft
+	// domains are unrelated after restore.
+	const (
+		checkpointID            = uint64(45)
+		restoredTargetHorizon   = uint64(100)
+		sourceCheckpointHorizon = uint64(10_000)
+	)
+	batch := b.pebbleStore.OpenWriteSession()
+	require.NoError(t, state.AppendLogs(batch, []*commonpb.Log{{
+		Sequence: 1,
+		Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_CreatedQueryCheckpoint{
+			CreatedQueryCheckpoint: &commonpb.CreatedQueryCheckpointLog{
+				CheckpointId: checkpointID,
+				MaxSequence:  1,
+				AppliedIndex: sourceCheckpointHorizon,
+			},
+		}},
+	}}))
+	require.NoError(t, state.SetAppliedIndex(batch, restoredTargetHorizon))
+	require.NoError(t, batch.Commit())
+
+	auditBatch := b.readStore.NewBatch()
+	require.NoError(t, b.readStore.WriteAuditRaftProgress(auditBatch, restoredTargetHorizon))
+	require.NoError(t, auditBatch.Commit())
+
+	cursor, err := b.processLogs(context.Background(), 0, time.Time{})
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), cursor,
+		"restored indexing must reach the tail without waiting for new-cluster writes")
+	require.True(t, readstore.CheckpointDirReady(b.pebbleStore.QueryCheckpointReadIndexDir(checkpointID)))
+
+	progress, err := b.readStore.ReadRaftProgress()
+	require.NoError(t, err)
+	require.Equal(t, restoredTargetHorizon, progress,
+		"the read projection must never publish a source-cluster Raft index")
+}

--- a/internal/application/indexbuilder/process_logs_progress_test.go
+++ b/internal/application/indexbuilder/process_logs_progress_test.go
@@ -1,0 +1,338 @@
+package indexbuilder
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/infra/state"
+	"github.com/formancehq/ledger/v3/internal/pkg/signal"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+func seedLogTarget(t *testing.T, b *Builder, appliedIndex uint64, count int) {
+	t.Helper()
+
+	logs := make([]*commonpb.Log, 0, count)
+	for sequence := 1; sequence <= count; sequence++ {
+		logs = append(logs, &commonpb.Log{Sequence: uint64(sequence)})
+	}
+
+	batch := b.pebbleStore.OpenWriteSession()
+	if len(logs) > 0 {
+		require.NoError(t, state.AppendLogs(batch, logs))
+	}
+	require.NoError(t, state.SetAppliedIndex(batch, appliedIndex))
+	require.NoError(t, batch.Commit())
+}
+
+func TestProcessLogsCertifiesAppliedEntryWithoutLogMovement(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	b.notifications = signal.NewNotifications()
+	b.batchSize = 1
+	seedLogTarget(t, b, 9, 0)
+
+	cursor, err := b.processLogs(context.Background(), 0, time.Time{})
+	require.NoError(t, err)
+	require.Zero(t, cursor)
+
+	progress, err := b.readStore.ReadRaftProgress()
+	require.NoError(t, err)
+	require.Equal(t, uint64(9), progress,
+		"a failed, no-op, or technical-only Raft entry must still advance the projection certificate")
+}
+
+func TestProcessLogsRejectsCorruptTargetLog(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	b.notifications = signal.NewNotifications()
+	batch := b.pebbleStore.OpenWriteSession()
+	key := dal.NewKeyBuilder().PutZonePrefix(dal.ZoneHistory, dal.SubHistoryLog).PutUint64(1).Build()
+	require.NoError(t, batch.SetBytes(key, []byte{0xff}))
+	require.NoError(t, state.SetAppliedIndex(batch, 9))
+	require.NoError(t, batch.Commit())
+
+	_, err := b.processLogs(context.Background(), 0, time.Time{})
+	require.ErrorContains(t, err, "reading target log sequence")
+}
+
+func TestProcessLogsPublishesRaftHorizonOnlyAfterFinalNativeBatch(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	b.notifications = signal.NewNotifications()
+	b.batchSize = 1
+	seedLogTarget(t, b, 23, 3)
+
+	// An expired yield deadline makes each call stop after one batch. This
+	// models a crash/restart boundary without timing or sleeps.
+	cursor, err := b.processLogs(context.Background(), 0, time.Unix(1, 0))
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), cursor)
+	native, err := b.readStore.LastIndexedSequence()
+	require.NoError(t, err)
+	require.Equal(t, cursor, native)
+	progress, err := b.readStore.ReadRaftProgress()
+	require.NoError(t, err)
+	require.Zero(t, progress, "an intermediate native batch must not certify the fixed target")
+
+	// Advance the main store after the target was captured. Continuation calls
+	// must finish the original (H=23, seq=3) target rather than chase this newer
+	// head; the next target is captured only after H=23 is published.
+	batch := b.pebbleStore.OpenWriteSession()
+	require.NoError(t, state.AppendLogs(batch, []*commonpb.Log{{Sequence: 4}}))
+	require.NoError(t, state.SetAppliedIndex(batch, 24))
+	require.NoError(t, batch.Commit())
+
+	// Resume from the durable native cursor, as a restarted builder does.
+	cursor, err = b.processLogs(context.Background(), native, time.Unix(1, 0))
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), cursor)
+	progress, err = b.readStore.ReadRaftProgress()
+	require.NoError(t, err)
+	require.Zero(t, progress, "a crash between batches must leave the target unpublished")
+
+	cursor, err = b.processLogs(context.Background(), cursor, time.Unix(1, 0))
+	require.NoError(t, err)
+	require.Equal(t, uint64(3), cursor)
+	progress, err = b.readStore.ReadRaftProgress()
+	require.NoError(t, err)
+	require.Equal(t, uint64(23), progress,
+		"only the target-completing batch may atomically publish the Raft horizon")
+
+	cursor, err = b.processLogs(context.Background(), cursor, time.Unix(1, 0))
+	require.NoError(t, err)
+	require.Equal(t, uint64(4), cursor)
+	progress, err = b.readStore.ReadRaftProgress()
+	require.NoError(t, err)
+	require.Equal(t, uint64(24), progress,
+		"a later call captures and certifies the head that arrived after the fixed target")
+}
+
+func TestProcessLogsWaitsForAuditBeforeFreezingQueryCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	b.notifications = signal.NewNotifications()
+	b.batchSize = 1
+
+	const (
+		checkpointID = uint64(41)
+		horizon      = uint64(31)
+	)
+	batch := b.pebbleStore.OpenWriteSession()
+	require.NoError(t, state.AppendLogs(batch, []*commonpb.Log{{
+		Sequence: 1,
+		Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_CreatedQueryCheckpoint{
+			CreatedQueryCheckpoint: &commonpb.CreatedQueryCheckpointLog{
+				CheckpointId: checkpointID,
+				MaxSequence:  1,
+				AppliedIndex: horizon,
+			},
+		}},
+	}}))
+	require.NoError(t, state.SetAppliedIndex(batch, horizon))
+	require.NoError(t, batch.Commit())
+
+	type result struct {
+		cursor uint64
+		err    error
+	}
+	done := make(chan result, 1)
+	go func() {
+		cursor, err := b.processLogs(context.Background(), 0, time.Time{})
+		done <- result{cursor: cursor, err: err}
+	}()
+
+	require.Eventually(t, func() bool {
+		progress, err := b.readStore.ReadRaftProgress()
+
+		return err == nil && progress == horizon
+	}, 5*time.Second, 10*time.Millisecond,
+		"the normal projection must reach the checkpoint log before waiting for audit")
+	require.False(t, readstore.CheckpointDirReady(b.pebbleStore.QueryCheckpointReadIndexDir(checkpointID)),
+		"the checkpoint must not be exposed while audit is behind")
+
+	auditBatch := b.readStore.NewBatch()
+	require.NoError(t, b.readStore.WriteAuditRaftProgress(auditBatch, horizon))
+	require.NoError(t, auditBatch.Commit())
+	b.readStore.NotifyProgress()
+
+	select {
+	case got := <-done:
+		require.NoError(t, got.err)
+		require.Equal(t, uint64(1), got.cursor)
+	case <-time.After(5 * time.Second):
+		t.Fatal("processLogs did not resume after audit reached the fixed checkpoint horizon")
+	}
+
+	dir := b.pebbleStore.QueryCheckpointReadIndexDir(checkpointID)
+	require.True(t, readstore.CheckpointDirReady(dir))
+	frozen, err := readstore.OpenReadOnly(dir, noopLogger{})
+	require.NoError(t, err)
+	defer func() { _ = frozen.Close() }()
+	frozenAuditProgress, err := frozen.ReadAuditRaftProgress()
+	require.NoError(t, err)
+	require.Equal(t, horizon, frozenAuditProgress,
+		"the ready checkpoint must contain the audit certificate it promised")
+}
+
+func TestProcessLogsWaitsWhenAuditStartsRebuilding(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	b.notifications = signal.NewNotifications()
+	b.batchSize = 1
+
+	const (
+		checkpointID = uint64(42)
+		horizon      = uint64(32)
+	)
+	batch := b.pebbleStore.OpenWriteSession()
+	require.NoError(t, state.AppendLogs(batch, []*commonpb.Log{{
+		Sequence: 1,
+		Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_CreatedQueryCheckpoint{
+			CreatedQueryCheckpoint: &commonpb.CreatedQueryCheckpointLog{
+				CheckpointId: checkpointID,
+				MaxSequence:  1,
+				AppliedIndex: horizon,
+			},
+		}},
+	}}))
+	require.NoError(t, state.SetAppliedIndex(batch, horizon))
+	require.NoError(t, batch.Commit())
+
+	type result struct {
+		cursor uint64
+		err    error
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan result, 1)
+	go func() {
+		cursor, err := b.processLogs(ctx, 0, time.Time{})
+		done <- result{cursor: cursor, err: err}
+	}()
+
+	require.Eventually(t, func() bool {
+		progress, err := b.readStore.ReadRaftProgress()
+
+		return err == nil && progress == horizon
+	}, 5*time.Second, 10*time.Millisecond)
+	b.readStore.SetAuditProjectionState(false, true)
+	auditBatch := b.readStore.NewBatch()
+	require.NoError(t, b.readStore.WriteAuditRaftProgress(auditBatch, horizon))
+	require.NoError(t, auditBatch.Commit())
+	b.readStore.NotifyProgress()
+
+	require.Never(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, 100*time.Millisecond, 10*time.Millisecond,
+		"processLogs must not abandon a checkpoint while the audit projection rebuilds")
+	require.False(t, readstore.CheckpointDirReady(b.pebbleStore.QueryCheckpointReadIndexDir(checkpointID)),
+		"a rebuilding audit projection must keep the checkpoint unmaterialized")
+
+	b.readStore.SetAuditProjectionState(false, false)
+	select {
+	case got := <-done:
+		require.NoError(t, got.err)
+		require.Equal(t, uint64(1), got.cursor)
+	case <-time.After(5 * time.Second):
+		t.Fatal("processLogs did not resume after the audit projection became ready")
+	}
+	require.True(t, readstore.CheckpointDirReady(b.pebbleStore.QueryCheckpointReadIndexDir(checkpointID)))
+}
+
+func TestProcessLogsLeavesCheckpointUnavailableWhenAuditIsDisabled(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	b.notifications = signal.NewNotifications()
+	b.batchSize = 1
+	b.readStore.SetAuditProjectionState(true, false)
+
+	const (
+		checkpointID = uint64(43)
+		horizon      = uint64(33)
+	)
+	batch := b.pebbleStore.OpenWriteSession()
+	require.NoError(t, state.AppendLogs(batch, []*commonpb.Log{{
+		Sequence: 1,
+		Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_CreatedQueryCheckpoint{
+			CreatedQueryCheckpoint: &commonpb.CreatedQueryCheckpointLog{
+				CheckpointId: checkpointID,
+				MaxSequence:  1,
+				AppliedIndex: horizon,
+			},
+		}},
+	}}))
+	require.NoError(t, state.SetAppliedIndex(batch, horizon))
+	require.NoError(t, batch.Commit())
+
+	cursor, err := b.processLogs(context.Background(), 0, time.Time{})
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), cursor)
+	require.False(t, readstore.CheckpointDirReady(b.pebbleStore.QueryCheckpointReadIndexDir(checkpointID)))
+}
+
+func TestProcessLogsCertifiesCheckpointHorizonBeforeLaterTarget(t *testing.T) {
+	t.Parallel()
+
+	b := newTestBuilderWithStore(t)
+	b.notifications = signal.NewNotifications()
+	b.batchSize = 1
+
+	const (
+		checkpointID      = uint64(44)
+		checkpointHorizon = uint64(34)
+		targetHorizon     = uint64(35)
+	)
+	batch := b.pebbleStore.OpenWriteSession()
+	require.NoError(t, state.AppendLogs(batch, []*commonpb.Log{
+		{
+			Sequence: 1,
+			Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_CreatedQueryCheckpoint{
+				CreatedQueryCheckpoint: &commonpb.CreatedQueryCheckpointLog{
+					CheckpointId: checkpointID,
+					MaxSequence:  1,
+					AppliedIndex: checkpointHorizon,
+				},
+			}},
+		},
+		{Sequence: 2},
+	}))
+	require.NoError(t, state.SetAppliedIndex(batch, targetHorizon))
+	require.NoError(t, batch.Commit())
+
+	auditBatch := b.readStore.NewBatch()
+	require.NoError(t, b.readStore.WriteAuditRaftProgress(auditBatch, checkpointHorizon))
+	require.NoError(t, auditBatch.Commit())
+
+	cursor, err := b.processLogs(context.Background(), 0, time.Unix(1, 0))
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), cursor)
+	progress, err := b.readStore.ReadRaftProgress()
+	require.NoError(t, err)
+	require.Equal(t, checkpointHorizon, progress,
+		"the checkpoint log may certify its own horizon without certifying the later fixed target")
+	require.True(t, readstore.CheckpointDirReady(b.pebbleStore.QueryCheckpointReadIndexDir(checkpointID)))
+
+	cursor, err = b.processLogs(context.Background(), cursor, time.Unix(1, 0))
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), cursor)
+	progress, err = b.readStore.ReadRaftProgress()
+	require.NoError(t, err)
+	require.Equal(t, targetHorizon, progress)
+}

--- a/internal/application/usagebuilder/builder.go
+++ b/internal/application/usagebuilder/builder.go
@@ -207,9 +207,9 @@ func (b *Builder) flushIfDue(now time.Time, cursor uint64) error {
 
 // boot runs once before the tail loop: seed both atomics from the persisted
 // state and drain the reachable backlog with a bigger batch size so the
-// steady-state loop starts already caught up. A cursor-read error aborts the
-// loop (returned to tailworker, which logs and stops); a catch-up error is
-// logged and swallowed so steady-state indexing still starts.
+// steady-state loop starts already caught up. TailWorker retries a cursor-read
+// error before starting steady state; a catch-up error is logged and swallowed
+// so steady-state indexing still starts.
 func (b *Builder) boot(ctx context.Context) error {
 	cursor, err := b.usageStore.ReadProgress()
 	if err != nil {

--- a/internal/bootstrap/module.go
+++ b/internal/bootstrap/module.go
@@ -585,6 +585,7 @@ func Module() fx.Option {
 				ks *keystore.KeyStore,
 				ss *state.SharedState,
 				attrs *attributes.Attributes,
+				rs *readstore.Store,
 				authCfg internalauth.AuthConfig,
 			) ctrl.Admission {
 				var opts []func(*admission.Admission)
@@ -595,6 +596,7 @@ func Module() fx.Option {
 				if authCfg.Enabled {
 					opts = append(opts, admission.WithAuthEnabled())
 				}
+				opts = append(opts, admission.WithAuditProjectionState(rs.AuditProjectionState))
 
 				return admission.NewAdmission(
 					store,

--- a/internal/domain/processing/processor_query_checkpoint.go
+++ b/internal/domain/processing/processor_query_checkpoint.go
@@ -30,6 +30,7 @@ func processCreateQueryCheckpoint(order *raftcmdpb.CreateQueryCheckpointOrder, c
 		CheckpointId: checkpointID,
 		MaxSequence:  s.GetNextSequenceID() - 1,
 		CreatedAt:    s.GetDate().Mutate(),
+		AppliedIndex: s.GetRaftIndex(),
 	}
 
 	s.SaveQueryCheckpoint(cp)
@@ -42,6 +43,7 @@ func processCreateQueryCheckpoint(order *raftcmdpb.CreateQueryCheckpointOrder, c
 				CheckpointId: checkpointID,
 				MaxSequence:  cp.GetMaxSequence(),
 				CreatedAt:    cp.GetCreatedAt(),
+				AppliedIndex: cp.GetAppliedIndex(),
 			},
 		},
 	}, nil

--- a/internal/domain/processing/processor_query_checkpoint_test.go
+++ b/internal/domain/processing/processor_query_checkpoint_test.go
@@ -51,6 +51,7 @@ func TestProcessCreateQueryCheckpoint_UnderLimit(t *testing.T) {
 	mockStore.EXPECT().IncrementNextQueryCheckpointID().Return(uint64(7))
 	mockStore.EXPECT().GetNextSequenceID().Return(uint64(100))
 	mockStore.EXPECT().GetDate().Return(now.AsReader())
+	mockStore.EXPECT().GetRaftIndex().Return(uint64(123))
 	mockStore.EXPECT().SaveQueryCheckpoint(gomock.Any())
 
 	result, procErr := processor.ProcessOrder(createQueryCheckpointOrder(), mockStore)
@@ -61,6 +62,7 @@ func TestProcessCreateQueryCheckpoint_UnderLimit(t *testing.T) {
 	require.Equal(t, uint64(7), createdLog.GetCheckpointId())
 	require.Equal(t, uint64(99), createdLog.GetMaxSequence())
 	require.Equal(t, uint64(42), createdLog.GetCreatedAt().GetData())
+	require.Equal(t, uint64(123), createdLog.GetAppliedIndex())
 }
 
 // At the cap a create is rejected with the typed error carrying the limit; no id
@@ -99,6 +101,7 @@ func TestProcessCreateQueryCheckpoint_UncappedWhenLimitZero(t *testing.T) {
 	mockStore.EXPECT().IncrementNextQueryCheckpointID().Return(uint64(1))
 	mockStore.EXPECT().GetNextSequenceID().Return(uint64(1))
 	mockStore.EXPECT().GetDate().Return(now.AsReader())
+	mockStore.EXPECT().GetRaftIndex().Return(uint64(123))
 	mockStore.EXPECT().SaveQueryCheckpoint(gomock.Any())
 
 	result, procErr := processor.ProcessOrder(createQueryCheckpointOrder(), mockStore)

--- a/internal/domain/processing/skip_safe_scope.go
+++ b/internal/domain/processing/skip_safe_scope.go
@@ -180,6 +180,7 @@ func (s *skipSafeScope) GetLastAuditHash() []byte          { return s.inner.GetL
 func (s *skipSafeScope) GetNextLedgerID() uint32           { return s.inner.GetNextLedgerID() }
 func (s *skipSafeScope) IncrementNextLedgerID() uint32     { return s.inner.IncrementNextLedgerID() }
 func (s *skipSafeScope) GetDate() commonpb.TimestampReader { return s.inner.GetDate() }
+func (s *skipSafeScope) GetRaftIndex() uint64              { return s.inner.GetRaftIndex() }
 
 // ──────────────────────────────────────────────────────────────────────────
 // Numscript library — reads pass through; Put/Set are NOT buffered.

--- a/internal/domain/processing/skip_safe_scope_test.go
+++ b/internal/domain/processing/skip_safe_scope_test.go
@@ -77,6 +77,7 @@ func TestSkipSafeScope_ReadsAndBufferedWritesPassThrough(t *testing.T) {
 	s.parent.EXPECT().GetNextLedgerID().Return(uint32(5)).AnyTimes()
 	s.parent.EXPECT().GetNextQueryCheckpointID().Return(uint64(0)).AnyTimes()
 	s.parent.EXPECT().GetNextAuditSequenceID().Return(uint64(50)).Times(1)
+	s.parent.EXPECT().GetRaftIndex().Return(uint64(123)).Times(1)
 
 	overlay := newOrderOverlayScope(s.parent)
 	trap := newSkipSafeScope(overlay)
@@ -100,6 +101,7 @@ func TestSkipSafeScope_ReadsAndBufferedWritesPassThrough(t *testing.T) {
 	// Non-buffered counter reads (audit seq is monotonic, read-only via
 	// Scope) pass through.
 	require.Equal(t, uint64(50), trap.GetNextAuditSequenceID())
+	require.Equal(t, uint64(123), trap.GetRaftIndex())
 
 	// GetClusterPolicy is a read and passes through.
 	s.parent.EXPECT().GetClusterPolicy().Return(&commonpb.ClusterPolicy{Revision: 3}).Times(1)

--- a/internal/domain/processing/store.go
+++ b/internal/domain/processing/store.go
@@ -90,6 +90,10 @@ type Scope interface {
 	GetNextLedgerID() uint32
 	IncrementNextLedgerID() uint32
 	GetDate() commonpb.TimestampReader
+	// GetRaftIndex returns the committed Raft entry currently being applied.
+	// It is deterministic proposal input and is used to bind derived snapshots
+	// to the same causal horizon as the primary store.
+	GetRaftIndex() uint64
 
 	// Numscript library operations — heterogeneous shapes (string/bool returns,
 	// multi-arg keys). Kept discrete; the Accessor trio does not fit.

--- a/internal/domain/processing/store_generated_test.go
+++ b/internal/domain/processing/store_generated_test.go
@@ -591,6 +591,44 @@ func (c *MockScopeGetNumscriptLatestVersionCall) DoAndReturn(f func(string, stri
 	return c
 }
 
+// GetRaftIndex mocks base method.
+func (m *MockScope) GetRaftIndex() uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRaftIndex")
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// GetRaftIndex indicates an expected call of GetRaftIndex.
+func (mr *MockScopeMockRecorder) GetRaftIndex() *MockScopeGetRaftIndexCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRaftIndex", reflect.TypeOf((*MockScope)(nil).GetRaftIndex))
+	return &MockScopeGetRaftIndexCall{Call: call}
+}
+
+// MockScopeGetRaftIndexCall wrap *gomock.Call
+type MockScopeGetRaftIndexCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockScopeGetRaftIndexCall) Return(arg0 uint64) *MockScopeGetRaftIndexCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockScopeGetRaftIndexCall) Do(f func() uint64) *MockScopeGetRaftIndexCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockScopeGetRaftIndexCall) DoAndReturn(f func() uint64) *MockScopeGetRaftIndexCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
 // GetReverted mocks base method.
 func (m *MockScope) GetReverted(key domain.TransactionKey) (bool, error) {
 	m.ctrl.T.Helper()

--- a/internal/infra/attributes/prepare.go
+++ b/internal/infra/attributes/prepare.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cockroachdb/pebble/v2"
 
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
 
@@ -20,20 +21,22 @@ import (
 // exactly one Pebble entry that Set overwrites in place, so there are no
 // versions to fold. The attribute zone is left byte-for-byte intact.
 //
-// The six resets are:
+// The seven restore preparations are:
 //  1. lastAppliedIndex is preserved as the restored genesis boundary — the
 //     raft index the restored FSM genesis occupies in the new log (see
 //     below); a genesis checkpoint (index 0) gets the fallback boundary 1.
-//  2. persisted config (nodeId, clusterId) deleted, so the backup is portable
+//  2. live query-checkpoint rows marked as restored, because their physical
+//     checkpoint directories are not part of the restored Pebble store.
+//  3. persisted config (nodeId, clusterId) deleted, so the backup is portable
 //     to any cluster.
-//  3. ZoneClusterTransient wiped — in-flight-only tracking (backup jobs) has
+//  4. ZoneClusterTransient wiped — in-flight-only tracking (backup jobs) has
 //     no meaning on the restored cluster.
-//  4. persisted bloom blocks dropped, so the booting node rebuilds the bloom
+//  5. persisted bloom blocks dropped, so the booting node rebuilds the bloom
 //     from a full attribute scan using its own config.
-//  5. persisted Raft peers dropped (EN-1413), so the restored cluster does
+//  6. persisted Raft peers dropped (EN-1413), so the restored cluster does
 //     not dial the source cluster's pods. NewNode reseeds [ZoneGlobal]
 //     [SubGlobPeers] from cfg.Peers + self on the next boot.
-//  6. cache zone (ZoneCache) cleared, so the restored node boots with a cold
+//  7. cache zone (ZoneCache) cleared, so the restored node boots with a cold
 //     cache and re-seeds from the rebuilt attribute zone on first touch.
 //
 // The caller must ensure all in-memory state has been flushed to Pebble before
@@ -94,6 +97,42 @@ func PrepareForBackup(s *dal.Store) error {
 		_ = batch.Cancel()
 
 		return fmt.Errorf("writing genesis boundary: %w", err)
+	}
+
+	// Query-checkpoint metadata survives in the primary Pebble store, but the
+	// physical main/read-index checkpoint directories do not. Mark every live
+	// row before the restored node starts so the asynchronous read-index builder
+	// never interprets a source-cluster applied index as progress in the new Raft
+	// domain. RebuildDelta applies the same marker to post-checkpoint rows.
+	checkpointReader, err := s.NewDirectReadHandle()
+	if err != nil {
+		_ = batch.Cancel()
+
+		return fmt.Errorf("opening query checkpoints for restore preparation: %w", err)
+	}
+	checkpoints, err := dal.CollectZone[*raftcmdpb.QueryCheckpointState](checkpointReader, dal.ZoneGlobal, dal.SubGlobQueryCheckpoint)
+	closeErr := checkpointReader.Close()
+	if err != nil {
+		_ = batch.Cancel()
+
+		return fmt.Errorf("reading query checkpoints for restore preparation: %w", err)
+	}
+	if closeErr != nil {
+		_ = batch.Cancel()
+
+		return fmt.Errorf("closing query checkpoints after restore preparation: %w", closeErr)
+	}
+	for _, checkpoint := range checkpoints {
+		checkpoint.RestoredFromBackup = true
+		key := dal.NewKeyBuilder().
+			PutZonePrefix(dal.ZoneGlobal, dal.SubGlobQueryCheckpoint).
+			PutUint64(checkpoint.GetCheckpointId()).
+			Build()
+		if err := batch.SetProto(key, checkpoint); err != nil {
+			_ = batch.Cancel()
+
+			return fmt.Errorf("marking query checkpoint %d as restored: %w", checkpoint.GetCheckpointId(), err)
+		}
 	}
 
 	// Remove persisted config (nodeId, clusterId) so the backup is portable to any cluster.

--- a/internal/infra/attributes/prepare_test.go
+++ b/internal/infra/attributes/prepare_test.go
@@ -174,6 +174,14 @@ func TestPrepareForBackupResetsGlobalZone(t *testing.T) {
 	require.NoError(t, setAppliedIndex(batch, 200))
 	require.NoError(t, batch.SetBytes([]byte{dal.ZoneGlobal, dal.SubGlobPersistedConfig}, []byte("node+cluster")))
 	require.NoError(t, batch.SetBytes([]byte{dal.ZoneGlobal, dal.SubGlobBloom, 0x00}, []byte("stale-block")))
+	checkpointKey := dal.NewKeyBuilder().
+		PutZonePrefix(dal.ZoneGlobal, dal.SubGlobQueryCheckpoint).
+		PutUint64(7).
+		Build()
+	require.NoError(t, batch.SetProto(checkpointKey, &raftcmdpb.QueryCheckpointState{
+		CheckpointId: 7,
+		AppliedIndex: 190,
+	}))
 	// EN-1413: a peer entry left over from the source cluster — the
 	// restore path must drop these so the booting node does not dial
 	// the wrong pods.
@@ -200,6 +208,12 @@ func TestPrepareForBackupResetsGlobalZone(t *testing.T) {
 	_, _, err = s.Get(append([]byte{dal.ZoneGlobal, dal.SubGlobPeers},
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07))
 	require.ErrorIs(t, err, pebble.ErrNotFound, "persisted Raft peers must be dropped (EN-1413)")
+
+	checkpoint, err := dal.ReadProto[*raftcmdpb.QueryCheckpointState](s, checkpointKey)
+	require.NoError(t, err)
+	require.Equal(t, uint64(190), checkpoint.GetAppliedIndex())
+	require.True(t, checkpoint.GetRestoredFromBackup(),
+		"pre-checkpoint rows must be marked because physical query-checkpoint directories are not restored")
 }
 
 // TestPrepareForBackupGenesisCheckpointFallback asserts a checkpoint taken at

--- a/internal/infra/backup/rebuild.go
+++ b/internal/infra/backup/rebuild.go
@@ -426,7 +426,7 @@ func RebuildDelta(
 			}
 
 		case *commonpb.LogPayload_CreatedQueryCheckpoint:
-			// Rebuild the metadata row (id + max_sequence + created_at) from the log.
+			// Rebuild the metadata row (id + max_sequence + created_at + applied_index) from the log.
 			// The physical checkpoint files cannot be reconstructed from the audit, so a
 			// rebuilt checkpoint reads as Unavailable until an operator deletes it. The
 			// row keeps the projection audit-consistent so the cap and
@@ -436,6 +436,7 @@ func RebuildDelta(
 					CheckpointId: cp.GetCheckpointId(),
 					MaxSequence:  cp.GetMaxSequence(),
 					CreatedAt:    cp.GetCreatedAt(),
+					AppliedIndex: cp.GetAppliedIndex(),
 				}); err != nil {
 					_ = batch.Cancel()
 

--- a/internal/infra/backup/rebuild.go
+++ b/internal/infra/backup/rebuild.go
@@ -426,17 +426,19 @@ func RebuildDelta(
 			}
 
 		case *commonpb.LogPayload_CreatedQueryCheckpoint:
-			// Rebuild the metadata row (id + max_sequence + created_at + applied_index) from the log.
+			// Rebuild the metadata row from the log and mark its restore provenance.
 			// The physical checkpoint files cannot be reconstructed from the audit, so a
-			// rebuilt checkpoint reads as Unavailable until an operator deletes it. The
-			// row keeps the projection audit-consistent so the cap and
-			// compareQueryCheckpoints stay correct after a rebuild.
+			// rebuilt checkpoint reads as Unavailable until an operator deletes it.
+			// restored_from_backup also prevents the read-index builder from treating
+			// the source-cluster applied_index as a certificate in the new Raft domain.
+			// The business fields remain audit-derived so the cap and checker stay correct.
 			if cp := p.CreatedQueryCheckpoint; cp != nil {
 				if err := state.SaveQueryCheckpoint(batch, &raftcmdpb.QueryCheckpointState{
-					CheckpointId: cp.GetCheckpointId(),
-					MaxSequence:  cp.GetMaxSequence(),
-					CreatedAt:    cp.GetCreatedAt(),
-					AppliedIndex: cp.GetAppliedIndex(),
+					CheckpointId:       cp.GetCheckpointId(),
+					MaxSequence:        cp.GetMaxSequence(),
+					CreatedAt:          cp.GetCreatedAt(),
+					AppliedIndex:       cp.GetAppliedIndex(),
+					RestoredFromBackup: true,
 				}); err != nil {
 					_ = batch.Cancel()
 

--- a/internal/infra/backup/rebuild_test.go
+++ b/internal/infra/backup/rebuild_test.go
@@ -510,17 +510,17 @@ func TestRebuildDelta_ReplaysQueryCheckpoint(t *testing.T) {
 
 	store := newRebuildTestStore(t)
 
-	created := func(seq, id, maxSeq, createdAt uint64) *commonpb.Log {
+	created := func(seq, id, maxSeq, createdAt, appliedIndex uint64) *commonpb.Log {
 		return &commonpb.Log{Sequence: seq, Payload: &commonpb.LogPayload{
 			Type: &commonpb.LogPayload_CreatedQueryCheckpoint{CreatedQueryCheckpoint: &commonpb.CreatedQueryCheckpointLog{
-				CheckpointId: id, MaxSequence: maxSeq, CreatedAt: &commonpb.Timestamp{Data: createdAt},
+				CheckpointId: id, MaxSequence: maxSeq, CreatedAt: &commonpb.Timestamp{Data: createdAt}, AppliedIndex: appliedIndex,
 			}},
 		}}
 	}
 
 	batch := store.OpenWriteSession()
-	require.NoError(t, batch.SetProto(coldLogKey(1), created(1, 1, 10, 100)))
-	require.NoError(t, batch.SetProto(coldLogKey(2), created(2, 2, 20, 200)))
+	require.NoError(t, batch.SetProto(coldLogKey(1), created(1, 1, 10, 100, 1000)))
+	require.NoError(t, batch.SetProto(coldLogKey(2), created(2, 2, 20, 200, 2000)))
 	require.NoError(t, batch.SetProto(coldLogKey(3), &commonpb.Log{Sequence: 3, Payload: &commonpb.LogPayload{
 		Type: &commonpb.LogPayload_DeletedQueryCheckpoint{DeletedQueryCheckpoint: &commonpb.DeletedQueryCheckpointLog{CheckpointId: 1}},
 	}}))
@@ -538,6 +538,7 @@ func TestRebuildDelta_ReplaysQueryCheckpoint(t *testing.T) {
 	require.Contains(t, rows, uint64(2))
 	require.Equal(t, uint64(20), rows[2].GetMaxSequence())
 	require.Equal(t, uint64(200), rows[2].GetCreatedAt().GetData())
+	require.Equal(t, uint64(2000), rows[2].GetAppliedIndex())
 
 	// The counter never rewinds: it advances above the highest replayed id (2),
 	// the deleted one included.

--- a/internal/infra/backup/rebuild_test.go
+++ b/internal/infra/backup/rebuild_test.go
@@ -539,6 +539,8 @@ func TestRebuildDelta_ReplaysQueryCheckpoint(t *testing.T) {
 	require.Equal(t, uint64(20), rows[2].GetMaxSequence())
 	require.Equal(t, uint64(200), rows[2].GetCreatedAt().GetData())
 	require.Equal(t, uint64(2000), rows[2].GetAppliedIndex())
+	require.True(t, rows[2].GetRestoredFromBackup(),
+		"a delta-rebuilt checkpoint must retain explicit restore provenance")
 
 	// The counter never rewinds: it advances above the highest replayed id (2),
 	// the deleted one included.

--- a/internal/infra/state/scope.go
+++ b/internal/infra/state/scope.go
@@ -326,6 +326,9 @@ func NewScopeFactory(
 	return g
 }
 
+// GetRaftIndex exposes the fixed committed entry index bound to this proposal.
+func (g *gatedScope) GetRaftIndex() uint64 { return g.raftIndex }
+
 // NewScope reconfigures the scope's coverage for the given bits and
 // returns itself. The previous configuration is overwritten in place;
 // callers must finish using the scope before requesting another one

--- a/internal/infra/state/write_set.go
+++ b/internal/infra/state/write_set.go
@@ -1404,6 +1404,10 @@ func (b *WriteSet) GetDate() commonpb.TimestampReader {
 	return b.Date.AsReader()
 }
 
+// GetRaftIndex returns zero for bare recovery/test scopes. Production apply
+// uses gatedScope, which overrides this with the committed entry index.
+func (b *WriteSet) GetRaftIndex() uint64 { return 0 }
+
 // SetDate updates the proposal date late in the apply cycle. The technical-
 // update phase runs with `proposal.GetDate()` (raw, no HLC advance); when
 // orders follow, applyProposal computes the HLC-advanced effective date and

--- a/internal/infra/state/write_set_test.go
+++ b/internal/infra/state/write_set_test.go
@@ -358,6 +358,7 @@ func TestWriteSetDateAndHash(t *testing.T) {
 	buf, _, _ := newTestBuffer(t)
 
 	require.Equal(t, uint64(1700000000), buf.GetDate().GetData())
+	require.Zero(t, buf.GetRaftIndex(), "a bare recovery scope has no committed Raft entry")
 }
 
 // TestWriteSetResetIsolation verifies that data written during proposal N is

--- a/internal/pkg/tailworker/tailworker.go
+++ b/internal/pkg/tailworker/tailworker.go
@@ -29,8 +29,9 @@ type Config struct {
 	// channel is always selectable and would spin the loop, calling Tick
 	// continuously.
 	Wake <-chan struct{}
-	// Boot runs once before the ticker starts. A non-nil error aborts the
-	// loop (the worker does no further work). Optional.
+	// Boot must complete before the ticker starts. Non-cancellation errors are
+	// retried with bounded exponential backoff so a transient storage failure
+	// cannot permanently kill the worker. Optional.
 	Boot func(context.Context) error
 	// Tick runs once per ticker fire and per Wake signal. A context.Canceled
 	// error is swallowed (expected on shutdown); any other error is logged
@@ -70,11 +71,7 @@ func (t *TailWorker) Stop() {
 
 func (t *TailWorker) loop(ctx context.Context) {
 	if t.cfg.Boot != nil {
-		if err := t.cfg.Boot(ctx); err != nil {
-			if !errors.Is(err, context.Canceled) {
-				t.cfg.Logger.Errorf("%s boot: %v", t.cfg.Name, err)
-			}
-
+		if !t.runBoot(ctx) {
 			return
 		}
 	}
@@ -93,5 +90,36 @@ func (t *TailWorker) loop(ctx context.Context) {
 		if err := t.cfg.Tick(ctx); err != nil && !errors.Is(err, context.Canceled) {
 			t.cfg.Logger.Errorf("%s tick: %v", t.cfg.Name, err)
 		}
+	}
+}
+
+func (t *TailWorker) runBoot(ctx context.Context) bool {
+	const (
+		initialBackoff = 100 * time.Millisecond
+		maxBackoff     = 10 * time.Second
+	)
+
+	backoff := initialBackoff
+	for {
+		err := t.cfg.Boot(ctx)
+		if err == nil {
+			return true
+		}
+		if errors.Is(err, context.Canceled) || ctx.Err() != nil {
+			return false
+		}
+
+		t.cfg.Logger.Errorf("%s boot failed (retrying in %v): %v", t.cfg.Name, backoff, err)
+		timer := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+
+			return false
+		case <-timer.C:
+		}
+		backoff = min(backoff*2, maxBackoff)
 	}
 }

--- a/internal/pkg/tailworker/tailworker_test.go
+++ b/internal/pkg/tailworker/tailworker_test.go
@@ -41,16 +41,23 @@ func TestBootRunsOnceThenTicks(t *testing.T) {
 	require.Equal(t, int32(1), boots.Load(), "Boot must run exactly once")
 }
 
-func TestBootErrorAbortsLoop(t *testing.T) {
+func TestBootErrorRetriesThenTicks(t *testing.T) {
 	t.Parallel()
 
+	var boots atomic.Int32
 	var ticks atomic.Int32
 
 	tw := New(Config{
 		Name:   "test",
 		Logger: testLogger(),
 		Ticker: 5 * time.Millisecond,
-		Boot:   func(context.Context) error { return errors.New("boom") },
+		Boot: func(context.Context) error {
+			if boots.Add(1) == 1 {
+				return errors.New("transient")
+			}
+
+			return nil
+		},
 		Tick: func(context.Context) error {
 			ticks.Add(1)
 
@@ -60,7 +67,40 @@ func TestBootErrorAbortsLoop(t *testing.T) {
 	tw.Start()
 	t.Cleanup(tw.Stop)
 
-	require.Never(t, func() bool { return ticks.Load() > 0 }, 100*time.Millisecond, 10*time.Millisecond)
+	require.Eventually(t, func() bool { return ticks.Load() > 0 }, time.Second, 5*time.Millisecond)
+	require.Equal(t, int32(2), boots.Load(), "Boot must recover without restarting the worker")
+}
+
+func TestStopCancelsBootBackoff(t *testing.T) {
+	t.Parallel()
+
+	booted := make(chan struct{}, 1)
+	tw := New(Config{
+		Name:   "test",
+		Logger: testLogger(),
+		Ticker: time.Hour,
+		Boot: func(context.Context) error {
+			booted <- struct{}{}
+
+			return errors.New("persistent")
+		},
+		Tick: func(context.Context) error { return nil },
+	})
+	tw.Start()
+
+	select {
+	case <-booted:
+	case <-time.After(time.Second):
+		t.Fatal("Boot never ran")
+	}
+
+	done := make(chan struct{})
+	go func() { tw.Stop(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not cancel the boot retry backoff")
+	}
 }
 
 func TestTickCanceledErrorSwallowedOthersContinue(t *testing.T) {

--- a/internal/proto/commonpb/common.pb.go
+++ b/internal/proto/commonpb/common.pb.go
@@ -4697,6 +4697,7 @@ type CreatedQueryCheckpointLog struct {
 	CheckpointId  uint64                 `protobuf:"fixed64,1,opt,name=checkpoint_id,json=checkpointId,proto3" json:"checkpoint_id,omitempty"`
 	MaxSequence   uint64                 `protobuf:"fixed64,2,opt,name=max_sequence,json=maxSequence,proto3" json:"max_sequence,omitempty"`
 	CreatedAt     *Timestamp             `protobuf:"bytes,3,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
+	AppliedIndex  uint64                 `protobuf:"fixed64,4,opt,name=applied_index,json=appliedIndex,proto3" json:"applied_index,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -4750,6 +4751,13 @@ func (x *CreatedQueryCheckpointLog) GetCreatedAt() *Timestamp {
 		return x.CreatedAt
 	}
 	return nil
+}
+
+func (x *CreatedQueryCheckpointLog) GetAppliedIndex() uint64 {
+	if x != nil {
+		return x.AppliedIndex
+	}
+	return 0
 }
 
 // DeletedQueryCheckpointLog records a query checkpoint being deleted.
@@ -12655,12 +12663,13 @@ const file_common_proto_rawDesc = "" +
 	"\tlast_used\x18\x02 \x01(\v2\x11.common.TimestampR\blastUsed\"3\n" +
 	"\x1dSetQueryCheckpointScheduleLog\x12\x12\n" +
 	"\x04cron\x18\x01 \x01(\tR\x04cron\"#\n" +
-	"!DeletedQueryCheckpointScheduleLog\"\x95\x01\n" +
+	"!DeletedQueryCheckpointScheduleLog\"\xba\x01\n" +
 	"\x19CreatedQueryCheckpointLog\x12#\n" +
 	"\rcheckpoint_id\x18\x01 \x01(\x06R\fcheckpointId\x12!\n" +
 	"\fmax_sequence\x18\x02 \x01(\x06R\vmaxSequence\x120\n" +
 	"\n" +
-	"created_at\x18\x03 \x01(\v2\x11.common.TimestampR\tcreatedAt\"@\n" +
+	"created_at\x18\x03 \x01(\v2\x11.common.TimestampR\tcreatedAt\x12#\n" +
+	"\rapplied_index\x18\x04 \x01(\x06R\fappliedIndex\"@\n" +
 	"\x19DeletedQueryCheckpointLog\x12#\n" +
 	"\rcheckpoint_id\x18\x01 \x01(\x06R\fcheckpointId\"\xc6\x03\n" +
 	"\n" +

--- a/internal/proto/commonpb/common_reader.pb.go
+++ b/internal/proto/commonpb/common_reader.pb.go
@@ -4217,6 +4217,7 @@ type CreatedQueryCheckpointLogReader interface {
 	GetCheckpointId() uint64
 	GetMaxSequence() uint64
 	GetCreatedAt() TimestampReader
+	GetAppliedIndex() uint64
 	Mutate() *CreatedQueryCheckpointLog
 }
 
@@ -4236,6 +4237,10 @@ func (r *createdQueryCheckpointLogReadonly) GetCreatedAt() TimestampReader {
 		return nil
 	}
 	return v.AsReader()
+}
+
+func (r *createdQueryCheckpointLogReadonly) GetAppliedIndex() uint64 {
+	return (*CreatedQueryCheckpointLog)(r).GetAppliedIndex()
 }
 
 func (r *createdQueryCheckpointLogReadonly) Mutate() *CreatedQueryCheckpointLog {

--- a/internal/proto/commonpb/common_vtproto.pb.go
+++ b/internal/proto/commonpb/common_vtproto.pb.go
@@ -1404,6 +1404,7 @@ func (m *CreatedQueryCheckpointLog) CloneVT() *CreatedQueryCheckpointLog {
 	r.CheckpointId = m.CheckpointId
 	r.MaxSequence = m.MaxSequence
 	r.CreatedAt = m.CreatedAt.CloneVT()
+	r.AppliedIndex = m.AppliedIndex
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -6637,6 +6638,9 @@ func (this *CreatedQueryCheckpointLog) EqualVT(that *CreatedQueryCheckpointLog) 
 		return false
 	}
 	if !this.CreatedAt.EqualVT(that.CreatedAt) {
+		return false
+	}
+	if this.AppliedIndex != that.AppliedIndex {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -15225,6 +15229,12 @@ func (m *CreatedQueryCheckpointLog) MarshalToSizedBufferVT(dAtA []byte) (int, er
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.AppliedIndex != 0 {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.AppliedIndex))
+		i--
+		dAtA[i] = 0x21
 	}
 	if m.CreatedAt != nil {
 		size, err := m.CreatedAt.MarshalToSizedBufferVT(dAtA[:i])
@@ -23892,6 +23902,9 @@ func (m *CreatedQueryCheckpointLog) SizeVT() (n int) {
 	if m.CreatedAt != nil {
 		l = m.CreatedAt.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	if m.AppliedIndex != 0 {
+		n += 9
 	}
 	n += len(m.unknownFields)
 	return n
@@ -35419,6 +35432,16 @@ func (m *CreatedQueryCheckpointLog) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 4:
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AppliedIndex", wireType)
+			}
+			m.AppliedIndex = 0
+			if (iNdEx + 8) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AppliedIndex = uint64(binary.LittleEndian.Uint64(dAtA[iNdEx:]))
+			iNdEx += 8
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/internal/proto/raftcmdpb/raft_cmd.pb.go
+++ b/internal/proto/raftcmdpb/raft_cmd.pb.go
@@ -1428,8 +1428,9 @@ func (x *DeleteQueryCheckpointOrder) GetCheckpointId() uint64 {
 type QueryCheckpointState struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	CheckpointId  uint64                 `protobuf:"fixed64,1,opt,name=checkpoint_id,json=checkpointId,proto3" json:"checkpoint_id,omitempty"`
-	MaxSequence   uint64                 `protobuf:"fixed64,2,opt,name=max_sequence,json=maxSequence,proto3" json:"max_sequence,omitempty"` // next_sequence - 1 at creation
-	CreatedAt     *commonpb.Timestamp    `protobuf:"bytes,3,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`         // Creation timestamp (from proposal date)
+	MaxSequence   uint64                 `protobuf:"fixed64,2,opt,name=max_sequence,json=maxSequence,proto3" json:"max_sequence,omitempty"`    // next_sequence - 1 at creation
+	CreatedAt     *commonpb.Timestamp    `protobuf:"bytes,3,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`            // Creation timestamp (from proposal date)
+	AppliedIndex  uint64                 `protobuf:"fixed64,4,opt,name=applied_index,json=appliedIndex,proto3" json:"applied_index,omitempty"` // Raft horizon of the checkpoint snapshot
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1483,6 +1484,13 @@ func (x *QueryCheckpointState) GetCreatedAt() *commonpb.Timestamp {
 		return x.CreatedAt
 	}
 	return nil
+}
+
+func (x *QueryCheckpointState) GetAppliedIndex() uint64 {
+	if x != nil {
+		return x.AppliedIndex
+	}
+	return 0
 }
 
 type SetQueryCheckpointScheduleOrder struct {
@@ -5384,12 +5392,13 @@ const file_raft_cmd_proto_rawDesc = "" +
 	"\aversion\x18\x03 \x01(\tR\aversion\"\x1c\n" +
 	"\x1aCreateQueryCheckpointOrder\"A\n" +
 	"\x1aDeleteQueryCheckpointOrder\x12#\n" +
-	"\rcheckpoint_id\x18\x01 \x01(\x06R\fcheckpointId\"\x90\x01\n" +
+	"\rcheckpoint_id\x18\x01 \x01(\x06R\fcheckpointId\"\xb5\x01\n" +
 	"\x14QueryCheckpointState\x12#\n" +
 	"\rcheckpoint_id\x18\x01 \x01(\x06R\fcheckpointId\x12!\n" +
 	"\fmax_sequence\x18\x02 \x01(\x06R\vmaxSequence\x120\n" +
 	"\n" +
-	"created_at\x18\x03 \x01(\v2\x11.common.TimestampR\tcreatedAt\"5\n" +
+	"created_at\x18\x03 \x01(\v2\x11.common.TimestampR\tcreatedAt\x12#\n" +
+	"\rapplied_index\x18\x04 \x01(\x06R\fappliedIndex\"5\n" +
 	"\x1fSetQueryCheckpointScheduleOrder\x12\x12\n" +
 	"\x04cron\x18\x01 \x01(\tR\x04cron\"$\n" +
 	"\"DeleteQueryCheckpointScheduleOrder\"\xc6\x03\n" +

--- a/internal/proto/raftcmdpb/raft_cmd.pb.go
+++ b/internal/proto/raftcmdpb/raft_cmd.pb.go
@@ -1426,13 +1426,14 @@ func (x *DeleteQueryCheckpointOrder) GetCheckpointId() uint64 {
 // QueryCheckpointState stores metadata for a query checkpoint in Pebble.
 // The actual data lives in physical Pebble checkpoint directories.
 type QueryCheckpointState struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	CheckpointId  uint64                 `protobuf:"fixed64,1,opt,name=checkpoint_id,json=checkpointId,proto3" json:"checkpoint_id,omitempty"`
-	MaxSequence   uint64                 `protobuf:"fixed64,2,opt,name=max_sequence,json=maxSequence,proto3" json:"max_sequence,omitempty"`    // next_sequence - 1 at creation
-	CreatedAt     *commonpb.Timestamp    `protobuf:"bytes,3,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`            // Creation timestamp (from proposal date)
-	AppliedIndex  uint64                 `protobuf:"fixed64,4,opt,name=applied_index,json=appliedIndex,proto3" json:"applied_index,omitempty"` // Raft horizon of the checkpoint snapshot
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	CheckpointId       uint64                 `protobuf:"fixed64,1,opt,name=checkpoint_id,json=checkpointId,proto3" json:"checkpoint_id,omitempty"`
+	MaxSequence        uint64                 `protobuf:"fixed64,2,opt,name=max_sequence,json=maxSequence,proto3" json:"max_sequence,omitempty"`                       // next_sequence - 1 at creation
+	CreatedAt          *commonpb.Timestamp    `protobuf:"bytes,3,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`                               // Creation timestamp (from proposal date)
+	AppliedIndex       uint64                 `protobuf:"fixed64,4,opt,name=applied_index,json=appliedIndex,proto3" json:"applied_index,omitempty"`                    // Raft horizon of the checkpoint snapshot
+	RestoredFromBackup bool                   `protobuf:"varint,5,opt,name=restored_from_backup,json=restoredFromBackup,proto3" json:"restored_from_backup,omitempty"` // Technical provenance: physical checkpoint files were not restored
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *QueryCheckpointState) Reset() {
@@ -1491,6 +1492,13 @@ func (x *QueryCheckpointState) GetAppliedIndex() uint64 {
 		return x.AppliedIndex
 	}
 	return 0
+}
+
+func (x *QueryCheckpointState) GetRestoredFromBackup() bool {
+	if x != nil {
+		return x.RestoredFromBackup
+	}
+	return false
 }
 
 type SetQueryCheckpointScheduleOrder struct {
@@ -5392,13 +5400,14 @@ const file_raft_cmd_proto_rawDesc = "" +
 	"\aversion\x18\x03 \x01(\tR\aversion\"\x1c\n" +
 	"\x1aCreateQueryCheckpointOrder\"A\n" +
 	"\x1aDeleteQueryCheckpointOrder\x12#\n" +
-	"\rcheckpoint_id\x18\x01 \x01(\x06R\fcheckpointId\"\xb5\x01\n" +
+	"\rcheckpoint_id\x18\x01 \x01(\x06R\fcheckpointId\"\xe7\x01\n" +
 	"\x14QueryCheckpointState\x12#\n" +
 	"\rcheckpoint_id\x18\x01 \x01(\x06R\fcheckpointId\x12!\n" +
 	"\fmax_sequence\x18\x02 \x01(\x06R\vmaxSequence\x120\n" +
 	"\n" +
 	"created_at\x18\x03 \x01(\v2\x11.common.TimestampR\tcreatedAt\x12#\n" +
-	"\rapplied_index\x18\x04 \x01(\x06R\fappliedIndex\"5\n" +
+	"\rapplied_index\x18\x04 \x01(\x06R\fappliedIndex\x120\n" +
+	"\x14restored_from_backup\x18\x05 \x01(\bR\x12restoredFromBackup\"5\n" +
 	"\x1fSetQueryCheckpointScheduleOrder\x12\x12\n" +
 	"\x04cron\x18\x01 \x01(\tR\x04cron\"$\n" +
 	"\"DeleteQueryCheckpointScheduleOrder\"\xc6\x03\n" +

--- a/internal/proto/raftcmdpb/raft_cmd_reader.pb.go
+++ b/internal/proto/raftcmdpb/raft_cmd_reader.pb.go
@@ -1218,6 +1218,7 @@ type QueryCheckpointStateReader interface {
 	GetCheckpointId() uint64
 	GetMaxSequence() uint64
 	GetCreatedAt() commonpb.TimestampReader
+	GetAppliedIndex() uint64
 	Mutate() *QueryCheckpointState
 }
 
@@ -1237,6 +1238,10 @@ func (r *queryCheckpointStateReadonly) GetCreatedAt() commonpb.TimestampReader {
 		return nil
 	}
 	return v.AsReader()
+}
+
+func (r *queryCheckpointStateReadonly) GetAppliedIndex() uint64 {
+	return (*QueryCheckpointState)(r).GetAppliedIndex()
 }
 
 func (r *queryCheckpointStateReadonly) Mutate() *QueryCheckpointState {

--- a/internal/proto/raftcmdpb/raft_cmd_reader.pb.go
+++ b/internal/proto/raftcmdpb/raft_cmd_reader.pb.go
@@ -1219,6 +1219,7 @@ type QueryCheckpointStateReader interface {
 	GetMaxSequence() uint64
 	GetCreatedAt() commonpb.TimestampReader
 	GetAppliedIndex() uint64
+	GetRestoredFromBackup() bool
 	Mutate() *QueryCheckpointState
 }
 
@@ -1242,6 +1243,10 @@ func (r *queryCheckpointStateReadonly) GetCreatedAt() commonpb.TimestampReader {
 
 func (r *queryCheckpointStateReadonly) GetAppliedIndex() uint64 {
 	return (*QueryCheckpointState)(r).GetAppliedIndex()
+}
+
+func (r *queryCheckpointStateReadonly) GetRestoredFromBackup() bool {
+	return (*QueryCheckpointState)(r).GetRestoredFromBackup()
 }
 
 func (r *queryCheckpointStateReadonly) Mutate() *QueryCheckpointState {

--- a/internal/proto/raftcmdpb/raft_cmd_vtproto.pb.go
+++ b/internal/proto/raftcmdpb/raft_cmd_vtproto.pb.go
@@ -567,6 +567,7 @@ func (m *QueryCheckpointState) CloneVT() *QueryCheckpointState {
 	r.CheckpointId = m.CheckpointId
 	r.MaxSequence = m.MaxSequence
 	r.CreatedAt = m.CreatedAt.CloneVT()
+	r.AppliedIndex = m.AppliedIndex
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -3027,6 +3028,9 @@ func (this *QueryCheckpointState) EqualVT(that *QueryCheckpointState) bool {
 		return false
 	}
 	if !this.CreatedAt.EqualVT(that.CreatedAt) {
+		return false
+	}
+	if this.AppliedIndex != that.AppliedIndex {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -6744,6 +6748,12 @@ func (m *QueryCheckpointState) MarshalToSizedBufferVT(dAtA []byte) (int, error) 
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.AppliedIndex != 0 {
+		i -= 8
+		binary.LittleEndian.PutUint64(dAtA[i:], uint64(m.AppliedIndex))
+		i--
+		dAtA[i] = 0x21
 	}
 	if m.CreatedAt != nil {
 		size, err := m.CreatedAt.MarshalToSizedBufferVT(dAtA[:i])
@@ -11145,6 +11155,9 @@ func (m *QueryCheckpointState) SizeVT() (n int) {
 		l = m.CreatedAt.SizeVT()
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
+	if m.AppliedIndex != 0 {
+		n += 9
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -15322,6 +15335,16 @@ func (m *QueryCheckpointState) UnmarshalVT(dAtA []byte) error {
 				return err
 			}
 			iNdEx = postIndex
+		case 4:
+			if wireType != 1 {
+				return fmt.Errorf("proto: wrong wireType = %d for field AppliedIndex", wireType)
+			}
+			m.AppliedIndex = 0
+			if (iNdEx + 8) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.AppliedIndex = uint64(binary.LittleEndian.Uint64(dAtA[iNdEx:]))
+			iNdEx += 8
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/internal/proto/raftcmdpb/raft_cmd_vtproto.pb.go
+++ b/internal/proto/raftcmdpb/raft_cmd_vtproto.pb.go
@@ -568,6 +568,7 @@ func (m *QueryCheckpointState) CloneVT() *QueryCheckpointState {
 	r.MaxSequence = m.MaxSequence
 	r.CreatedAt = m.CreatedAt.CloneVT()
 	r.AppliedIndex = m.AppliedIndex
+	r.RestoredFromBackup = m.RestoredFromBackup
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -3031,6 +3032,9 @@ func (this *QueryCheckpointState) EqualVT(that *QueryCheckpointState) bool {
 		return false
 	}
 	if this.AppliedIndex != that.AppliedIndex {
+		return false
+	}
+	if this.RestoredFromBackup != that.RestoredFromBackup {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -6748,6 +6752,16 @@ func (m *QueryCheckpointState) MarshalToSizedBufferVT(dAtA []byte) (int, error) 
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.RestoredFromBackup {
+		i--
+		if m.RestoredFromBackup {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x28
 	}
 	if m.AppliedIndex != 0 {
 		i -= 8
@@ -11158,6 +11172,9 @@ func (m *QueryCheckpointState) SizeVT() (n int) {
 	if m.AppliedIndex != 0 {
 		n += 9
 	}
+	if m.RestoredFromBackup {
+		n += 2
+	}
 	n += len(m.unknownFields)
 	return n
 }
@@ -15345,6 +15362,26 @@ func (m *QueryCheckpointState) UnmarshalVT(dAtA []byte) error {
 			}
 			m.AppliedIndex = uint64(binary.LittleEndian.Uint64(dAtA[iNdEx:]))
 			iNdEx += 8
+		case 5:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field RestoredFromBackup", wireType)
+			}
+			var v int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				v |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			m.RestoredFromBackup = bool(v != 0)
 		default:
 			iNdEx = preIndex
 			skippy, err := protohelpers.Skip(dAtA[iNdEx:])

--- a/internal/storage/readstore/audit_index.go
+++ b/internal/storage/readstore/audit_index.go
@@ -3,6 +3,7 @@ package readstore
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"slices"
 
@@ -10,6 +11,12 @@ import (
 
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
+
+// ErrAuditProjectionUnavailable reports that an audit progress wait cannot
+// complete because the local projection is disabled. Rebuilding is transient:
+// waiters remain parked until the projection is ready again and has certified
+// their horizon.
+var ErrAuditProjectionUnavailable = errors.New("audit projection unavailable")
 
 // ReadAuditProgress returns the last indexed audit sequence (0 if unset).
 func (s *Store) ReadAuditProgress() (uint64, error) {
@@ -84,6 +91,64 @@ func (s *Store) WriteAuditProgress(batch *dal.WriteSession, sequence uint64) err
 	return auditCursor.Write(batch, sequence)
 }
 
+// ReadAuditRaftProgress returns the fixed Raft horizon certified by the audit
+// projection. It does not replace the native audit cursor used for folding.
+func (s *Store) ReadAuditRaftProgress() (uint64, error) {
+	return auditRaftCursor.Read(s.db)
+}
+
+// ReadAuditRaftProgressFrom is the snapshot-aware certificate read.
+func (s *Store) ReadAuditRaftProgressFrom(reader dal.PebbleGetter) (uint64, error) {
+	return auditRaftCursor.Read(reader)
+}
+
+// WriteAuditRaftProgress publishes the audit causal certificate atomically
+// with the final native batch for the target horizon.
+func (s *Store) WriteAuditRaftProgress(batch *dal.WriteSession, appliedIndex uint64) error {
+	return auditRaftCursor.Write(batch, appliedIndex)
+}
+
+// WaitForAuditRaftProgress blocks until the audit projection has certified H.
+func (s *Store) WaitForAuditRaftProgress(ctx context.Context, horizon uint64) error {
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.progressMu.Lock()
+			s.progressCond.Broadcast()
+			s.progressMu.Unlock()
+		case <-done:
+		}
+	}()
+
+	s.progressMu.Lock()
+	defer s.progressMu.Unlock()
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if s.auditDisabled {
+			return ErrAuditProjectionUnavailable
+		}
+		if s.auditRebuilding {
+			s.progressCond.Wait()
+
+			continue
+		}
+
+		progress, err := s.ReadAuditRaftProgress()
+		if err != nil {
+			return fmt.Errorf("reading audit projection Raft progress: %w", err)
+		}
+		if progress >= horizon {
+			return nil
+		}
+
+		s.progressCond.Wait()
+	}
+}
+
 // DropAuditIndexInBatch stages deletion of every audit-index key (but NOT the
 // cursor) into batch so a rebuild can repopulate from scratch. The caller owns
 // the commit, allowing the drop to be made atomic with a cursor reset.
@@ -142,8 +207,8 @@ func prefixUpperBound(prefix []byte) []byte {
 // for "alice" would also match a value indexed as "alice\x00evil" (whose key
 // shares the prefix). Fixed-width fields (uint64, byte) pass exactLen=0 since
 // their value segment cannot be a prefix of a longer value.
-func (s *Store) auditSeqsForPrefix(lower, upper []byte, exactLen int) ([]uint64, error) {
-	iter, err := s.db.NewIter(&pebble.IterOptions{LowerBound: lower, UpperBound: upper})
+func auditSeqsForPrefix(reader dal.PebbleReader, lower, upper []byte, exactLen int) ([]uint64, error) {
+	iter, err := reader.NewIter(&pebble.IterOptions{LowerBound: lower, UpperBound: upper})
 	if err != nil {
 		return nil, fmt.Errorf("creating audit index iterator: %w", err)
 	}
@@ -179,6 +244,15 @@ func (s *Store) auditSeqsForPrefix(lower, upper []byte, exactLen int) ([]uint64,
 	return seqs, nil
 }
 
+// AuditIndexSnapshot binds audit lookups to one readstore snapshot. Filter
+// compilation and its Raft certificate must use the same instance.
+type AuditIndexSnapshot struct{ reader dal.PebbleReader }
+
+// NewAuditIndexSnapshot returns the audit lookup surface for a pinned reader.
+func NewAuditIndexSnapshot(reader dal.PebbleReader) *AuditIndexSnapshot {
+	return &AuditIndexSnapshot{reader: reader}
+}
+
 // AuditSeqsByString returns audit sequences indexed under a string field for an
 // exact value (equality match).
 //
@@ -189,6 +263,14 @@ func (s *Store) auditSeqsForPrefix(lower, upper []byte, exactLen int) ([]uint64,
 // rejects any key longer than a single [prefix][seq] entry, so only the true
 // equality matches survive.
 func (s *Store) AuditSeqsByString(field byte, value string) ([]uint64, error) {
+	return auditSeqsByString(s.db, field, value)
+}
+
+func (s *AuditIndexSnapshot) AuditSeqsByString(field byte, value string) ([]uint64, error) {
+	return auditSeqsByString(s.reader, field, value)
+}
+
+func auditSeqsByString(reader dal.PebbleReader, field byte, value string) ([]uint64, error) {
 	kb := dal.NewKeyBuilder()
 	lower := kb.Reset().
 		PutByte(PrefixInternal).
@@ -197,11 +279,19 @@ func (s *Store) AuditSeqsByString(field byte, value string) ([]uint64, error) {
 		PutStringNull(value).
 		Build()
 
-	return s.auditSeqsForPrefix(lower, prefixUpperBound(lower), len(lower)+8)
+	return auditSeqsForPrefix(reader, lower, prefixUpperBound(lower), len(lower)+8)
 }
 
 // AuditSeqsByOutcome returns audit sequences for success (true) or failure (false).
 func (s *Store) AuditSeqsByOutcome(success bool) ([]uint64, error) {
+	return auditSeqsByOutcome(s.db, success)
+}
+
+func (s *AuditIndexSnapshot) AuditSeqsByOutcome(success bool) ([]uint64, error) {
+	return auditSeqsByOutcome(s.reader, success)
+}
+
+func auditSeqsByOutcome(reader dal.PebbleReader, success bool) ([]uint64, error) {
 	var b byte
 	if success {
 		b = 1
@@ -214,12 +304,20 @@ func (s *Store) AuditSeqsByOutcome(success bool) ([]uint64, error) {
 		PutByte(b).
 		Build()
 
-	return s.auditSeqsForPrefix(lower, prefixUpperBound(lower), 0)
+	return auditSeqsForPrefix(reader, lower, prefixUpperBound(lower), 0)
 }
 
 // AuditSeqsByUint64Range returns audit sequences for a numeric field whose value
 // falls in [lo, hi] inclusive.
 func (s *Store) AuditSeqsByUint64Range(field byte, lo, hi uint64) ([]uint64, error) {
+	return auditSeqsByUint64Range(s.db, field, lo, hi)
+}
+
+func (s *AuditIndexSnapshot) AuditSeqsByUint64Range(field byte, lo, hi uint64) ([]uint64, error) {
+	return auditSeqsByUint64Range(s.reader, field, lo, hi)
+}
+
+func auditSeqsByUint64Range(reader dal.PebbleReader, field byte, lo, hi uint64) ([]uint64, error) {
 	kb := dal.NewKeyBuilder()
 	lower := kb.Reset().
 		PutByte(PrefixInternal).
@@ -246,5 +344,5 @@ func (s *Store) AuditSeqsByUint64Range(field byte, lo, hi uint64) ([]uint64, err
 			Build()
 	}
 
-	return s.auditSeqsForPrefix(lower, upper, 0)
+	return auditSeqsForPrefix(reader, lower, upper, 0)
 }

--- a/internal/storage/readstore/audit_index.go
+++ b/internal/storage/readstore/audit_index.go
@@ -18,6 +18,11 @@ import (
 // their horizon.
 var ErrAuditProjectionUnavailable = errors.New("audit projection unavailable")
 
+// ErrAuditProjectionFailed reports a steady-state local audit indexing error.
+// The worker keeps retrying, but an in-flight checkpoint must remain
+// unavailable and release the normal indexer rather than blocking its tail.
+var ErrAuditProjectionFailed = errors.New("audit projection failed")
+
 // ReadAuditProgress returns the last indexed audit sequence (0 if unset).
 func (s *Store) ReadAuditProgress() (uint64, error) {
 	return auditCursor.Read(s.db)
@@ -130,6 +135,9 @@ func (s *Store) WaitForAuditRaftProgress(ctx context.Context, horizon uint64) er
 		}
 		if s.auditDisabled {
 			return ErrAuditProjectionUnavailable
+		}
+		if s.auditFailed {
+			return ErrAuditProjectionFailed
 		}
 		if s.auditRebuilding {
 			s.progressCond.Wait()

--- a/internal/storage/readstore/checkpoint_marker_test.go
+++ b/internal/storage/readstore/checkpoint_marker_test.go
@@ -47,6 +47,28 @@ func TestCreateCheckpointThenMarkIsOpenable(t *testing.T) {
 	require.NoError(t, ro.Close())
 }
 
+func TestCheckpointMarkerRequiresStableAuditGeneration(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	dir := t.TempDir()
+	_, _, generation := s.AuditProjectionStateWithGeneration()
+
+	s.SetAuditProjectionState(false, true)
+	ready, err := s.MarkCheckpointReadyAtAuditGeneration(dir, generation)
+	require.NoError(t, err)
+	require.False(t, ready)
+	require.False(t, CheckpointDirReady(dir),
+		"a rebuild that starts during materialization must keep the checkpoint unavailable")
+
+	s.SetAuditProjectionState(false, false)
+	_, _, generation = s.AuditProjectionStateWithGeneration()
+	ready, err = s.MarkCheckpointReadyAtAuditGeneration(dir, generation)
+	require.NoError(t, err)
+	require.True(t, ready)
+	require.True(t, CheckpointDirReady(dir))
+}
+
 // TestCreateCheckpointFailsIfDirExists documents the pebble contract the index
 // builder relies on: CreateCheckpoint errors when the destination already
 // exists, so the atomic materialization builds into a temp dir and renames.

--- a/internal/storage/readstore/cursor.go
+++ b/internal/storage/readstore/cursor.go
@@ -52,4 +52,6 @@ var (
 	progressCursor        = Uint64Cursor{key: ProgressKey()}
 	appliedProposalCursor = Uint64Cursor{key: AppliedProposalProgressKey()}
 	auditCursor           = Uint64Cursor{key: AuditProgressKey()}
+	readRaftCursor        = Uint64Cursor{key: ReadRaftProgressKey()}
+	auditRaftCursor       = Uint64Cursor{key: AuditRaftProgressKey()}
 )

--- a/internal/storage/readstore/keys.go
+++ b/internal/storage/readstore/keys.go
@@ -44,6 +44,12 @@ const (
 	// SubInternalAuditProgress holds the per-replica audit indexing cursor.
 	// Layout: [PrefixInternal][SubInternalAuditProgress] -> last_indexed_audit_sequence BE8.
 	SubInternalAuditProgress byte = 0x06
+	// SubInternalReadRaftProgress certifies that the normal read projection has
+	// folded every native log visible at the associated Raft applied index.
+	SubInternalReadRaftProgress byte = 0x07
+	// SubInternalAuditRaftProgress is the equivalent causal certificate for
+	// the audit secondary index. It is independent from the native audit cursor.
+	SubInternalAuditRaftProgress byte = 0x08
 )
 
 // AuditField discriminates the indexed field within the audit-index keyspace.
@@ -645,6 +651,16 @@ func AppliedProposalProgressKey() []byte {
 //	[0xFE][0x06]
 func AuditProgressKey() []byte {
 	return []byte{PrefixInternal, SubInternalAuditProgress}
+}
+
+// ReadRaftProgressKey returns the causal progress key for the normal indexes.
+func ReadRaftProgressKey() []byte {
+	return []byte{PrefixInternal, SubInternalReadRaftProgress}
+}
+
+// AuditRaftProgressKey returns the causal progress key for the audit index.
+func AuditRaftProgressKey() []byte {
+	return []byte{PrefixInternal, SubInternalAuditRaftProgress}
 }
 
 // AuditIndexPrefix returns the global prefix for the whole audit index,

--- a/internal/storage/readstore/raft_progress_test.go
+++ b/internal/storage/readstore/raft_progress_test.go
@@ -107,11 +107,19 @@ func TestAuditRaftProgressWaitsThroughRebuildAndRejectsDisabled(t *testing.T) {
 	require.NoError(t, s.WaitForAuditRaftProgress(t.Context(), 1),
 		"the waiter may consume the certificate only after the projection becomes ready")
 
+	s.SetAuditProjectionFailed()
+	disabled, rebuilding, generation = s.AuditProjectionStateWithGeneration()
+	require.False(t, disabled)
+	require.True(t, rebuilding, "admission treats a failed projection as transiently unavailable")
+	require.Equal(t, uint64(3), generation)
+	require.ErrorIs(t, s.WaitForAuditRaftProgress(context.Background(), 1), ErrAuditProjectionFailed,
+		"an in-flight checkpoint must release the normal indexer on a steady-state failure")
+
 	s.SetAuditProjectionState(true, false)
 	disabled, rebuilding, generation = s.AuditProjectionStateWithGeneration()
 	require.True(t, disabled)
 	require.False(t, rebuilding)
-	require.Equal(t, uint64(3), generation)
+	require.Equal(t, uint64(4), generation)
 	require.ErrorIs(t, s.WaitForAuditRaftProgress(context.Background(), 1), ErrAuditProjectionUnavailable)
 }
 

--- a/internal/storage/readstore/raft_progress_test.go
+++ b/internal/storage/readstore/raft_progress_test.go
@@ -1,0 +1,218 @@
+package readstore
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+func TestProjectionRaftProgressRoundTripAndSnapshot(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	before := s.NewSnapshot()
+	t.Cleanup(func() { _ = before.Close() })
+
+	batch := s.NewBatch()
+	require.NoError(t, s.WriteProgress(batch, 5))
+	require.NoError(t, s.WriteRaftProgress(batch, 12))
+	require.NoError(t, s.WriteAuditProgress(batch, 6))
+	require.NoError(t, s.WriteAuditRaftProgress(batch, 12))
+	require.NoError(t, batch.Commit())
+
+	readProgress, err := s.ReadRaftProgress()
+	require.NoError(t, err)
+	require.Equal(t, uint64(12), readProgress)
+	auditProgress, err := s.ReadAuditRaftProgress()
+	require.NoError(t, err)
+	require.Equal(t, uint64(12), auditProgress)
+
+	readProgress, err = s.ReadRaftProgressFrom(before)
+	require.NoError(t, err)
+	require.Zero(t, readProgress, "a snapshot predating publication must not observe the certificate")
+	auditProgress, err = s.ReadAuditRaftProgressFrom(before)
+	require.NoError(t, err)
+	require.Zero(t, auditProgress, "audit certification must obey the same snapshot boundary")
+
+	after := s.NewSnapshot()
+	t.Cleanup(func() { _ = after.Close() })
+	nativeProgress, err := s.ReadProgressFrom(after)
+	require.NoError(t, err)
+	require.Equal(t, uint64(5), nativeProgress)
+	readProgress, err = s.ReadRaftProgressFrom(after)
+	require.NoError(t, err)
+	require.Equal(t, uint64(12), readProgress)
+	auditProgress, err = s.ReadAuditRaftProgressFrom(after)
+	require.NoError(t, err)
+	require.Equal(t, uint64(12), auditProgress)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, s.WaitForRaftProgress(ctx, 12))
+	require.NoError(t, s.WaitForAuditRaftProgress(ctx, 12))
+}
+
+func TestProjectionRaftProgressWaitCancellation(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorIs(t, s.WaitForRaftProgress(ctx, 1), context.Canceled)
+	require.ErrorIs(t, s.WaitForAuditRaftProgress(ctx, 1), context.Canceled)
+}
+
+func TestAuditRaftProgressWaitsThroughRebuildAndRejectsDisabled(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	disabled, rebuilding := s.AuditProjectionState()
+	require.False(t, disabled)
+	require.False(t, rebuilding)
+
+	s.SetAuditProjectionState(false, true)
+	disabled, rebuilding, generation := s.AuditProjectionStateWithGeneration()
+	require.False(t, disabled)
+	require.True(t, rebuilding)
+	require.Equal(t, uint64(1), generation)
+
+	waitCtx, cancelWait := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancelWait()
+	require.ErrorIs(t, s.WaitForAuditRaftProgress(waitCtx, 1), context.DeadlineExceeded,
+		"rebuilding is transient: the certificate wait must remain pending")
+
+	batch := s.NewBatch()
+	require.NoError(t, s.WriteAuditRaftProgress(batch, 1))
+	require.NoError(t, batch.Commit())
+	s.NotifyProgress()
+
+	certifiedCtx, cancelCertified := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancelCertified()
+	require.ErrorIs(t, s.WaitForAuditRaftProgress(certifiedCtx, 1), context.DeadlineExceeded,
+		"a stale certificate must not become ready while rebuilding")
+
+	// Repeating the same state does not create a fictitious lifecycle change.
+	s.SetAuditProjectionState(false, true)
+	_, _, sameGeneration := s.AuditProjectionStateWithGeneration()
+	require.Equal(t, generation, sameGeneration)
+
+	s.SetAuditProjectionState(false, false)
+	require.NoError(t, s.WaitForAuditRaftProgress(t.Context(), 1),
+		"the waiter may consume the certificate only after the projection becomes ready")
+
+	s.SetAuditProjectionState(true, false)
+	disabled, rebuilding, generation = s.AuditProjectionStateWithGeneration()
+	require.True(t, disabled)
+	require.False(t, rebuilding)
+	require.Equal(t, uint64(3), generation)
+	require.ErrorIs(t, s.WaitForAuditRaftProgress(context.Background(), 1), ErrAuditProjectionUnavailable)
+}
+
+func TestWaitForProgressWakesAfterNotification(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	var progress atomic.Uint64
+	var calls atomic.Uint32
+	secondRead := make(chan struct{})
+	allowSecondRead := make(chan struct{})
+
+	read := func() (uint64, error) {
+		if calls.Add(1) == 2 {
+			close(secondRead)
+			<-allowSecondRead
+		}
+
+		return progress.Load(), nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	waitErr := make(chan error, 1)
+	go func() { waitErr <- s.waitForProgress(ctx, 8, read, "test progress") }()
+
+	select {
+	case <-secondRead:
+	case <-ctx.Done():
+		t.Fatal("waiter did not enter the locked progress loop")
+	}
+	close(allowSecondRead)
+
+	// Acquiring progressMu now waits until the waiter has entered Cond.Wait.
+	// Broadcasting while holding the same lock makes the wake-up deterministic.
+	s.progressMu.Lock()
+	progress.Store(8)
+	s.progressCond.Broadcast()
+	s.progressMu.Unlock()
+
+	select {
+	case err := <-waitErr:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal("waiter did not observe certified progress")
+	}
+}
+
+func TestWaitForProgressReportsReadErrors(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	want := errors.New("read failed")
+	require.ErrorIs(t, s.waitForProgress(context.Background(), 1, func() (uint64, error) {
+		return 0, want
+	}, "test progress"), want)
+
+	var calls int
+	err := s.waitForProgress(context.Background(), 1, func() (uint64, error) {
+		calls++
+		if calls == 1 {
+			return 0, nil
+		}
+
+		return 0, want
+	}, "test progress")
+	require.ErrorIs(t, err, want)
+}
+
+func TestAuditIndexSnapshotQueriesPinnedRows(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	kb := dal.NewKeyBuilder()
+	batch := s.NewBatch()
+	require.NoError(t, batch.SetBytes(AuditIndexStringKey(kb, AuditFieldLedger, "main", 3), nil))
+	require.NoError(t, batch.SetBytes(kb.Reset().
+		PutByte(PrefixInternal).
+		PutByte(SubInternalAuditIndex).
+		PutByte(AuditFieldOutcome).
+		PutByte(1).
+		PutUint64(3).
+		Build(), nil))
+	require.NoError(t, batch.SetBytes(AuditIndexUint64Key(kb, AuditFieldProposalID, 9, 3), nil))
+	require.NoError(t, batch.Commit())
+
+	reader := s.NewSnapshot()
+	t.Cleanup(func() { _ = reader.Close() })
+	index := NewAuditIndexSnapshot(reader)
+
+	seqs, err := index.AuditSeqsByString(AuditFieldLedger, "main")
+	require.NoError(t, err)
+	require.Equal(t, []uint64{3}, seqs)
+	seqs, err = index.AuditSeqsByOutcome(true)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{3}, seqs)
+	seqs, err = index.AuditSeqsByUint64Range(AuditFieldProposalID, 9, 9)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{3}, seqs)
+
+	seqs, err = s.AuditSeqsByOutcome(false)
+	require.NoError(t, err)
+	require.Empty(t, seqs)
+}

--- a/internal/storage/readstore/store.go
+++ b/internal/storage/readstore/store.go
@@ -302,7 +302,7 @@ func (s *Store) SetAuditProjectionState(disabled, rebuilding bool) {
 	s.progressMu.Unlock()
 }
 
-// SetAuditProjectionFailed marks a steady-state indexing failure. It is
+// SetAuditProjectionFailed marks a boot or steady-state indexing failure. It is
 // exposed as transient rebuilding to admission, but progress waiters receive a
 // terminal local error so one checkpoint cannot stall the normal indexer.
 func (s *Store) SetAuditProjectionFailed() {

--- a/internal/storage/readstore/store.go
+++ b/internal/storage/readstore/store.go
@@ -53,8 +53,11 @@ type Store struct {
 	// progressMu and progressCond allow callers to wait until the indexed
 	// sequence reaches a target value. The index builder calls
 	// NotifyProgress after each WriteProgress to wake up waiters.
-	progressMu   sync.Mutex
-	progressCond *sync.Cond
+	progressMu      sync.Mutex
+	progressCond    *sync.Cond
+	auditDisabled   bool
+	auditRebuilding bool
+	auditGeneration uint64
 
 	// readOnly marks a store opened via OpenReadOnly — a frozen view (query
 	// checkpoint) whose fold cursor will never advance, so freshness waits
@@ -179,11 +182,13 @@ func OpenReadOnly(dirPath string, logger logging.Logger) (*Store, error) {
 }
 
 // CreateCheckpoint creates a Pebble checkpoint of the read index at destDir.
-// The read index runs without a WAL, so a Pebble checkpoint carries only the
-// flushed SSTs: the memtable is flushed first so every committed row is in it.
+// The read index has WAL disabled, so committed batches may exist only in a
+// memtable. Flush it first: otherwise Pebble has neither an SST nor a WAL file
+// to link and a ready checkpoint can silently omit the progress certificates
+// and projection rows that its creator just waited for.
 func (s *Store) CreateCheckpoint(destDir string) error {
 	if err := s.db.Flush(); err != nil {
-		return fmt.Errorf("flushing read index memtable: %w", err)
+		return fmt.Errorf("flushing read index before checkpoint: %w", err)
 	}
 
 	return s.db.Checkpoint(destDir)
@@ -234,6 +239,24 @@ func (s *Store) WriteProgress(batch *dal.WriteSession, sequence uint64) error {
 	return progressCursor.Write(batch, sequence)
 }
 
+// ReadRaftProgress returns the Raft horizon certified by the normal read
+// projection. The native log cursor remains the fold/reclamation position.
+func (s *Store) ReadRaftProgress() (uint64, error) {
+	return readRaftCursor.Read(s.db)
+}
+
+// ReadRaftProgressFrom reads the normal projection certificate from a pinned
+// snapshot, so the certificate and index rows come from one Pebble view.
+func (s *Store) ReadRaftProgressFrom(reader dal.PebbleGetter) (uint64, error) {
+	return readRaftCursor.Read(reader)
+}
+
+// WriteRaftProgress publishes a normal-projection causal certificate. It must
+// be committed atomically with the final writes for that target.
+func (s *Store) WriteRaftProgress(batch *dal.WriteSession, appliedIndex uint64) error {
+	return readRaftCursor.Write(batch, appliedIndex)
+}
+
 // LastIndexedSequence returns the last indexed log sequence (read-only).
 func (s *Store) LastIndexedSequence() (uint64, error) {
 	return s.ReadProgress()
@@ -260,6 +283,55 @@ func (s *Store) NotifyProgress() {
 	s.progressMu.Lock()
 	s.progressCond.Broadcast()
 	s.progressMu.Unlock()
+}
+
+// SetAuditProjectionState records node-local operational readiness. It never
+// participates in Raft apply; it only prevents a causal progress certificate
+// from being mistaken for readiness while the local audit projection is
+// disabled or being rebuilt.
+func (s *Store) SetAuditProjectionState(disabled, rebuilding bool) {
+	s.progressMu.Lock()
+	if s.auditDisabled != disabled || s.auditRebuilding != rebuilding {
+		s.auditGeneration++
+	}
+	s.auditDisabled = disabled
+	s.auditRebuilding = rebuilding
+	s.progressCond.Broadcast()
+	s.progressMu.Unlock()
+}
+
+// AuditProjectionState returns the local audit projection lifecycle state.
+func (s *Store) AuditProjectionState() (disabled, rebuilding bool) {
+	s.progressMu.Lock()
+	defer s.progressMu.Unlock()
+
+	return s.auditDisabled, s.auditRebuilding
+}
+
+// AuditProjectionStateWithGeneration returns lifecycle state together with a
+// process-local generation that changes on every readiness transition. A
+// checkpoint captures the generation after its progress wait and verifies it
+// again when publishing .ready, so a concurrent rebuild cannot certify a
+// snapshot taken from a reset projection.
+func (s *Store) AuditProjectionStateWithGeneration() (disabled, rebuilding bool, generation uint64) {
+	s.progressMu.Lock()
+	defer s.progressMu.Unlock()
+
+	return s.auditDisabled, s.auditRebuilding, s.auditGeneration
+}
+
+// MarkCheckpointReadyAtAuditGeneration publishes the marker only if the audit
+// projection remained ready in the generation captured before materializing
+// the checkpoint. The state lock closes the final check-to-marker race with
+// SetAuditProjectionState.
+func (s *Store) MarkCheckpointReadyAtAuditGeneration(dir string, generation uint64) (bool, error) {
+	s.progressMu.Lock()
+	defer s.progressMu.Unlock()
+	if s.auditDisabled || s.auditRebuilding || s.auditGeneration != generation {
+		return false, nil
+	}
+
+	return true, MarkCheckpointReady(dir)
 }
 
 // ReadAppliedProposalProgress returns the last consumed AppliedProposal
@@ -958,6 +1030,49 @@ func (s *Store) WaitForSequence(ctx context.Context, minSeq uint64) error {
 			return nil
 		}
 
+		s.progressCond.Wait()
+	}
+}
+
+// WaitForRaftProgress blocks until the normal read projection has certified H.
+func (s *Store) WaitForRaftProgress(ctx context.Context, horizon uint64) error {
+	return s.waitForProgress(ctx, horizon, s.ReadRaftProgress, "read projection Raft progress")
+}
+
+func (s *Store) waitForProgress(ctx context.Context, target uint64, read func() (uint64, error), label string) error {
+	cur, err := read()
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", label, err)
+	}
+	if cur >= target {
+		return nil
+	}
+
+	done := make(chan struct{})
+	defer close(done)
+	go func() {
+		select {
+		case <-ctx.Done():
+			s.progressMu.Lock()
+			s.progressCond.Broadcast()
+			s.progressMu.Unlock()
+		case <-done:
+		}
+	}()
+
+	s.progressMu.Lock()
+	defer s.progressMu.Unlock()
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		cur, err = read()
+		if err != nil {
+			return fmt.Errorf("reading %s: %w", label, err)
+		}
+		if cur >= target {
+			return nil
+		}
 		s.progressCond.Wait()
 	}
 }

--- a/internal/storage/readstore/store.go
+++ b/internal/storage/readstore/store.go
@@ -57,6 +57,7 @@ type Store struct {
 	progressCond    *sync.Cond
 	auditDisabled   bool
 	auditRebuilding bool
+	auditFailed     bool
 	auditGeneration uint64
 
 	// readOnly marks a store opened via OpenReadOnly — a frozen view (query
@@ -291,11 +292,26 @@ func (s *Store) NotifyProgress() {
 // disabled or being rebuilt.
 func (s *Store) SetAuditProjectionState(disabled, rebuilding bool) {
 	s.progressMu.Lock()
-	if s.auditDisabled != disabled || s.auditRebuilding != rebuilding {
+	if s.auditDisabled != disabled || s.auditRebuilding != rebuilding || s.auditFailed {
 		s.auditGeneration++
 	}
 	s.auditDisabled = disabled
 	s.auditRebuilding = rebuilding
+	s.auditFailed = false
+	s.progressCond.Broadcast()
+	s.progressMu.Unlock()
+}
+
+// SetAuditProjectionFailed marks a steady-state indexing failure. It is
+// exposed as transient rebuilding to admission, but progress waiters receive a
+// terminal local error so one checkpoint cannot stall the normal indexer.
+func (s *Store) SetAuditProjectionFailed() {
+	s.progressMu.Lock()
+	if !s.auditFailed {
+		s.auditGeneration++
+	}
+	s.auditRebuilding = false
+	s.auditFailed = true
 	s.progressCond.Broadcast()
 	s.progressMu.Unlock()
 }
@@ -305,7 +321,7 @@ func (s *Store) AuditProjectionState() (disabled, rebuilding bool) {
 	s.progressMu.Lock()
 	defer s.progressMu.Unlock()
 
-	return s.auditDisabled, s.auditRebuilding
+	return s.auditDisabled, s.auditRebuilding || s.auditFailed
 }
 
 // AuditProjectionStateWithGeneration returns lifecycle state together with a
@@ -317,7 +333,7 @@ func (s *Store) AuditProjectionStateWithGeneration() (disabled, rebuilding bool,
 	s.progressMu.Lock()
 	defer s.progressMu.Unlock()
 
-	return s.auditDisabled, s.auditRebuilding, s.auditGeneration
+	return s.auditDisabled, s.auditRebuilding || s.auditFailed, s.auditGeneration
 }
 
 // MarkCheckpointReadyAtAuditGeneration publishes the marker only if the audit
@@ -327,7 +343,7 @@ func (s *Store) AuditProjectionStateWithGeneration() (disabled, rebuilding bool,
 func (s *Store) MarkCheckpointReadyAtAuditGeneration(dir string, generation uint64) (bool, error) {
 	s.progressMu.Lock()
 	defer s.progressMu.Unlock()
-	if s.auditDisabled || s.auditRebuilding || s.auditGeneration != generation {
+	if s.auditDisabled || s.auditRebuilding || s.auditFailed || s.auditGeneration != generation {
 		return false, nil
 	}
 

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -537,6 +537,7 @@ message CreatedQueryCheckpointLog {
   fixed64 checkpoint_id = 1;
   fixed64 max_sequence = 2;
   Timestamp created_at = 3;
+  fixed64 applied_index = 4;
 }
 
 // DeletedQueryCheckpointLog records a query checkpoint being deleted.

--- a/misc/proto/raft_cmd.proto
+++ b/misc/proto/raft_cmd.proto
@@ -185,6 +185,7 @@ message QueryCheckpointState {
   fixed64 checkpoint_id = 1;
   fixed64 max_sequence = 2;            // next_sequence - 1 at creation
   common.Timestamp created_at = 3;    // Creation timestamp (from proposal date)
+  fixed64 applied_index = 4;           // Raft horizon of the checkpoint snapshot
 }
 
 message SetQueryCheckpointScheduleOrder {

--- a/misc/proto/raft_cmd.proto
+++ b/misc/proto/raft_cmd.proto
@@ -186,6 +186,7 @@ message QueryCheckpointState {
   fixed64 max_sequence = 2;            // next_sequence - 1 at creation
   common.Timestamp created_at = 3;    // Creation timestamp (from proposal date)
   fixed64 applied_index = 4;           // Raft horizon of the checkpoint snapshot
+  bool restored_from_backup = 5;       // Technical provenance: physical checkpoint files were not restored
 }
 
 message SetQueryCheckpointScheduleOrder {

--- a/tests/e2e/cluster/restore_test.go
+++ b/tests/e2e/cluster/restore_test.go
@@ -102,11 +102,13 @@ var _ = Describe("Restore", Ordered, func() {
 	ports := lease.Ports()
 
 	var (
-		ctx            context.Context
-		restoreWalDir  string
-		restoreDataDir string
-		minioEndpoint  string
-		s3Client       *s3.Client
+		ctx                        context.Context
+		restoreWalDir              string
+		restoreDataDir             string
+		minioEndpoint              string
+		s3Client                   *s3.Client
+		deltaCheckpointID          uint64
+		deltaCheckpointMaxSequence uint64
 	)
 
 	BeforeAll(func() {
@@ -333,6 +335,15 @@ var _ = Describe("Restore", Ordered, func() {
 			_, err = client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.SetMetadataFieldTypeAction(ledgerName, commonpb.TargetType_TARGET_TYPE_TRANSACTION, "category", commonpb.MetadataType_METADATA_TYPE_INT64)))
 			Expect(err).To(Succeed())
 
+			// This checkpoint is created only after the full backup. Its metadata
+			// row — including applied_index — must therefore be rebuilt from the
+			// incremental log export rather than copied from checkpoint files.
+			checkpoint, err := clusterClient.CreateQueryCheckpoint(ctx, &clusterpb.CreateQueryCheckpointRequest{})
+			Expect(err).To(Succeed())
+			deltaCheckpointID = checkpoint.GetCheckpointId()
+			deltaCheckpointMaxSequence = checkpoint.GetMaxSequence()
+			Expect(deltaCheckpointID).NotTo(BeZero())
+
 			resp, err := clusterClient.IncrementalBackup(ctx, &clusterpb.IncrementalBackupRequest{
 				Storage: testutil.S3BackupStorage(&commonpb.S3StorageConfig{
 					Bucket:   restoreS3Bucket,
@@ -351,14 +362,21 @@ var _ = Describe("Restore", Ordered, func() {
 			Expect(err).To(Succeed())
 
 			logSegments := 0
+			checkpointLogExported := false
+			checkpointLogSequence := deltaCheckpointMaxSequence + 1
 			for _, seg := range manifest.Exports {
 				if seg.Type == "log" {
 					logSegments++
+					if seg.StartSeq <= checkpointLogSequence && seg.EndSeq >= checkpointLogSequence {
+						checkpointLogExported = true
+					}
 				}
 			}
 
 			Expect(logSegments).To(BeNumerically(">", 1),
 				"a 1-byte segment cap must split the multi-sequence log export into multiple segments")
+			Expect(checkpointLogExported).To(BeTrue(),
+				"the manifest must export the post-checkpoint query-checkpoint creation log")
 		})
 
 		It("should write more data and take a SECOND incremental backup", func() {
@@ -701,6 +719,21 @@ var _ = Describe("Restore", Ordered, func() {
 			Expect(err).To(Succeed())
 			Expect(erinResp.FindVolume("USD", "").Input).To(Equal("2500"),
 				"transaction written in the second incremental must be restored from the full + multi-incremental chain")
+		})
+
+		It("should rebuild the post-checkpoint query checkpoint and pass CheckStore", func() {
+			info, err := clusterClient.GetQueryCheckpointInfo(ctx, &clusterpb.GetQueryCheckpointInfoRequest{
+				CheckpointId: deltaCheckpointID,
+			})
+			Expect(err).To(Succeed())
+			Expect(info.GetCheckpointId()).To(Equal(deltaCheckpointID))
+			Expect(info.GetMaxSequence()).To(Equal(deltaCheckpointMaxSequence),
+				"the restored logical projection must match the live source row")
+
+			result, err := actions.CollectCheckStoreEvents(ctx, client)
+			Expect(err).To(Succeed())
+			Expect(result.Errors).To(BeEmpty(),
+				"CheckStore must validate the rebuilt applied_index against the exported audit chain")
 		})
 
 		It("should account for a post-checkpoint balance on the apply path after restore", func() {


### PR DESCRIPTION
## Summary

- add independent Raft applied-index certificates for the read and audit projections;
- publish certificates atomically with the terminal projection batch;
- make audit readiness explicit for checkpoint admission and materialization;
- preserve checkpoint applied-index provenance across incremental restore;
- wait through rebuilds, stop on explicit disabled/failed states, and generation-guard ready publication.

## Stack

EN-1946 stack 2/8. Depends on #1897 (test/en-1946-bound-cross-store-alignment).

Merge/review order: #1897 → #1889 → #1890 → #1894 → #1891 → #1893 → #1892 → #1881.

## Validation

Final base: b9080b6270942237cb2f98fe7aa4b6f90d83fc4c.
Final head: 01f5df313ad6cc82e6cfd84fcbd75ad621d721f0.
Canonical PR validation: PASS, including full race validation and business/cluster E2E.
Independent exact diff review: APPROVE (residual risk MEDIUM).

Jira: EN-1946. Do not merge automatically.