### PR TITLE
feat(reads): align live queries to Raft horizons (EN-1946)

### DIFF
--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -1867,7 +1867,7 @@ ledgerctl version
 
 The **server** exposes the same build metadata over two unauthenticated channels:
 
-- **HTTP** — `GET /_info` returns flat JSON (no `data` envelope): `{"version":"…","commit":"…","buildDate":"…","goVersion":"…","protocolVersion":"1"}`.
+- **HTTP** — `GET /_info` returns flat JSON (no `data` envelope): `{"version":"…","commit":"…","buildDate":"…","goVersion":"…","protocolVersion":"2"}`.
 - **gRPC** — the `Discovery` RPC's `DiscoveryResponse` carries a `ServerInfo` message with the same information, including `protocol_version`.
 
 This is useful for monitoring deployed nodes and spotting version skew across a cluster (the per-node `version` is also surfaced on each `NodeInfo` in `GetClusterState`).
@@ -2377,26 +2377,20 @@ non-audit condition (`metadata[...]`, `address`, `source`, …). This keeps audi
 reads first-class with every other list endpoint while never degrading to a
 full-chain scan.
 
-> **Consistency note.** The audit secondary index is maintained by an
-> asynchronous per-node worker, so a filter that contains any field other than
-> `seq` (for example `ledger` or `outcome`) is eventually consistent when
-> `--min-log-sequence` is zero. With a non-zero bound, every node that receives
-> or forwards the live request first waits for its log index to reach that
-> sequence, samples its live audit head, and waits for its own audit index to
-> reach that head. This preserves the bound when the request is routed to
-> another node. An unfiltered live read, or a conjunction made only of `seq`
-> bounds, scans the audit zone directly. With a non-zero bound, every gRPC node
-> traversed by the routed request waits for its own log-index progress before
-> routing or serving, but does not wait for audit-index progress.
+> **Consistency note.** For a live filter containing any field other than
+> `seq` (for example `ledger` or `outcome`), the server fixes the main-store
+> Raft horizon for the request and waits for the local audit projection to
+> certify that horizon before taking the snapshot it queries. A non-zero
+> `--min-log-sequence` additionally waits for the native log index before that
+> automatically aligned read. An unfiltered live read, or a conjunction made
+> only of `seq` bounds, scans the authoritative audit zone directly and does
+> not wait for the audit projection.
 >
-> **Checkpoint + indexed-filter caveat.** A query checkpoint snapshots the audit index
-> at creation time; checkpoint creation waits for the log index but not yet for
-> the audit indexer, so a read whose filter contains a field other than `seq`
-> may omit entries whose audit-zone rows exist in the checkpoint but were not
-> indexed when it was taken (a frozen checkpoint never catches up). Unfiltered
-> and `seq`-only checkpoint reads scan the zone directly and are unaffected.
-> Making the audit indexer catch up before the checkpoint snapshot is a tracked
-> follow-up.
+> **Checkpoint reads.** Checkpoint creation waits for both read and audit
+> projections to certify the checkpoint horizon before publishing readiness.
+> Indexed audit reads therefore use the complete frozen audit projection;
+> unfiltered and `seq`-only reads continue to scan the frozen audit zone
+> directly.
 
 **Behavior:**
 - Streams audit entries from the server, oldest first by default / chronological (`--reverse` for newest first)

--- a/docs/technical/architecture/subsystems/api/grpc-api.md
+++ b/docs/technical/architecture/subsystems/api/grpc-api.md
@@ -688,13 +688,14 @@ for {
 }
 ```
 
-For a live request whose filter contains any field other than `seq`, a non-zero
-`MinLogSequence` makes every gRPC node that receives or serves the routed
-request wait for its log index to reach the bound and for its local audit index
-to reach the live audit head sampled afterward. With a zero bound, those
-index-backed results are best-effort. Unfiltered and `seq`-only conjunctions
-scan the audit zone directly and need only the log-sequence wait. Checkpoint
-reads ignore the bound.
+For a live request whose filter contains any field other than `seq`, the server
+automatically fixes a main-store Raft horizon and waits for its local audit
+projection to certify that horizon before querying the projection snapshot. A
+non-zero `MinLogSequence` additionally waits for the native log index before
+that aligned read. Unfiltered and `seq`-only conjunctions scan the authoritative
+audit zone directly and need only the optional log-sequence wait. Checkpoint
+reads ignore the request bound because checkpoint readiness already certifies
+both frozen projections at creation time.
 
 ## Store Metrics
 

--- a/docs/technical/architecture/subsystems/api/http-api.md
+++ b/docs/technical/architecture/subsystems/api/http-api.md
@@ -404,10 +404,10 @@ Query parameters:
   JSON `QueryFilter` DSL used by prepared queries, which cannot represent audit
   conditions. A filter containing any field other than `seq` is served by the
   asynchronous audit index; unfiltered and `seq`-only conjunctions scan the
-  audit zone directly. This HTTP endpoint exposes no `minLogSequence` bound, so
-  index-backed reads are best-effort and may omit entries not yet indexed; gRPC
-  callers can request a consistency-bound wait that is preserved across routing
-  hops.
+  audit zone directly. Although this HTTP endpoint exposes no
+  `minLogSequence` bound, a filtered read automatically fixes a main-store Raft
+  horizon and waits for the audit projection to certify it before querying the
+  projection snapshot.
 
 **Response**: `{ "data": [ AuditEntry, ... ] }` (list omits per-order `items`).
 

--- a/docs/technical/architecture/subsystems/api/protocol-compatibility.md
+++ b/docs/technical/architecture/subsystems/api/protocol-compatibility.md
@@ -20,7 +20,7 @@ compatibility of development revisions.
 ## Wire contract and failure behavior
 
 `pkg/grpcprotocol.Version` is the compiled service protocol revision, currently
-`"1"`. `pkg/grpcprotocol.MetadataKey` is `ledger-protocol-version`. Clients send
+`"2"`. `pkg/grpcprotocol.MetadataKey` is `ledger-protocol-version`. Clients send
 exactly one value for this metadata key on every RPC. The Go
 `grpcprotocol.ClientOption()` dial option supplies the local revision for unary
 and streaming calls. Local `dev` builds carry the same constant without release
@@ -61,10 +61,10 @@ servers or support for mixed wire-format upgrades.
 
 Every consumer of the service gRPC endpoint must declare its protocol,
 including SDKs, automation, `grpcurl`, and internal requests forwarded to a
-leader. For example, with a schema implementing revision 1:
+leader. For example, with a schema implementing revision 2:
 
 ```bash
-grpcurl -plaintext -H 'ledger-protocol-version: 1' \
+grpcurl -plaintext -H 'ledger-protocol-version: 2' \
   localhost:8888 cluster.ClusterService.GetClusterState
 ```
 

--- a/docs/technical/architecture/subsystems/consensus/raft-consensus.md
+++ b/docs/technical/architecture/subsystems/consensus/raft-consensus.md
@@ -565,9 +565,12 @@ indexes need their own progress barrier:
 2. `ReadIndex` sends a `ReadIndex` request through the Raft orchestrate loop. The leader confirms it is still the leader by exchanging heartbeats with a quorum of peers (the `ReadOnlySafe` mode, which is the default).
 3. The leader responds with the current **commit index** via `rd.ReadStates`.
 4. `WaitForApplied` blocks until the local FSM has applied entries up to that commit index (using a `sync.Cond` that broadcasts after each `lastPersistedIndex.Store()`).
-5. The caller reads from the local Pebble store, which is now guaranteed to
-   reflect all writes committed before the ReadIndex call. This does not by
-   itself advance independently asynchronous secondary indexes.
+5. The caller opens a local main-store snapshot, reads its durable applied
+   index `H`, and verifies that `H` covers the returned commit index `R`.
+6. If the query uses an asynchronous projection, it waits for that projection's
+   independent Raft certificate to cover fixed `H`.
+7. The certificate is re-read from the projection snapshot used by the query;
+   the wait never follows the moving store head.
 
 **Benefits**:
 - **Linearizable reads on leaders, followers, and caught-up learners** that can reach quorum
@@ -578,14 +581,17 @@ indexes need their own progress barrier:
 
 **Consistency and routing exceptions**:
 - `x-consistency: stale` bypasses `ReadIndex` and reads the local store directly;
-  it may return an older view.
+  it may return an older view, but any projection it uses is still aligned to
+  the fixed applied index of that local main-store snapshot.
 - `x-consistency: leader` routes the read to the node currently considered
   leader. A call forwarded to a remote node does not propagate the consistency
   metadata, so the remote call defaults to linearizable mode and performs its
   quorum barrier. However, if the receiving node already considers itself
   leader, `getLeaderCtrl` returns the local controller directly and skips
   `ReadIndex`. Because `CheckQuorum` is disabled, an isolated former leader can
-  therefore serve stale local state in this mode.
+  therefore serve stale local state in this mode. Projection-backed reads still
+  align to that local main-store snapshot even though no quorum horizon `R` is
+  available.
 - If a non-leader node is syncing or cannot complete its local barrier,
   `RoutedController` can transparently retry the read against the leader. The
   forwarded attempt can still fail when the leader is unavailable. If
@@ -593,19 +599,14 @@ indexes need their own progress barrier:
   router returns the barrier failure rather than serving the newly local
   controller without a successful `ReadIndex`.
 - A `ListAuditEntries` filter that contains any field other than `seq` resolves
-  through the independently asynchronous audit index. With the default
-  `minLogSequence = 0`, its handler does not wait for audit-index progress, so
-  it can temporarily omit entries that are already committed even though the
-  ReadIndex barrier completed. A non-zero `minLogSequence` makes each gRPC node
-  that receives the live request wait for that log sequence, sample its live
-  audit head, and wait for its own audit index to reach that head. The bound is
-  propagated when routing selects another node, so the node that actually
-  serves the indexed query repeats the wait against its own independently
-  maintained index. Unfiltered listings and conjunctions made only of `seq`
-  bounds scan the audit zone directly and do not have this secondary-index lag;
-  they still honor a non-zero log-sequence wait. Checkpoint reads ignore the
-  bound, and an index-backed checkpoint filter can retain audit-index lag frozen
-  at checkpoint creation.
+  through the independently asynchronous audit index. It waits for the audit
+  projection's Raft certificate to cover the fixed main-store horizon and
+  compiles the filter from that verified audit snapshot. Unfiltered listings
+  and conjunctions made only of `seq` bounds scan the authoritative audit zone
+  directly and do not wait for the projection. The temporary
+  `minLogSequence` field remains an additional native-sequence floor for live
+  requests, but is no longer the causal alignment proof. Checkpoint creation
+  waits for both read and audit certificates before publishing readiness.
 - `GetLedgerStats` has mixed provenance. `transactionCount` and `logCount` are
   FSM-backed, while `postingCount`, `revertCount`,
   `numscriptExecutionCount`, `referenceCount`, `ephemeralEvictedCount`,

--- a/docs/technical/architecture/subsystems/read-path/README.md
+++ b/docs/technical/architecture/subsystems/read-path/README.md
@@ -15,7 +15,7 @@ and the pipeline pages.
 
 | Document | Description |
 |----------|-------------|
-| [query-pipeline.md](query-pipeline.md) | End-to-end read flow: ReadIndex barrier, min_log_sequence, Pebble snapshot, iterator algebra, pagination, streaming. |
+| [query-pipeline.md](query-pipeline.md) | End-to-end read flow: ReadIndex barrier, fixed Raft projection horizon, Pebble snapshots, iterator algebra, pagination, streaming. |
 | [iterator-seek-contract.md](iterator-seek-contract.md) | Absolute SeekGE/SeekLE semantics across the iterator algebra, the AddressTxIterator materialized union, and the seekFloor/seekCeil exhaustion-proof cache. |
 | [read-snapshot-consistency.md](read-snapshot-consistency.md) | Single-snapshot rule for controller reads that stitch LedgerInfo with attribute data. |
 | [readstore-event-keys.md](readstore-event-keys.md) | Append-only metadata/existence event resolution, lease-bounded reclamation, and edge-triggered GC cycles. |
@@ -29,4 +29,4 @@ and the pipeline pages.
 
 - [Indexer](../indexer/) — populates the read store the query path consumes.
 - [Consensus](../consensus/) — `ReadIndex` quorum that gates default live reads (with stale/checkpoint exceptions).
-- [FSM](../fsm/) — what the read path waits to catch up to via `min_log_sequence`.
+- [FSM](../fsm/) — durable applied index used as the common projection horizon.

--- a/docs/technical/architecture/subsystems/read-path/prepared-queries.md
+++ b/docs/technical/architecture/subsystems/read-path/prepared-queries.md
@@ -74,7 +74,8 @@ A compile error at FSM time is hash-bound as an `AuditFailure`, so a checker run
 3. Enters the standard read route. Default live consistency establishes a
    `ReadIndexAndWait` horizon; `stale`, leader-local, and checkpoint reads have
    the documented exceptions. The executor waits for read-index alignment only
-   when `AlignmentOwed` is true — a non-nil filter or a LOGS target — then calls
+   when `AlignmentOwed` is true — the filter tree contains a read-index leaf or
+   the target is LOGS — then calls
    `Compile(indexSnap, kb, pq.GetFilter(), ...)` and executes the iterator.
 4. For `LIST`, streams the matching entities through the standard cursor pipeline (see [query-pipeline.md](query-pipeline.md)).
 5. For `AGGREGATE_VOLUMES`, loops over the candidate account set and sums per-asset volumes from the main store. The aggregation is **computed at request time** — there is no materialised aggregate table.

--- a/docs/technical/architecture/subsystems/read-path/query-checkpoints.md
+++ b/docs/technical/architecture/subsystems/read-path/query-checkpoints.md
@@ -55,21 +55,22 @@ The read index materializes asynchronously and **per-replica** (step 5). Readine
   certified `H`, so a filtered audit query cannot be frozen against an
   incomplete audit index. Every creation trigger passes through a shared
   admission preflight, so public `Apply`, the cluster RPC and the automatic
-  scheduler all fail explicitly with `ErrIndexBuilding` while the local audit
-  projection is disabled or rebuilding. An enabled projection starts in the
-  rebuilding state and only becomes ready after boot has classified its
-   persisted cursor and completed the initial rebuild/catch-up. A failed rebuild
-   remains in rebuilding state until a later successful rebuild/catch-up; it
-   cannot advertise a false readiness window. An already-proposed create waits
+  scheduler all fail explicitly with `ErrAuditDisabled` when the projection is
+  permanently disabled and `ErrIndexBuilding` while it is rebuilding. An
+  enabled projection starts in the rebuilding state and only becomes ready
+  after boot has classified its persisted cursor and completed the initial
+  rebuild/catch-up. A failed rebuild
+  remains in rebuilding state until a later successful rebuild/catch-up; it
+  cannot advertise a false readiness window. An already-proposed create waits
   through a transient rebuild and resumes only after the replacement projection
   is ready and has certified `H`. A rebuild racing after that wait is detected
   by an audit lifecycle generation captured before the snapshot and checked
   atomically with `.ready` publication; a changed generation leaves the marker
   absent and retries materialization from a clean directory. A disabled
-   projection leaves the checkpoint unavailable. In every waiting case the
-   caller's deadline/cancellation ends its marker wait. Unfiltered or
-   sequence-only live audit reads remain independent of the audit index, but a
-   checkpoint promises the complete projection set.
+  projection leaves the checkpoint unavailable. In every waiting case the
+  caller's deadline/cancellation ends its marker wait. Unfiltered or
+  sequence-only live audit reads remain independent of the audit index, but a
+  checkpoint promises the complete projection set.
   An audit indexing failure during boot or steady state is also advertised as
   transiently rebuilding to admission, while the checkpoint already in flight
   is left unavailable and the normal builder continues past its log. The audit

--- a/docs/technical/architecture/subsystems/read-path/query-pipeline.md
+++ b/docs/technical/architecture/subsystems/read-path/query-pipeline.md
@@ -2,22 +2,14 @@
 
 ## Overview
 
-Entity-list reads can pass through four distinct mechanisms: a Raft
-**`ReadIndex`** barrier for default live consistency, an optional
-**`min_log_sequence`** wait for read-side freshness, Pebble snapshots, and a
-composable iterator pipeline. A query waits for cross-store alignment only when
-`query.AlignmentOwed` says its shape actually consults an index leaf: filtered
-account/transaction queries and every log query. Unfiltered account/transaction
-queries use only the main-store handle and do not wait for the read index. Point
-reads likewise use their own main-store path. `stale` skips only the Raft
-barrier, while the leader-local and checkpoint exceptions are described below
-and in the [consensus contract](../consensus/raft-consensus.md#linearizable-reads-via-readindex).
+Indexed entity-list reads go through four stages: a **Raft `ReadIndex`** barrier
+for linearizability, a fixed main-store horizon, per-projection **Raft progress**
+waits, coordinated **Pebble snapshots**, and a **composable iterator pipeline**.
+The result is streamed back through gRPC with cursor-based pagination. Point
+reads and main-store-only queries use their own single main-store handle and do
+not wait for projections they do not consult.
 
-The list dispatcher is shared across `ListAccounts`, `ListTransactions`, and
-`ListLogs`, but the selected execution path depends on the query shape. Point
-reads such as `GetAccount` and `GetTransaction`, plus main-store-only queries
-such as `ListLedgers`, use the controller layer but not the read-store iterator
-algebra.
+The indexed-list pipeline is deliberately uniform across `ListAccounts`, `ListTransactions`, and `ListLogs`. Point reads such as `GetAccount` and `GetTransaction`, plus main-store-only queries such as `ListLedgers`, use the controller layer but not the read-store iterator algebra. The differences between indexed lists are which read-store prefix is scanned and how iterators are composed.
 
 ```mermaid
 sequenceDiagram
@@ -31,18 +23,19 @@ sequenceDiagram
     participant Main as Pebble<br/>(main store)
     participant Index as Pebble<br/>(read store)
 
-    C->>G: ListAccounts(filter, min_log_seq, cursor)
-    G->>G: Auth + extract min_log_seq
+    C->>G: ListAccounts(filter, cursor)
+    G->>G: Auth + consistency selection
     G->>Ctrl: ListAccounts(...)
     Ctrl->>N: ReadIndexAndWait(ctx)
     N->>Raft: ReadIndex
     Raft-->>N: commitIndex
     N->>FSM: WaitForApplied(commitIndex)
     FSM-->>N: applied up to commitIndex
-    N-->>Ctrl: ReadBarrierInfo
+    N-->>Ctrl: ReadBarrierInfo(R)
     Ctrl->>Main: store.NewReadHandle()
-    Ctrl->>Index: NewSnapshot / AlignedIndexSnapshot
-    Note over Ctrl,Index: Separate snapshots coordinated to the main-store horizon
+    Ctrl->>Main: Read durable LastAppliedIndex H; assert H >= R
+    Ctrl->>Index: Wait RaftProgress >= H; open snapshot; re-read certificate
+    Note over Ctrl,Index: H is fixed; the wait never chases the moving head
     Ctrl->>Ctrl: Resolve ledger + schema
     Ctrl->>Ctrl: Compile filter → iterator tree
     Ctrl->>Index: Iterate read store
@@ -87,37 +80,62 @@ was used.
 1. Call `node.ReadIndex(ctx)` — Raft sends a heartbeat round-trip to confirm quorum and returns the current commit index.
 2. `fsm.WaitForApplied(commitIndex)` — block until the local FSM has applied every entry up to that commit index.
 
-For a default live request, once both steps succeed the local main-store snapshot
-reflects state at least as fresh as the moment the request reached the cluster.
-FSM-backed results served from that snapshot inherit this linearizable horizon;
-secondary-index results do so only after their separate alignment wait. The
-barrier alone does not advance independently asynchronous projections such as
-the audit index or usagestore.
+Once both succeed, the local Pebble snapshot reflects state at least as fresh as the moment the request reached the cluster. This guarantees **linearizable reads on any node**: a read started after a successful write returns at least that write's effects, regardless of which node serves the read.
 
-If the node is syncing or otherwise unable to confirm `ReadIndex`, the call
-fails. The router may resolve a remote leader and forward; if leadership moved
-local after the failed barrier, it returns the failure rather than serving the
-local store without a fresh barrier. Explicit `stale` skips this barrier, an
-explicit leader-local read does not perform it, and checkpoint reads use their
-frozen snapshot instead.
+If the node is syncing or otherwise unable to confirm `ReadIndex`, the call fails — callers either retry or forward to the leader. The explicit `leader` consistency mode remains available at this stage: a remote hop defaults to the linearizable path, while a node that already considers itself leader serves locally without `R` and still aligns every projection it uses to the fixed local `H` below.
 
-## Freshness — `min_log_sequence`
+## Projection alignment — fixed Raft horizon
 
-The client can pass `min_log_sequence` in the request's `ReadOptions` to demand
-a *read-side* freshness guarantee. `ReadIndex` only guarantees the **FSM** has
-caught up; `min_log_sequence` additionally waits for the **read store** to have
-indexed up to that log sequence. This wait is independent of consistency mode
-and can therefore also block a `stale` read.
+A projection-backed read now aligns automatically against the exact main
+snapshot it will use, independently of the temporary client-facing
+`min_log_sequence` gate:
 
-`waitMinLogSequence()` (`server_bucket.go:434`) calls `readStore.WaitForSequence(ctx, minLogSequence)`, which blocks until the indexer's persisted progress cursor (see [indexer / Progress Cursors](../indexer/indexer.md#progress-cursors)) has caught up.
+1. A linearizable read obtains Raft horizon `R` through `ReadIndexAndWait`.
+   `stale` deliberately skips this step.
+2. The controller opens one main-store snapshot, reads its durable
+   `LastAppliedIndex` as fixed horizon `H`, and verifies `H >= R` when `R` is
+   present.
+3. It waits only for projections the query actually uses. Each must publish a
+   Raft progress certificate `>= H`.
+4. It opens each projection snapshot and re-reads the certificate from that
+   same snapshot before compiling or iterating the query.
 
-Important nuance, repeated from the indexer page: `min_log_sequence` pins **log application** on this replica, **not local rewrite completion**. A read against an index undergoing schema rewrite will keep serving `v_current` until the atomic switch lands — see [indexer / Changing a Metadata Key's Type](../indexer/indexer.md#changing-a-metadata-keys-type-setmetadatafieldtype).
+The indexer captures its own bounded main-store snapshot and publishes `H` only
+after processing every native item visible in it. Intermediate batches advance
+only the native cursor; the terminal projection writes and certificate are one
+atomic Pebble batch. Raft entries that emit no log or audit item still advance
+the certificate. Native log/audit cursors remain separate because folds,
+history resolution, and trimming use them.
 
-Checkpoint reads (see below) ignore `min_log_sequence` — a frozen checkpoint is by definition at a single past sequence.
+For account and transaction queries, `AlignmentOwed` walks the complete
+boolean filter tree. Main-store-only leaves (transaction ID, reverted status,
+and account-target address matching) do not acquire a read-index wait; an AND,
+OR, or NOT tree containing any indexed leaf does. LOGS always uses the read
+index because even its unfiltered universe is projected.
+
+`stale` therefore means “no quorum barrier”, not “permit torn projections”: it
+uses the local main snapshot's fixed `H` and performs the same projection waits.
+Per-index build/rewrite readiness remains explicit through
+`IndexVersionState`; a Raft certificate does not promote an unfinished build.
+
+The legacy `min_log_sequence` request field is still honored as an additional
+client-selected native-sequence floor during this staged rollout. It is no
+longer the causal proof used to align projections: the fixed Raft horizon above
+provides that proof automatically. Checkpoint reads continue to ignore the
+field because they address an immutable past snapshot.
 
 ## Pebble snapshot
 
-`store.NewReadHandle()` returns a Pebble snapshot. Within one controller request, main-store leaves and enrichment (volumes, metadata, transaction bodies) all read through the **one** main-store handle `query.OpenQueryHandle` opened. A query for which `AlignmentOwed` is false uses `readStore.NewSnapshot()` only as an implementation handle and executes `listWithoutIndex`; it does not wait for the read-store fold. A query that actually consults an index uses `query.AlignedIndexSnapshot`, which returns a separate index snapshot whose fold cursor covers the main handle's sequence. The two aligned snapshots are therefore *coordinated*, not identical — the index view may be **ahead** of the main handle, and `query.MainHorizonKeep` trims that excess back to the main-store horizon for TRANSACTIONS and LOGS (ACCOUNTS are served as folded). The contract and its per-target exceptions live in [read-snapshot-consistency.md](read-snapshot-consistency.md#cross-store-alignment-en-1748). The main handle — with the reclaim hold taken alongside it — is owned by the returned cursor and closed when that cursor is closed; the index snapshot and its read lease are released once the page's index iteration ends, before enrichment reads the handle. A paginated API call is streamed from that one cursor; when a client requests a subsequent page using the `x-next-cursor`, the server creates a new controller request and therefore fresh snapshot state.
+`store.NewReadHandle()` returns a Pebble snapshot. Within one controller request,
+main-store leaves and enrichment all use that **one** handle. Read-index
+iterators use a separate snapshot certified at the main handle's applied-index
+horizon. The projection may be ahead, so `query.MainHorizonKeep` still trims by
+the main snapshot's native log sequence for TRANSACTIONS and LOGS (ACCOUNTS are
+served as folded). The Raft certificate does not replace this native trimming
+cursor. The detailed per-target rules live in
+[read-snapshot-consistency.md](read-snapshot-consistency.md#cross-store-alignment-en-1748).
+The main handle and reclamation reservation live with the returned cursor; the
+projection snapshot and read lease are released after index iteration.
 
 The cursor carries only the exclusive resume position (for example, an account address or transaction ID); it does not identify or retain the Pebble snapshot. Within one request/page, results are served under the coordinated consistency contract described above: main-store leaves and enrichment reflect that request's single pin, subject to the per-target cross-store exceptions — ACCOUNTS membership is served as folded, so a page may include index members absent from the pinned main store. Because the cursor does not retain that snapshot state, there is no general snapshot-consistency guarantee across separate pages. Inserts, deletes, or updates committed between requests may therefore affect later pages according to the documented cursor ordering and filtering semantics. Duplications or omissions across pages under concurrent writes are not, by themselves, evidence of a product defect unless an API contract explicitly promises a cross-page snapshot.
 
@@ -167,7 +185,12 @@ The cursor is sent back as an `x-next-cursor` gRPC trailer.
 
 ## Special read paths
 
-**Query checkpoints.** When the request carries a `checkpoint_id > 0`, the controller resolves the checkpoint to its frozen main-store + read-store snapshot pair, ignores `min_log_sequence` entirely, and runs the same iterator pipeline against the frozen views. The pair is already frozen, so `AlignedIndexSnapshot` performs no catch-up wait. Useful for reconciliation and auditing. See [query-checkpoints.md](query-checkpoints.md).
+**Query checkpoints.** When the request carries a `checkpoint_id > 0`, the
+controller resolves the checkpoint to its frozen main-store + read-store pair
+and verifies the stored projection certificate against the checkpoint's durable
+applied index. `min_log_sequence` is ignored for that immutable snapshot. Useful
+for reconciliation and auditing. See
+[query-checkpoints.md](query-checkpoints.md).
 
 **Aggregate volumes.** `ExecutePreparedQuery` with the `AGGREGATE_VOLUMES` mode runs the same compiled filter to obtain a candidate account set, then loops over per-account asset volumes in the main store and sums per asset. The aggregation is computed at request time — there is no precomputed aggregate table.
 

--- a/docs/technical/architecture/subsystems/read-path/read-snapshot-consistency.md
+++ b/docs/technical/architecture/subsystems/read-path/read-snapshot-consistency.md
@@ -106,19 +106,19 @@ state ever produced.
 index snapshot through `query.AlignedIndexSnapshot`, and wraps the compiled
 iterator with `query.MainHorizonKeep`.**
 
-`AlignedIndexSnapshot` returns a read-index snapshot whose fold cursor covers
-the handle's last applied sequence (verified through the snapshot itself, so
-the check cannot race it), waiting for the fold for as long as the caller's
-context allows. There is deliberately no server-side cap: alignment is not
-optional for a filtered read, so how much latency to spend on it belongs to
-the caller, and a cap would diverge rather than converge — the pin is fixed
-for the life of the handle, so waiting makes progress, while a retry opens a
-new handle at a higher sequence and leaves the fold further behind than the
-attempt that gave up. It also
-registers the handle's sequence as a *read lease*, bounding the event GC (see
-below); the caller releases it with the returned closure when iteration ends.
-Because the fold is ordered, such a snapshot holds every index event at or
-below the handle's sequence. That sequence is the query's **pin**:
+For linearizable reads, routing first obtains the Raft `ReadIndex` horizon `R`.
+`AlignedIndexSnapshot` then reads the durable `LastAppliedIndex` `H` from the
+already-open main handle and verifies `H >= R`. For `stale`, there is no `R`,
+but the local main handle still supplies the fixed `H`. The function waits for
+the read projection's independent Raft certificate to reach `H`, opens a
+projection snapshot, and re-reads the certificate through that snapshot so the
+proof cannot race the view it vouches for. There is no server-side timeout: the
+caller context owns the deadline, and the wait targets fixed `H`, never the
+moving store head.
+
+The native log sequence remains the query's **pin** for event resolution,
+reclamation leases and ahead-of-main trimming. It is deliberately not used as
+the causal cross-projection certificate:
 
 - main-store leaves and enrichment reflect the pin exactly;
 - metadata and exists index leaves resolve their append-only event groups at
@@ -139,6 +139,17 @@ the reverse LOGS arm, whose unfiltered scan also iterates the read index),
 `AggregateVolumes`, and the prepared-query executor. Index-introspection
 endpoints (GetIndexStatus, InspectIndex, GetIndexEntryStatus) read only the
 index snapshot and need no alignment.
+
+Audit follows the same rule independently. Unfiltered audit reads and filters
+made only of audit `sequence` bounds scan the authoritative main snapshot and
+do not wait for the audit projection. Other supported audit filters wait for
+the audit Raft certificate, compile against that verified audit snapshot, and
+load `AuditEntry` values from the original main snapshot. Candidates ahead of
+the main audit sequence are trimmed. The audit lifecycle generation is captured
+before opening the projection snapshot and rechecked before accepting its
+certificate, so a concurrent rebuild cannot expose the previous generation.
+A disabled/rebuilding audit index fails a dependent query explicitly; it does
+not affect independent audit reads.
 
 **Version activation**: a rewrite stamps every event it writes with the one
 FSM sequence it read from, so a promoted version resolves as EMPTY at any pin

--- a/docs/technical/architecture/subsystems/read-path/typed-metadata.md
+++ b/docs/technical/architecture/subsystems/read-path/typed-metadata.md
@@ -155,10 +155,11 @@ as RFC3339 strings.
 
 ### Progress and barriers
 
-`min_log_sequence` waits for the local FSM and indexer's log cursor. It does not
-wait for a schema rewrite to switch versions. `PendingVersion != 0` is the local
-rewrite signal exposed through index status; there is no field-level conversion
-status or schema-rewrite barrier.
+Indexed reads automatically wait for the projection's Raft certificate at the
+fixed main-snapshot horizon. That certificate does not wait for a schema rewrite
+to switch versions. `PendingVersion != 0` is the local rewrite signal exposed
+through index status; there is no field-level conversion status or
+schema-rewrite barrier.
 
 ## API surface
 

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -13,7 +13,7 @@ This document compares the POC's API with the original Formance ledger API and d
 ### Service protocol compatibility (EN-1851)
 
 The v3 gRPC service requires one `ledger-protocol-version` metadata value per
-business RPC, equal to `pkg/grpcprotocol.Version` (currently `"1"`). Missing,
+business RPC, equal to `pkg/grpcprotocol.Version` (currently `"2"`). Missing,
 invalid, duplicate, or different revisions fail with `FailedPrecondition` before
 business handler execution. This applies to unary and streaming Bucket, Cluster,
 and Restore operations, including internal forwarding. Discovery, gRPC health,

--- a/internal/adapter/grpc/protocol_interceptor_test.go
+++ b/internal/adapter/grpc/protocol_interceptor_test.go
@@ -94,7 +94,7 @@ func TestServiceServerProtocolVersion(t *testing.T) {
 				{"missing", nil},
 				{"empty", []string{""}},
 				{"older", []string{"0"}},
-				{"newer", []string{"2"}},
+				{"newer", []string{"3"}},
 				{"invalid", []string{"dev"}},
 				{"duplicate", []string{grpcprotocol.Version, grpcprotocol.Version}},
 				{"conflicting", []string{grpcprotocol.Version, "0"}},

--- a/internal/adapter/http/handlers_list_audit_entries.go
+++ b/internal/adapter/http/handlers_list_audit_entries.go
@@ -33,16 +33,13 @@ import (
 // see commonpb/query_filter.go).
 //
 // It is NOT a full parity of the gRPC ListOptions contract: the gRPC surface
-// additionally honors the read-consistency options `checkpointId` (pinned
-// checkpoint read) and `minLogSequence` (audit-index catch-up wait for filtered
-// reads). This HTTP endpoint intentionally does not expose either — it always
-// performs a live, best-effort read. A filter containing a field other than
-// seq therefore resolves through the async audit secondary index and may
-// transiently omit very recent entries that have not yet been indexed; a client
-// needing a pinned or consistency-bounded audit read must use the gRPC surface.
-// If these options are added to HTTP later, wire them through the same
-// controller entry points the gRPC path uses (impl.openCheckpointStores /
-// minLogSequence gating).
+// additionally honors `checkpointId` and `minLogSequence`. This HTTP endpoint
+// intentionally exposes neither and always performs a live read. A filter
+// containing a field other than seq still resolves through the asynchronous
+// audit projection, but the routed controller fixes a main-store Raft horizon
+// and the controller waits for the projection to certify it before querying
+// its snapshot. If checkpoint or explicit native-sequence options are added to
+// HTTP later, wire them through the same controller entry points as gRPC.
 func (s *Server) handleListAuditEntries(w http.ResponseWriter, r *http.Request) {
 	pageSize, ok := parsePageSize(w, r)
 	if !ok {

--- a/internal/application/admission/admission.go
+++ b/internal/application/admission/admission.go
@@ -873,16 +873,14 @@ func (a *Admission) checkQueryCheckpointProjectionReady(reqs []*servicepb.Reques
 		}
 
 		disabled, rebuilding := a.auditProjectionState()
-		if !disabled && !rebuilding {
-			return nil
+		if disabled {
+			return &domain.BusinessError{Err: domain.ErrAuditDisabled}
 		}
-
-		state := "disabled"
 		if rebuilding {
-			state = "rebuilding"
+			return &domain.BusinessError{Err: &domain.ErrIndexBuilding{Index: "audit (rebuilding)"}}
 		}
 
-		return &domain.BusinessError{Err: &domain.ErrIndexBuilding{Index: "audit (" + state + ")"}}
+		return nil
 	}
 
 	return nil

--- a/internal/application/admission/query_checkpoint_readiness_test.go
+++ b/internal/application/admission/query_checkpoint_readiness_test.go
@@ -27,12 +27,13 @@ func TestCheckQueryCheckpointProjectionReady(t *testing.T) {
 		reqs       []*servicepb.Request
 		disabled   bool
 		rebuilding bool
-		wantErr    bool
+		wantReason string
+		wantKind   domain.ErrorKind
 	}{
 		{name: "ready", reqs: []*servicepb.Request{checkpoint}},
-		{name: "disabled", reqs: []*servicepb.Request{checkpoint}, disabled: true, wantErr: true},
-		{name: "rebuilding", reqs: []*servicepb.Request{checkpoint}, rebuilding: true, wantErr: true},
-		{name: "mixed batch", reqs: []*servicepb.Request{nonCheckpoint, checkpoint}, disabled: true, wantErr: true},
+		{name: "disabled", reqs: []*servicepb.Request{checkpoint}, disabled: true, wantReason: domain.ErrReasonAuditDisabled, wantKind: domain.KindPrecondition},
+		{name: "rebuilding", reqs: []*servicepb.Request{checkpoint}, rebuilding: true, wantReason: domain.ErrReasonIndexBuilding, wantKind: domain.KindUnavailable},
+		{name: "mixed batch", reqs: []*servicepb.Request{nonCheckpoint, checkpoint}, disabled: true, wantReason: domain.ErrReasonAuditDisabled, wantKind: domain.KindPrecondition},
 		{name: "unrelated request", reqs: []*servicepb.Request{nonCheckpoint}, disabled: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -42,15 +43,16 @@ func TestCheckQueryCheckpointProjectionReady(t *testing.T) {
 				return tc.disabled, tc.rebuilding
 			}}
 			err := a.checkQueryCheckpointProjectionReady(tc.reqs)
-			if !tc.wantErr {
+			if tc.wantReason == "" {
 				require.NoError(t, err)
 
 				return
 			}
 
-			var building *domain.ErrIndexBuilding
-			require.ErrorAs(t, err, &building)
-			require.Contains(t, building.Index, "audit")
+			var describable domain.Describable
+			require.ErrorAs(t, err, &describable)
+			require.Equal(t, tc.wantReason, describable.Reason())
+			require.Equal(t, tc.wantKind, domain.Kind(describable))
 		})
 	}
 }

--- a/internal/application/ctrl/controller_default.go
+++ b/internal/application/ctrl/controller_default.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/cockroachdb/pebble/v2"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
@@ -55,6 +56,17 @@ const (
 type releasingCloser struct {
 	handle  io.Closer
 	release func()
+}
+
+type joinedCloser []io.Closer
+
+func (c joinedCloser) Close() error {
+	var err error
+	for _, closer := range c {
+		err = errors.Join(err, closer.Close())
+	}
+
+	return err
 }
 
 func (c releasingCloser) Close() error {
@@ -900,26 +912,50 @@ func (ctrl *DefaultController) AggregateVolumes(ctx context.Context, ledgerName 
 
 	schemaFields := query.SchemaFieldsForTarget(ledgerInfo.GetMetadataSchema(), commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS)
 
-	snap, mainSeq, releaseLease, err := query.AlignedIndexSnapshot(ctx, ctrl.readStore, handle, releaseHold)
-	if err != nil {
-		return nil, err
-	}
+	var (
+		indexReader     dal.PebbleReader
+		indexVersionFor readstore.IndexVersionResolver
+		mainSeq         uint64
+		horizonKeep     func([]byte) (bool, error)
+	)
 
-	defer releaseLease()
-	defer func() { _ = snap.Close() }()
+	if query.AlignmentOwed(filter, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS) {
+		snap, alignedMainSeq, releaseLease, alignErr := query.AlignedIndexSnapshot(ctx, ctrl.readStore, handle, releaseHold)
+		if alignErr != nil {
+			return nil, alignErr
+		}
+
+		defer releaseLease()
+		defer func() { _ = snap.Close() }()
+
+		indexReader = snap
+		mainSeq = alignedMainSeq
+		indexVersionFor = readstore.PinnedVersionResolver(snap, ledgerInfo.GetName(), mainSeq)
+		horizonKeep = query.MainHorizonKeep(commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, handle, snap, ledgerInfo.GetName(), mainSeq)
+	} else {
+		// Main-store-only filters still go through Compile for validation and
+		// boolean semantics, but must not wait for or lease the read projection.
+		releaseHold()
+
+		snap := ctrl.readStore.NewSnapshot()
+		defer func() { _ = snap.Close() }()
+
+		indexReader = snap
+		indexVersionFor = readstore.SnapshotVersionResolver(snap, ledgerInfo.GetName())
+	}
 
 	kb := dal.NewKeyBuilder()
 
 	indexStart := time.Now()
 
-	compiled, err := query.Compile(snap, kb, filter, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, ledgerInfo.GetName(), nil, schemaFields, ledgerInfo, query.NewPebbleIndexReader(ctrl.attrs.Index, handle), readstore.PinnedVersionResolver(snap, ledgerInfo.GetName(), mainSeq), profile, handle, mainSeq)
+	compiled, err := query.Compile(indexReader, kb, filter, commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, ledgerInfo.GetName(), nil, schemaFields, ledgerInfo, query.NewPebbleIndexReader(ctrl.attrs.Index, handle), indexVersionFor, profile, handle, mainSeq)
 	if err != nil {
 		return nil, domain.WrapCompileError(err)
 	}
 
 	var iter = compiled
-	if keep := query.MainHorizonKeep(commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, handle, snap, ledgerInfo.GetName(), mainSeq); keep != nil {
-		iter = readstore.NewFilterIterator(compiled, keep)
+	if horizonKeep != nil {
+		iter = readstore.NewFilterIterator(compiled, horizonKeep)
 	}
 	defer iter.Close()
 
@@ -1669,10 +1705,11 @@ func (ctrl *DefaultController) ListAuditEntries(ctx context.Context, pageSize ui
 }
 
 // ListAuditEntriesFrom returns a cursor over audit entries using the provided
-// stores (live or query checkpoint). The audit trail is queried exclusively
-// through the readstore audit secondary index (EN-1339) plus an audit-zone
-// sequence bound — there is no scan-time predicate fallback, so an expression
-// the index cannot answer is rejected upstream with InvalidArgument.
+// stores (live or query checkpoint). Nil and sequence-only filters scan the
+// authoritative audit zone directly. Indexed filters use a certificate-gated
+// readstore snapshot (EN-1339), then trim candidates to the main snapshot's
+// audit horizon. There is no scan-time predicate fallback for unsupported
+// expressions; they are rejected with InvalidArgument.
 func (ctrl *DefaultController) ListAuditEntriesFrom(ctx context.Context, store *dal.Store, rs *readstore.Store, pageSize uint32, afterSequence uint64, filter *commonpb.QueryFilter, reverse bool) (cursor.Cursor[*auditpb.AuditEntry], error) {
 	ctx, span := tracer.Start(ctx, "ctrl.list_audit_entries",
 		trace.WithAttributes(
@@ -1697,6 +1734,14 @@ func (ctrl *DefaultController) ListAuditEntriesFrom(ctx context.Context, store *
 		}
 	}()
 
+	mainAppliedIndex, err := query.ReadLastAppliedIndex(handle)
+	if err != nil {
+		return nil, fmt.Errorf("reading main-store applied index: %w", err)
+	}
+	if barrier, ok := query.ReadBarrierHorizon(ctx); ok && mainAppliedIndex < barrier {
+		return nil, fmt.Errorf("main-store snapshot applied index %d is behind ReadIndex horizon %d", mainAppliedIndex, barrier)
+	}
+
 	// The audit projection folds independently of this handle's main-store
 	// view, so its index can hold sequences past the audit head visible here
 	// (a live handle opened before the fold, or a frozen pair whose read index
@@ -1706,9 +1751,70 @@ func (ctrl *DefaultController) ListAuditEntriesFrom(ctx context.Context, store *
 	if err != nil {
 		return nil, fmt.Errorf("reading main-store audit horizon: %w", err)
 	}
+	if err := query.ValidateAuditFilter(filter); err != nil {
+		return nil, err
+	}
 
-	seqs, loSeq, hiSeq, narrowed, err := query.CompileAuditFilter(rs, filter)
+	var auditSnap *pebble.Snapshot
+	indexReader := query.AuditIndexReader(rs)
+	if query.AuditFilterNeedsIndex(filter) {
+		for {
+			disabled, rebuilding, auditGeneration := rs.AuditProjectionStateWithGeneration()
+			if disabled {
+				return nil, &domain.BusinessError{Err: domain.ErrAuditDisabled}
+			}
+			if rebuilding {
+				return nil, &domain.BusinessError{Err: &domain.ErrIndexBuilding{Index: "audit (rebuilding)"}}
+			}
+
+			auditSnap = rs.NewSnapshot()
+			progress, err := rs.ReadAuditRaftProgressFrom(auditSnap)
+			if err != nil {
+				_ = auditSnap.Close()
+
+				return nil, fmt.Errorf("reading audit projection progress: %w", err)
+			}
+			if progress >= mainAppliedIndex {
+				disabled, rebuilding, currentGeneration := rs.AuditProjectionStateWithGeneration()
+				if disabled {
+					_ = auditSnap.Close()
+
+					return nil, &domain.BusinessError{Err: domain.ErrAuditDisabled}
+				}
+				if rebuilding {
+					_ = auditSnap.Close()
+
+					return nil, &domain.BusinessError{Err: &domain.ErrIndexBuilding{Index: "audit (rebuilding)"}}
+				}
+				if currentGeneration != auditGeneration {
+					_ = auditSnap.Close()
+
+					continue
+				}
+				indexReader = readstore.NewAuditIndexSnapshot(auditSnap)
+
+				break
+			}
+			_ = auditSnap.Close()
+			if rs.Frozen() {
+				return nil, &domain.BusinessError{Err: &domain.ErrIndexBuilding{Index: "audit checkpoint"}}
+			}
+			if err := rs.WaitForAuditRaftProgress(ctx, mainAppliedIndex); errors.Is(err, readstore.ErrAuditProjectionUnavailable) {
+				return nil, &domain.BusinessError{Err: domain.ErrAuditDisabled}
+			} else if errors.Is(err, readstore.ErrAuditProjectionFailed) {
+				return nil, &domain.BusinessError{Err: &domain.ErrIndexBuilding{Index: "audit (rebuilding)"}}
+			} else if err != nil {
+				return nil, fmt.Errorf("waiting for audit projection alignment at Raft index %d: %w", mainAppliedIndex, err)
+			}
+		}
+	}
+
+	seqs, loSeq, hiSeq, narrowed, err := query.CompileAuditFilter(indexReader, filter)
 	if err != nil {
+		if auditSnap != nil {
+			_ = auditSnap.Close()
+		}
+
 		return nil, err
 	}
 	if hiSeq > mainAuditSequence {
@@ -1719,10 +1825,17 @@ func (ctrl *DefaultController) ListAuditEntriesFrom(ctx context.Context, store *
 	// reverse=false as ascending, so pass reverse through directly.
 	c, err := query.ReadAuditEntriesPage(ctx, handle, seqs, narrowed, loSeq, hiSeq, afterSequence, reverse, pageSize)
 	if err != nil {
+		if auditSnap != nil {
+			_ = auditSnap.Close()
+		}
+
 		return nil, fmt.Errorf("listing audit entries: %w", err)
 	}
 
 	closeHandle = false
+	if auditSnap != nil {
+		return cursor.NewClosingCursor(c, joinedCloser{auditSnap, handle}), nil
+	}
 
 	return cursor.NewClosingCursor(c, handle), nil
 }

--- a/internal/application/ctrl/controller_default_audit_alignment_test.go
+++ b/internal/application/ctrl/controller_default_audit_alignment_test.go
@@ -1,0 +1,275 @@
+package ctrl
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/infra/state"
+	"github.com/formancehq/ledger/v3/internal/pkg/cursor"
+	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/query"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+type testCloseFunc func() error
+
+func (f testCloseFunc) Close() error { return f() }
+
+func TestJoinedCloserClosesEverySnapshotAndJoinsErrors(t *testing.T) {
+	t.Parallel()
+
+	wantErr := errors.New("close failure")
+	closed := 0
+	err := (joinedCloser{
+		testCloseFunc(func() error {
+			closed++
+
+			return wantErr
+		}),
+		testCloseFunc(func() error {
+			closed++
+
+			return nil
+		}),
+	}).Close()
+
+	require.Equal(t, 2, closed)
+	require.ErrorIs(t, err, wantErr)
+}
+
+func TestListAuditEntriesRejectsMainSnapshotBehindReadBarrier(t *testing.T) {
+	t.Parallel()
+
+	ctrl, _ := newAuditAlignmentController(t, 12, 1)
+	ctx := query.WithReadBarrierHorizon(context.Background(), 13)
+
+	_, err := ctrl.ListAuditEntries(ctx, 10, 0, nil, false, 0)
+	require.ErrorContains(t, err, "behind ReadIndex horizon")
+}
+
+func TestListAuditEntriesFrozenProjectionMustCoverMainCheckpoint(t *testing.T) {
+	t.Parallel()
+
+	ctrl, rs := newAuditAlignmentController(t, 12, 1)
+	batch := rs.NewBatch()
+	require.NoError(t, rs.WriteAuditProgress(batch, 1))
+	require.NoError(t, rs.WriteAuditRaftProgress(batch, 11))
+	require.NoError(t, batch.Commit())
+
+	checkpointDir := filepath.Join(t.TempDir(), "readindex")
+	require.NoError(t, rs.CreateCheckpoint(checkpointDir))
+	frozen, err := readstore.OpenReadOnly(checkpointDir, logging.NopZap())
+	require.NoError(t, err)
+	defer func() { _ = frozen.Close() }()
+
+	_, err = ctrl.ListAuditEntriesFrom(
+		context.Background(), ctrl.store, frozen, 10, 0, auditLedgerFilter("main"), false,
+	)
+	require.ErrorContains(t, err, "audit checkpoint")
+}
+
+func newAuditAlignmentController(t *testing.T, appliedIndex uint64, sequences ...uint64) (*DefaultController, *readstore.Store) {
+	t.Helper()
+
+	logger := logging.NopZap()
+	meter := noop.NewMeterProvider().Meter("test")
+	store, err := dal.NewStore(t.TempDir(), logger, meter, dal.DefaultConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Close() })
+
+	batch := store.OpenWriteSession()
+	for _, sequence := range sequences {
+		key := dal.NewKeyBuilder().PutZonePrefix(dal.ZoneHistory, dal.SubHistoryAudit).PutUint64(sequence).Build()
+		require.NoError(t, batch.SetProto(key, &auditpb.AuditEntry{
+			Sequence: sequence,
+			Outcome:  &auditpb.AuditEntry_Success{Success: &auditpb.AuditSuccess{}},
+			Ledgers:  []string{"main"},
+		}))
+	}
+	require.NoError(t, state.SetAppliedIndex(batch, appliedIndex))
+	require.NoError(t, batch.Commit())
+
+	rs, err := readstore.New(t.TempDir(), logger, readstore.DefaultConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rs.Close() })
+
+	return NewDefaultController(nil, store, logger, attributes.New(), rs, nil, meter), rs
+}
+
+func auditSequenceFilter(minimum uint64) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Audit{Audit: &commonpb.AuditCondition{
+		Field: commonpb.AuditField_AUDIT_FIELD_SEQUENCE,
+		Condition: &commonpb.AuditCondition_UintCond{UintCond: &commonpb.UintCondition{
+			Min: &minimum,
+		}},
+	}}}
+}
+
+func auditLedgerFilter(ledger string) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Audit{Audit: &commonpb.AuditCondition{
+		Field: commonpb.AuditField_AUDIT_FIELD_LEDGER,
+		Condition: &commonpb.AuditCondition_StringCond{StringCond: &commonpb.StringCondition{
+			Value: &commonpb.StringCondition_Hardcoded{Hardcoded: ledger},
+		}},
+	}}}
+}
+
+func collectAuditSequences(t *testing.T, c cursor.Cursor[*auditpb.AuditEntry]) []uint64 {
+	t.Helper()
+
+	entries, err := cursor.Collect(c)
+	require.NoError(t, err)
+	sequences := make([]uint64, len(entries))
+	for index, entry := range entries {
+		sequences[index] = entry.GetSequence()
+	}
+
+	return sequences
+}
+
+func TestListAuditEntriesOnlyWaitsWhenFilterUsesAuditProjection(t *testing.T) {
+	t.Parallel()
+
+	ctrl, rs := newAuditAlignmentController(t, 12, 1, 2)
+	rs.SetAuditProjectionState(true, false)
+	_, err := ctrl.ListAuditEntries(context.Background(), 10, 0, &commonpb.QueryFilter{}, false, 0)
+	require.Equal(t, codes.InvalidArgument, status.Code(err),
+		"malformed filters must be validated before projection readiness")
+
+	for name, filter := range map[string]*commonpb.QueryFilter{
+		"unfiltered":    nil,
+		"sequence-only": auditSequenceFilter(2),
+	} {
+		t.Run(name, func(t *testing.T) {
+			c, err := ctrl.ListAuditEntries(context.Background(), 10, 0, filter, false, 0)
+			require.NoError(t, err, "a query independent of the disabled projection must remain available")
+			got := collectAuditSequences(t, c)
+			if filter == nil {
+				require.Equal(t, []uint64{1, 2}, got)
+			} else {
+				require.Equal(t, []uint64{2}, got)
+			}
+		})
+	}
+
+	_, err = ctrl.ListAuditEntries(context.Background(), 10, 0, auditLedgerFilter("main"), false, 0)
+	var disabled domain.Describable
+	require.ErrorAs(t, err, &disabled)
+	require.Equal(t, domain.ErrReasonAuditDisabled, disabled.Reason())
+	require.Equal(t, domain.KindPrecondition, domain.Kind(disabled),
+		"a permanently disabled projection is a precondition, not a retryable build")
+
+	rs.SetAuditProjectionState(false, true)
+	_, err = ctrl.ListAuditEntries(context.Background(), 10, 0, auditLedgerFilter("main"), false, 0)
+	var rebuilding *domain.ErrIndexBuilding
+	require.ErrorAs(t, err, &rebuilding)
+	require.Equal(t, "audit (rebuilding)", rebuilding.Index)
+	require.Equal(t, domain.ErrReasonIndexBuilding, rebuilding.Reason())
+	require.Equal(t, domain.KindUnavailable, domain.Kind(rebuilding),
+		"a rebuilding projection remains retryable")
+}
+
+func TestListAuditEntriesEmptyOrDoesNotDependOnAuditProjection(t *testing.T) {
+	t.Parallel()
+
+	emptyOr := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Or{Or: &commonpb.OrFilter{}}}
+	for _, state := range []struct {
+		name       string
+		disabled   bool
+		rebuilding bool
+	}{
+		{name: "disabled", disabled: true},
+		{name: "rebuilding", rebuilding: true},
+	} {
+		t.Run(state.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl, rs := newAuditAlignmentController(t, 12, 1, 2)
+			rs.SetAuditProjectionState(state.disabled, state.rebuilding)
+
+			c, err := ctrl.ListAuditEntries(t.Context(), 10, 0, emptyOr, false, 0)
+			require.NoError(t, err)
+			require.Empty(t, collectAuditSequences(t, c),
+				"OR() is an empty set and must not wait for an index it never reads")
+		})
+	}
+}
+
+func TestListAuditEntriesIndexedFilterHonorsCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctrl, _ := newAuditAlignmentController(t, 12, 1)
+	ctx, cancel := context.WithCancel(query.WithReadBarrierHorizon(context.Background(), 12))
+	cancel()
+
+	_, err := ctrl.ListAuditEntries(ctx, 10, 0, auditLedgerFilter("main"), false, 0)
+	require.ErrorIs(t, err, context.Canceled,
+		"an unavailable required projection must not silently return an incomplete result")
+}
+
+func TestListAuditEntriesMapsConcurrentProjectionFailureToUnavailable(t *testing.T) {
+	t.Parallel()
+
+	ctrl, rs := newAuditAlignmentController(t, 12, 1)
+	errCh := make(chan error, 1)
+	started := make(chan struct{})
+	go func() {
+		close(started)
+		_, err := ctrl.ListAuditEntries(t.Context(), 10, 0, auditLedgerFilter("main"), false, 0)
+		errCh <- err
+	}()
+	<-started
+
+	require.Never(t, func() bool { return len(errCh) > 0 }, 50*time.Millisecond, time.Millisecond,
+		"the indexed read must wait while the projection certificate is behind")
+	rs.SetAuditProjectionFailed()
+
+	var err error
+	require.Eventually(t, func() bool {
+		select {
+		case err = <-errCh:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+	var rebuilding domain.Describable
+	require.ErrorAs(t, err, &rebuilding)
+	require.Equal(t, domain.ErrReasonIndexBuilding, rebuilding.Reason())
+	require.Equal(t, domain.KindUnavailable, domain.Kind(rebuilding),
+		"a projection failure racing the wait must keep the retryable rebuilding contract")
+}
+
+func TestListAuditEntriesUsesAlignedAuditSnapshotAndMainHorizon(t *testing.T) {
+	t.Parallel()
+
+	ctrl, rs := newAuditAlignmentController(t, 12, 1)
+	batch := rs.NewBatch()
+	kb := dal.NewKeyBuilder()
+	require.NoError(t, batch.SetBytes(readstore.AuditIndexStringKey(kb, readstore.AuditFieldLedger, "main", 1), nil))
+	// This row is ahead of the fixed main snapshot and must be horizon-trimmed.
+	require.NoError(t, batch.SetBytes(readstore.AuditIndexStringKey(kb, readstore.AuditFieldLedger, "main", 2), nil))
+	require.NoError(t, rs.WriteAuditProgress(batch, 2))
+	require.NoError(t, rs.WriteAuditRaftProgress(batch, 12))
+	require.NoError(t, batch.Commit())
+
+	ctx := query.WithReadBarrierHorizon(context.Background(), 12)
+	c, err := ctrl.ListAuditEntries(ctx, 10, 0, auditLedgerFilter("main"), false, 0)
+	require.NoError(t, err)
+	require.Equal(t, []uint64{1}, collectAuditSequences(t, c),
+		"audit candidates ahead of H must be trimmed before main-store materialization")
+}

--- a/internal/application/ctrl/list_entities.go
+++ b/internal/application/ctrl/list_entities.go
@@ -124,16 +124,20 @@ func listEntities[T interface{ ~string | ~uint64 }](
 	return result, err
 }
 
-// listWithoutIndex serves the main-store-only shapes: an unfiltered ACCOUNTS or
-// TRANSACTIONS page in either direction. Split out so the aligned path above
-// keeps one exit and this one cannot accidentally acquire a lease or a pin.
+// listWithoutIndex serves the main-store-only shapes: an ACCOUNTS or
+// TRANSACTIONS page whose complete filter tree reads the main store. Split out
+// so the aligned path above keeps one exit and this one cannot accidentally
+// acquire a lease or a pin.
 func listWithoutIndex[T interface{ ~string | ~uint64 }](snap dal.PebbleReader, params entityListParams[T]) (entityListResult, error) {
 	var result entityListResult
 
 	var err error
-	if params.reverse {
+	switch {
+	case params.reverse && params.filter != nil:
+		err = listDescFiltered(snap, params, &result.entityIDs)
+	case params.reverse:
 		err = listDescUnfiltered(snap, params, &result.entityIDs)
-	} else {
+	default:
 		err = listAscending(snap, params, &result.entityIDs)
 	}
 

--- a/internal/application/ctrl/list_transactions_alignment_test.go
+++ b/internal/application/ctrl/list_transactions_alignment_test.go
@@ -95,6 +95,7 @@ func TestListTransactions_AlignsComplementWithPrimaryHorizon(t *testing.T) {
 	wb.Init(indexBatch)
 	require.NoError(t, wb.WriteTransactionTimestampIndex(dal.NewKeyBuilder(), ledger, 42, txID))
 	require.NoError(t, rs.WriteProgress(indexBatch, logSeq))
+	require.NoError(t, rs.WriteRaftProgress(indexBatch, logSeq))
 	require.NoError(t, indexBatch.Commit())
 	rs.NotifyProgress()
 

--- a/internal/application/ctrl/projection_selectivity_test.go
+++ b/internal/application/ctrl/projection_selectivity_test.go
@@ -1,0 +1,113 @@
+package ctrl
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/infra/state"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+	"github.com/formancehq/ledger/v3/internal/query"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+func testUint64Bytes(value uint64) []byte {
+	ret := make([]byte, 8)
+	binary.BigEndian.PutUint64(ret, value)
+
+	return ret
+}
+
+func testTxIDFilter(id uint64) *commonpb.QueryFilter {
+	return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_BuiltinUint{
+		BuiltinUint: &commonpb.BuiltinUintCondition{
+			Field: commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ID,
+			Cond:  &commonpb.UintCondition{Min: &id, Max: &id},
+		},
+	}}
+}
+
+func TestListEntitiesAppliesReverseMainStoreOnlyFilter(t *testing.T) {
+	t.Parallel()
+
+	store := newCtrlTestStore(t)
+	attrs := attributes.New()
+	seedCreatedTransaction(t, store, attrs, "ledger", 1, 1, commonpb.NewTransaction().WithID(1))
+	seedCreatedTransaction(t, store, attrs, "ledger", 2, 2, commonpb.NewTransaction().WithID(2))
+
+	handle, err := store.NewReadHandle()
+	require.NoError(t, err)
+	defer func() { _ = handle.Close() }()
+
+	rs, err := readstore.New(t.TempDir(), logging.NopZap(), readstore.DefaultConfig())
+	require.NoError(t, err)
+	defer func() { _ = rs.Close() }()
+
+	result, err := listEntities(context.Background(), rs, entityListParams[uint64]{
+		target:       commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS,
+		ledgerName:   "ledger",
+		pageSize:     10,
+		filter:       testTxIDFilter(2),
+		reverse:      true,
+		pebbleReader: handle,
+		releaseHold:  func() {},
+		afterToBytes: testUint64Bytes,
+	})
+	require.NoError(t, err)
+	require.Equal(t, [][]byte{testUint64Bytes(2)}, result.entityIDs,
+		"the reverse fast path must compile its main-store-only filter")
+
+	_, err = listEntities(context.Background(), rs, entityListParams[uint64]{
+		target:       commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS,
+		ledgerName:   "ledger",
+		pageSize:     10,
+		filter:       &commonpb.QueryFilter{},
+		reverse:      true,
+		pebbleReader: handle,
+		releaseHold:  func() {},
+		afterToBytes: testUint64Bytes,
+	})
+	require.Error(t, err, "the reverse fast path must not silently accept a malformed filter")
+}
+
+func TestAggregateVolumesMainStoreOnlyFilterDoesNotWaitForReadProjection(t *testing.T) {
+	t.Parallel()
+
+	store := newCtrlTestStore(t)
+	attrs := attributes.New()
+	batch := store.OpenWriteSession()
+	require.NoError(t, state.SaveLedger(batch, "ledger", &commonpb.LedgerInfo{Name: "ledger"}))
+	_, err := attrs.Volume.Set(batch, domain.NewVolumeKey("ledger", "alice", "USD", "").Bytes(), &raftcmdpb.VolumePair{
+		Input: commonpb.NewUint256FromUint64(10),
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.SetAppliedIndex(batch, 10))
+	require.NoError(t, batch.Commit())
+
+	rs, err := readstore.New(t.TempDir(), logging.NopZap(), readstore.DefaultConfig())
+	require.NoError(t, err)
+	defer func() { _ = rs.Close() }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	meter := noop.NewMeterProvider().Meter("test")
+	ctrl := NewDefaultController(nil, store, logging.NopZap(), attrs, rs, nil, meter)
+	filter := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Address{Address: &commonpb.AddressMatch{
+		Match: &commonpb.AddressMatch_HardcodedExact{HardcodedExact: "alice"},
+	}}}
+
+	result, err := ctrl.AggregateVolumes(ctx, "ledger", filter, query.AggregateOptions{})
+	require.NoError(t, err,
+		"a main-store-only aggregation must remain independent of a lagging projection")
+	require.Len(t, result.GetVolumes(), 1)
+	require.Equal(t, uint64(10), result.GetVolumes()[0].GetInput().GetV0())
+}

--- a/internal/bootstrap/controller_routed.go
+++ b/internal/bootstrap/controller_routed.go
@@ -27,6 +27,10 @@ type RoutedController struct {
 
 	servicePool     *transport.ConnectionPool
 	localController ctrl.Controller
+	// readIndexAndWait is the node barrier dependency. NewRoutedController
+	// binds the real Raft implementation; the field keeps production method
+	// tests deterministic without constructing a running Raft node.
+	readIndexAndWait func(context.Context) (*node.ReadBarrierInfo, error)
 }
 
 // getLeaderCtrl returns the local controller when this node considers itself
@@ -98,7 +102,11 @@ func (b *RoutedController) readCtrl(ctx context.Context) (ctrl.Controller, *node
 	// or not the barrier succeeds — a failed attempt is still time the caller
 	// waited (see the fallback branch below).
 	barrierStart := time.Now()
-	barrier, err := b.ReadIndexAndWait(ctx)
+	readIndexAndWait := b.readIndexAndWait
+	if readIndexAndWait == nil {
+		readIndexAndWait = b.ReadIndexAndWait
+	}
+	barrier, err := readIndexAndWait(ctx)
 	query.ProfileFromContext(ctx).AddBarrierWait(time.Since(barrierStart))
 
 	if err == nil {
@@ -161,6 +169,14 @@ func (b *RoutedController) markForwardedIfRemote(ctx context.Context, selected c
 	if selected != b.localController {
 		query.ProfileFromContext(ctx).MarkForwarded()
 	}
+}
+
+func (b *RoutedController) withLocalBarrierHorizon(ctx context.Context, selected ctrl.Controller, barrier *node.ReadBarrierInfo) context.Context {
+	if selected == b.localController && barrier != nil {
+		return query.WithReadBarrierHorizon(ctx, barrier.CommitIndex)
+	}
+
+	return ctx
 }
 
 func (b *RoutedController) IsHealthy() bool {
@@ -236,21 +252,21 @@ func (b *RoutedController) GetTransaction(ctx context.Context, ledgerName string
 }
 
 func (b *RoutedController) ListTransactions(ctx context.Context, ledgerName string, pageSize uint32, afterTxID uint64, filter *commonpb.QueryFilter, reverse bool) (cursor.Cursor[*commonpb.Transaction], error) {
-	c, _, err := b.readCtrl(ctx)
+	c, barrier, err := b.readCtrl(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.ListTransactions(ctx, ledgerName, pageSize, afterTxID, filter, reverse)
+	return c.ListTransactions(b.withLocalBarrierHorizon(ctx, c, barrier), ledgerName, pageSize, afterTxID, filter, reverse)
 }
 
 func (b *RoutedController) ListLogs(ctx context.Context, ledgerName string, afterSequence uint64, pageSize uint32, filter *commonpb.QueryFilter) (cursor.Cursor[*commonpb.Log], error) {
-	c, _, err := b.readCtrl(ctx)
+	c, barrier, err := b.readCtrl(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.ListLogs(ctx, ledgerName, afterSequence, pageSize, filter)
+	return c.ListLogs(b.withLocalBarrierHorizon(ctx, c, barrier), ledgerName, afterSequence, pageSize, filter)
 }
 
 func (b *RoutedController) GetLog(ctx context.Context, sequence uint64) (*commonpb.Log, error) {
@@ -263,12 +279,12 @@ func (b *RoutedController) GetLog(ctx context.Context, sequence uint64) (*common
 }
 
 func (b *RoutedController) ListAuditEntries(ctx context.Context, pageSize uint32, afterSequence uint64, filter *commonpb.QueryFilter, reverse bool, minLogSequence uint64) (cursor.Cursor[*auditpb.AuditEntry], error) {
-	c, _, err := b.readCtrl(ctx)
+	c, barrier, err := b.readCtrl(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.ListAuditEntries(ctx, pageSize, afterSequence, filter, reverse, minLogSequence)
+	return c.ListAuditEntries(b.withLocalBarrierHorizon(ctx, c, barrier), pageSize, afterSequence, filter, reverse, minLogSequence)
 }
 
 func (b *RoutedController) GetAuditEntry(ctx context.Context, sequence uint64) (*auditpb.AuditEntry, error) {
@@ -307,7 +323,7 @@ func (b *RoutedController) ListAccounts(ctx context.Context, ledgerName string, 
 		return nil, err
 	}
 
-	if barrier != nil {
+	if barrier != nil && b.Node != nil && b.Logger() != nil {
 		b.Node.Logger().WithFields(map[string]any{
 			"op":             "ListAccounts",
 			"ledger":         ledgerName,
@@ -318,16 +334,16 @@ func (b *RoutedController) ListAccounts(ctx context.Context, ledgerName string, 
 		}).Infof("read barrier for ListAccounts")
 	}
 
-	return c.ListAccounts(ctx, ledgerName, pageSize, afterAddress, filter, reverse)
+	return c.ListAccounts(b.withLocalBarrierHorizon(ctx, c, barrier), ledgerName, pageSize, afterAddress, filter, reverse)
 }
 
 func (b *RoutedController) AggregateVolumes(ctx context.Context, ledgerName string, filter *commonpb.QueryFilter, opts query.AggregateOptions) (*commonpb.AggregateResult, error) {
-	c, _, err := b.readCtrl(ctx)
+	c, barrier, err := b.readCtrl(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.AggregateVolumes(ctx, ledgerName, filter, opts)
+	return c.AggregateVolumes(b.withLocalBarrierHorizon(ctx, c, barrier), ledgerName, filter, opts)
 }
 
 func (b *RoutedController) ListSigningKeys(ctx context.Context) (cursor.Cursor[*commonpb.SigningKey], error) {
@@ -376,12 +392,12 @@ func (b *RoutedController) ListPreparedQueries(ctx context.Context, ledger strin
 }
 
 func (b *RoutedController) ExecutePreparedQuery(ctx context.Context, req *servicepb.ExecutePreparedQueryRequest) (*servicepb.ExecutePreparedQueryResponse, error) {
-	c, _, err := b.readCtrl(ctx)
+	c, barrier, err := b.readCtrl(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.ExecutePreparedQuery(ctx, req)
+	return c.ExecutePreparedQuery(b.withLocalBarrierHorizon(ctx, c, barrier), req)
 }
 
 func (b *RoutedController) GetLedgerStats(ctx context.Context, ledgerName string) (*commonpb.LedgerStats, error) {
@@ -486,9 +502,14 @@ func (b *RoutedController) ListIndexes(ctx context.Context, req *servicepb.ListI
 var _ ctrl.Controller = (*RoutedController)(nil)
 
 func NewRoutedController(localController ctrl.Controller, node *node.Node, servicePool *transport.ConnectionPool) *RoutedController {
-	return &RoutedController{
+	routed := &RoutedController{
 		Node:            node,
 		servicePool:     servicePool,
 		localController: localController,
 	}
+	if node != nil {
+		routed.readIndexAndWait = node.ReadIndexAndWait
+	}
+
+	return routed
 }

--- a/internal/bootstrap/controller_routed_test.go
+++ b/internal/bootstrap/controller_routed_test.go
@@ -12,9 +12,29 @@ import (
 	"github.com/formancehq/ledger/v3/internal/application/ctrl"
 	"github.com/formancehq/ledger/v3/internal/application/ctrl/ctrlmock"
 	"github.com/formancehq/ledger/v3/internal/infra/node"
+	"github.com/formancehq/ledger/v3/internal/pkg/cursor"
+	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 	"github.com/formancehq/ledger/v3/internal/query"
 )
+
+type barrierHorizonMatcher uint64
+
+func (m barrierHorizonMatcher) Matches(value any) bool {
+	ctx, ok := value.(context.Context)
+	if !ok {
+		return false
+	}
+
+	horizon, ok := query.ReadBarrierHorizon(ctx)
+
+	return ok && horizon == uint64(m)
+}
+
+func (m barrierHorizonMatcher) String() string {
+	return "context carrying the local ReadIndex horizon"
+}
 
 func TestNewRoutedController(t *testing.T) {
 	t.Parallel()
@@ -26,6 +46,7 @@ func TestNewRoutedController(t *testing.T) {
 	assert.Nil(t, rc.localController)
 	assert.Nil(t, rc.servicePool)
 	assert.Nil(t, rc.Node)
+	assert.Nil(t, rc.readIndexAndWait)
 }
 
 func TestRoutedController_IsHealthy_NilNode(t *testing.T) {
@@ -109,4 +130,124 @@ func TestRoutedController_FinishLeaderFallback(t *testing.T) {
 		assert.Nil(t, barrier)
 		assert.False(t, profile.Forwarded)
 	})
+}
+
+func TestRoutedController_WithLocalBarrierHorizon(t *testing.T) {
+	t.Parallel()
+
+	mockCtrl := gomock.NewController(t)
+	local := ctrlmock.NewMockController(mockCtrl)
+	remote := ctrlmock.NewMockController(mockCtrl)
+	routed := &RoutedController{localController: local}
+
+	ctx := routed.withLocalBarrierHorizon(context.Background(), local, &node.ReadBarrierInfo{CommitIndex: 42})
+	horizon, ok := query.ReadBarrierHorizon(ctx)
+	require.True(t, ok)
+	require.Equal(t, uint64(42), horizon)
+
+	_, ok = query.ReadBarrierHorizon(routed.withLocalBarrierHorizon(context.Background(), remote, &node.ReadBarrierInfo{CommitIndex: 42}))
+	require.False(t, ok, "the remote hop establishes and checks its own barrier")
+
+	_, ok = query.ReadBarrierHorizon(routed.withLocalBarrierHorizon(context.Background(), local, nil))
+	require.False(t, ok, "stale and explicit leader reads deliberately carry no linearizable horizon")
+}
+
+func TestRoutedController_IndexedReadsForwardLocalBarrierHorizon(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		expect func(*ctrlmock.MockController)
+		call   func(context.Context, *RoutedController) error
+	}{
+		{
+			name: "list transactions",
+			expect: func(local *ctrlmock.MockController) {
+				local.EXPECT().ListTransactions(barrierHorizonMatcher(42), "ledger", uint32(10), uint64(0), nil, false).
+					Return(cursor.NewSliceCursor([]*commonpb.Transaction{}), nil)
+			},
+			call: func(ctx context.Context, routed *RoutedController) error {
+				_, err := routed.ListTransactions(ctx, "ledger", 10, 0, nil, false)
+
+				return err
+			},
+		},
+		{
+			name: "list logs",
+			expect: func(local *ctrlmock.MockController) {
+				local.EXPECT().ListLogs(barrierHorizonMatcher(42), "ledger", uint64(0), uint32(10), nil).
+					Return(cursor.NewSliceCursor([]*commonpb.Log{}), nil)
+			},
+			call: func(ctx context.Context, routed *RoutedController) error {
+				_, err := routed.ListLogs(ctx, "ledger", 0, 10, nil)
+
+				return err
+			},
+		},
+		{
+			name: "list audit entries",
+			expect: func(local *ctrlmock.MockController) {
+				local.EXPECT().ListAuditEntries(barrierHorizonMatcher(42), uint32(10), uint64(0), nil, false, uint64(0)).
+					Return(cursor.NewSliceCursor([]*auditpb.AuditEntry{}), nil)
+			},
+			call: func(ctx context.Context, routed *RoutedController) error {
+				_, err := routed.ListAuditEntries(ctx, 10, 0, nil, false, 0)
+
+				return err
+			},
+		},
+		{
+			name: "list accounts",
+			expect: func(local *ctrlmock.MockController) {
+				local.EXPECT().ListAccounts(barrierHorizonMatcher(42), "ledger", uint32(10), "", nil, false).
+					Return(cursor.NewSliceCursor([]*commonpb.Account{}), nil)
+			},
+			call: func(ctx context.Context, routed *RoutedController) error {
+				_, err := routed.ListAccounts(ctx, "ledger", 10, "", nil, false)
+
+				return err
+			},
+		},
+		{
+			name: "aggregate volumes",
+			expect: func(local *ctrlmock.MockController) {
+				local.EXPECT().AggregateVolumes(barrierHorizonMatcher(42), "ledger", nil, query.AggregateOptions{}).
+					Return(&commonpb.AggregateResult{}, nil)
+			},
+			call: func(ctx context.Context, routed *RoutedController) error {
+				_, err := routed.AggregateVolumes(ctx, "ledger", nil, query.AggregateOptions{})
+
+				return err
+			},
+		},
+		{
+			name: "execute prepared query",
+			expect: func(local *ctrlmock.MockController) {
+				local.EXPECT().ExecutePreparedQuery(barrierHorizonMatcher(42), gomock.Any()).
+					Return(&servicepb.ExecutePreparedQueryResponse{}, nil)
+			},
+			call: func(ctx context.Context, routed *RoutedController) error {
+				_, err := routed.ExecutePreparedQuery(ctx, &servicepb.ExecutePreparedQueryRequest{})
+
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockCtrl := gomock.NewController(t)
+			local := ctrlmock.NewMockController(mockCtrl)
+			tc.expect(local)
+			routed := &RoutedController{
+				Node:            &node.Node{},
+				localController: local,
+				readIndexAndWait: func(context.Context) (*node.ReadBarrierInfo, error) {
+					return &node.ReadBarrierInfo{CommitIndex: 42}, nil
+				},
+			}
+			ctx, _ := query.WithProfile(t.Context())
+			require.NoError(t, tc.call(ctx, routed))
+		})
+	}
 }

--- a/internal/query/aligned_snapshot.go
+++ b/internal/query/aligned_snapshot.go
@@ -13,19 +13,108 @@ import (
 	"github.com/formancehq/ledger/v3/internal/storage/readstore"
 )
 
+type readBarrierHorizonKey struct{}
+
+type queryHandleStore interface {
+	NewReadHandle() (*dal.ReadHandle, error)
+}
+
+// WithReadBarrierHorizon binds the linearizable ReadIndex result to the local
+// execution context. Stale reads deliberately omit it.
+func WithReadBarrierHorizon(ctx context.Context, horizon uint64) context.Context {
+	return context.WithValue(ctx, readBarrierHorizonKey{}, horizon)
+}
+
+// ReadBarrierHorizon returns the ReadIndex horizon carried by a local routed
+// read, when the request asked for linearizable consistency.
+func ReadBarrierHorizon(ctx context.Context) (uint64, bool) {
+	h, ok := ctx.Value(readBarrierHorizonKey{}).(uint64)
+
+	return h, ok
+}
+
+func mainAppliedHorizon(ctx context.Context, mainReader dal.PebbleGetter) (uint64, error) {
+	horizon, err := ReadLastAppliedIndex(mainReader)
+	if err != nil {
+		return 0, fmt.Errorf("reading main-store applied index: %w", err)
+	}
+	if barrier, ok := ReadBarrierHorizon(ctx); ok && horizon < barrier {
+		return 0, fmt.Errorf(
+			"main-store snapshot applied index %d is behind ReadIndex horizon %d",
+			horizon, barrier,
+		)
+	}
+
+	return horizon, nil
+}
+
 // AlignmentOwed reports whether a query of this shape must wait for the read
-// index to fold up to the main reader's sequence before it can be answered.
+// index to certify the main reader's applied horizon before it can be answered.
 //
 // Only a read that consults the index is owed alignment. An unfiltered
 // ACCOUNTS or TRANSACTIONS query draws its universe from the main store
 // (compileUniverse iterates the main reader) and enriches from that same
 // reader, so it never observes the two stores at different fold points —
 // waiting for the fold would gate it on data it does not read, and a lagging
-// or stopped builder would stall a read that is independent of it. LOGS is
+// or stopped builder would stall a read that is independent of it. The same
+// holds for filters whose complete tree is served by the main store, such as
+// transaction ID/reverted predicates and account-address predicates. LOGS is
 // not in that class even unfiltered: its universe is the read index's
 // per-ledger log limb.
 func AlignmentOwed(filter *commonpb.QueryFilter, target commonpb.QueryTarget) bool {
-	return filter != nil || target == commonpb.QueryTarget_QUERY_TARGET_LOGS
+	if target == commonpb.QueryTarget_QUERY_TARGET_LOGS {
+		return true
+	}
+
+	return filterUsesReadIndex(filter, target)
+}
+
+// filterUsesReadIndex mirrors the storage choice made by compile. Boolean
+// nodes use the read index as soon as any descendant does; NOT also compiles a
+// universe, but ACCOUNTS and TRANSACTIONS universes come from the main store.
+// Unknown/malformed leaves are left to Compile's fail-loud validation and do
+// not acquire an otherwise unused projection wait first.
+func filterUsesReadIndex(filter *commonpb.QueryFilter, target commonpb.QueryTarget) bool {
+	if filter == nil {
+		return false
+	}
+
+	switch f := filter.GetFilter().(type) {
+	case *commonpb.QueryFilter_And:
+		for _, child := range f.And.GetFilters() {
+			if filterUsesReadIndex(child, target) {
+				return true
+			}
+		}
+
+		return false
+	case *commonpb.QueryFilter_Or:
+		for _, child := range f.Or.GetFilters() {
+			if filterUsesReadIndex(child, target) {
+				return true
+			}
+		}
+
+		return false
+	case *commonpb.QueryFilter_Not:
+		return filterUsesReadIndex(f.Not.GetFilter(), target)
+	case *commonpb.QueryFilter_Address:
+		return target == commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS
+	case *commonpb.QueryFilter_BuiltinUint:
+		return f.BuiltinUint.GetField() != commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ID
+	case *commonpb.QueryFilter_Reverted:
+		return false
+	case *commonpb.QueryFilter_Field,
+		*commonpb.QueryFilter_Reference,
+		*commonpb.QueryFilter_LogId,
+		*commonpb.QueryFilter_LogBuiltinUint,
+		*commonpb.QueryFilter_AccountHasAsset:
+		return true
+	case *commonpb.QueryFilter_Ledger:
+		return target == commonpb.QueryTarget_QUERY_TARGET_LOGS
+	default:
+		return false
+	}
 }
 
 // Cross-store alignment for indexed queries (EN-1748). A filter tree mixes
@@ -37,17 +126,19 @@ func AlignmentOwed(filter *commonpb.QueryFilter, target commonpb.QueryTarget) bo
 // through complements ("no timestamp") and mis-windows conjunctions. No
 // single serialized state produces such a response.
 //
-// The alignment invariant: the read-index snapshot's fold cursor must cover
-// the main reader's last applied sequence. The fold is ordered, so such a
-// snapshot holds EVERY index row for the entities the main reader sees;
-// membership can then only exceed the main store (entities committed after
-// the handle), and MainHorizonKeep trims those back. The result is exactly
-// the state at the main reader's sequence.
-// AlignedIndexSnapshot returns a read-index snapshot whose fold cursor is at
-// or beyond mainReader's last applied log sequence, plus that sequence and a
-// release closure. The cursor is verified through the snapshot itself, so the
-// check can never race the snapshot it vouches for. Waits for the fold for as
-// long as the caller's context allows.
+// The alignment invariant uses two deliberately distinct positions. The main
+// reader supplies a fixed durable Raft applied index H; the read-index snapshot
+// must carry a Raft certificate >= H. The projection publishes that certificate
+// only after folding every native log visible in its source snapshot bounded by
+// H, and atomically with the target-completing batch. Its native log cursor is
+// retained separately for fold resumption, event resolution and trimming.
+//
+// AlignedIndexSnapshot returns the certified projection snapshot, the main
+// reader's native log sequence, and a release closure. The certificate is read
+// back through the snapshot itself, so the check cannot race the view it
+// vouches for. A linearizable routed read also carries its ReadIndex result R;
+// the already-open main snapshot must prove H >= R. Stale reads omit R but use
+// the same fixed local H and projection alignment.
 //
 // The release closure drops the read lease registered at the returned
 // sequence — the pin the event GC must not reclaim past (read_lease.go). The
@@ -62,13 +153,9 @@ func AlignmentOwed(filter *commonpb.QueryFilter, target commonpb.QueryTarget) bo
 // fold cursor as of the request's start, for every request in flight.
 //
 // The wait is bounded by the caller's context and nothing else. Alignment is
-// not optional — a filtered read cannot answer correctly until the fold
-// reaches the pin — so how long to spend on it is the caller's call, exactly
-// as a deadline expresses. A server-side cap would also diverge rather than
-// converge: mainSeq is fixed for the life of this handle, so waiting makes
-// progress, while a retry opens a NEW handle at a HIGHER sequence and leaves
-// the fold further behind than the attempt that just gave up. Under sustained
-// write load that never converges.
+// not optional — a filtered read cannot answer correctly until the projection
+// certifies H — so how much latency to spend belongs to the caller. H is fixed
+// for the life of the handle: the wait never chases the moving store head.
 //
 // The lease is released before waiting, so a long wait pins no history and
 // creates no reclamation pressure.
@@ -77,22 +164,21 @@ func AlignedIndexSnapshot(ctx context.Context, rs *readstore.Store, mainReader d
 	if err != nil {
 		return nil, 0, nil, fmt.Errorf("reading main-store sequence: %w", err)
 	}
-
-	// A frozen store (query checkpoint) never advances, so waiting on it is
-	// meaningless: the pair is consistent by construction at the checkpoint's
-	// sequence (the builder materializes the read index as its fold crosses
-	// the CreatedQueryCheckpoint log). Serve it as-is; the horizon filter
-	// still bounds the index-ahead direction. No GC runs against a frozen
-	// store, so there is no lease to hold.
-	if rs.Frozen() {
-		releaseHold()
-
-		return rs.NewSnapshot(), mainSeq, func() {}, nil
+	mainAppliedIndex, err := mainAppliedHorizon(ctx, mainReader)
+	if err != nil {
+		return nil, 0, nil, err
 	}
 
+	// A frozen store (query checkpoint) never advances. The builder publishes
+	// its .ready marker only after every promised projection has certified the
+	// checkpoint's applied index; still re-read that certificate below so a
+	// malformed or incomplete checkpoint fails rather than waiting forever. No
+	// GC runs against a frozen store, so there is no lease to hold.
 	for {
-		lease, ok := rs.Leases().Pin(mainSeq)
-		if !ok {
+		var releaseLease func()
+		if rs.Frozen() {
+			releaseLease = func() {}
+		} else if lease, ok := rs.Leases().Pin(mainSeq); !ok {
 			// OpenQueryHandle holds the floor across the handle's creation,
 			// so a pin beneath it means this read bypassed that helper and
 			// may resolve a group whose history is already reclaimed. There is
@@ -107,32 +193,41 @@ func AlignedIndexSnapshot(ctx context.Context, rs *readstore.Store, mainReader d
 				"invariant: aligned read pinned at %d, below the reclaim floor %d — the handle was not opened through OpenQueryHandle",
 				mainSeq, rs.Leases().ReclaimFloor(),
 			)
+		} else {
+			releaseLease = lease.Release
 		}
 
 		snap := rs.NewSnapshot()
 
-		lastIndexed, err := rs.LastIndexedSequenceFrom(snap)
+		lastIndexed, err := rs.ReadRaftProgressFrom(snap)
 		if err != nil {
 			_ = snap.Close()
-			lease.Release()
+			releaseLease()
 
 			return nil, 0, nil, fmt.Errorf("reading index progress: %w", err)
 		}
 
-		if lastIndexed >= mainSeq {
+		if lastIndexed >= mainAppliedIndex {
 			releaseHold()
 
-			return snap, mainSeq, lease.Release, nil
+			return snap, mainSeq, releaseLease, nil
 		}
 
 		_ = snap.Close()
-		lease.Release()
+		releaseLease()
 
-		if waitErr := rs.WaitForSequence(ctx, mainSeq); waitErr != nil {
+		if rs.Frozen() {
+			return nil, 0, nil, fmt.Errorf(
+				"frozen read projection at Raft index %d is behind main checkpoint horizon %d",
+				lastIndexed, mainAppliedIndex,
+			)
+		}
+
+		if waitErr := rs.WaitForRaftProgress(ctx, mainAppliedIndex); waitErr != nil {
 			// The caller's context ending is the caller's answer; a Pebble
 			// fault reading progress is a real I/O error and must not be
 			// laundered into a freshness condition.
-			return nil, 0, nil, fmt.Errorf("waiting for read index alignment at sequence %d: %w", mainSeq, waitErr)
+			return nil, 0, nil, fmt.Errorf("waiting for read projection alignment at Raft index %d: %w", mainAppliedIndex, waitErr)
 		}
 	}
 }
@@ -219,8 +314,21 @@ func MainHorizonKeep(
 // to make the later Acquire un-refusable, which a read that never resolves an
 // event never performs, so it would hold the event GC's watermark for the life
 // of a request — or of a streaming cursor — in exchange for nothing.
-func OpenQueryHandle(rs *readstore.Store, store *dal.Store, filter *commonpb.QueryFilter, target commonpb.QueryTarget) (*dal.ReadHandle, func(), error) {
-	if rs.Frozen() || !AlignmentOwed(filter, target) {
+func OpenQueryHandle(rs *readstore.Store, store queryHandleStore, filter *commonpb.QueryFilter, target commonpb.QueryTarget) (*dal.ReadHandle, func(), error) {
+	return openQueryHandle(rs, store, AlignmentOwed(filter, target))
+}
+
+// OpenReservedQueryHandle opens the main snapshot before a consumer whose
+// need for native event history cannot be described by an API query filter.
+// The short-lived reservation closes the reclamation race until the consumer
+// either installs a lease through AlignedIndexSnapshot or proves that it does
+// not need history and releases the reservation.
+func OpenReservedQueryHandle(rs *readstore.Store, store queryHandleStore) (*dal.ReadHandle, func(), error) {
+	return openQueryHandle(rs, store, true)
+}
+
+func openQueryHandle(rs *readstore.Store, store queryHandleStore, reserve bool) (*dal.ReadHandle, func(), error) {
+	if rs.Frozen() || !reserve {
 		// A checkpoint's index never advances and nothing reclaims against
 		// it, so there is no floor to hold either.
 		handle, err := store.NewReadHandle()

--- a/internal/query/aligned_snapshot_test.go
+++ b/internal/query/aligned_snapshot_test.go
@@ -3,6 +3,7 @@ package query_test
 import (
 	"context"
 	"encoding/binary"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -30,13 +31,83 @@ func setReadStoreProgress(t *testing.T, rs *readstore.Store, seq uint64) {
 
 	batch := rs.NewBatch()
 	require.NoError(t, rs.WriteProgress(batch, seq))
+	require.NoError(t, rs.WriteRaftProgress(batch, seq))
 	require.NoError(t, batch.Commit())
 	rs.NotifyProgress()
 }
 
-// The alignment invariant: the returned snapshot's fold cursor covers the
-// main handle's last applied sequence, so index leaves can never lag the
-// main-store leaves of the same query (EN-1748).
+func TestAlignmentOwedWaitsOnlyForUsedReadProjection(t *testing.T) {
+	t.Parallel()
+
+	txID := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_BuiltinUint{
+		BuiltinUint: &commonpb.BuiltinUintCondition{Field: commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_ID},
+	}}
+	timestamp := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_BuiltinUint{
+		BuiltinUint: &commonpb.BuiltinUintCondition{Field: commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP},
+	}}
+	reverted := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Reverted{
+		Reverted: &commonpb.RevertedCondition{},
+	}}
+	address := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Address{
+		Address: &commonpb.AddressMatch{},
+	}}
+	metadata := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Field{
+		Field: &commonpb.FieldCondition{},
+	}}
+
+	tests := []struct {
+		name   string
+		target commonpb.QueryTarget
+		filter *commonpb.QueryFilter
+		owed   bool
+	}{
+		{name: "unfiltered accounts", target: commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS},
+		{name: "unfiltered transactions", target: commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS},
+		{name: "unfiltered logs", target: commonpb.QueryTarget_QUERY_TARGET_LOGS, owed: true},
+		{name: "transaction id", target: commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS, filter: txID},
+		{name: "transaction reverted", target: commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS, filter: reverted},
+		{name: "account address", target: commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, filter: address},
+		{name: "transaction address", target: commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS, filter: address, owed: true},
+		{name: "transaction timestamp", target: commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS, filter: timestamp, owed: true},
+		{name: "account metadata", target: commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, filter: metadata, owed: true},
+		{
+			name:   "main-only and tree",
+			target: commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS,
+			filter: &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_And{And: &commonpb.AndFilter{
+				Filters: []*commonpb.QueryFilter{txID, reverted},
+			}}},
+		},
+		{
+			name:   "mixed or tree",
+			target: commonpb.QueryTarget_QUERY_TARGET_TRANSACTIONS,
+			filter: &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Or{Or: &commonpb.OrFilter{
+				Filters: []*commonpb.QueryFilter{txID, timestamp},
+			}}},
+			owed: true,
+		},
+		{
+			name:   "indexed leaf under not",
+			target: commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS,
+			filter: &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Not{Not: &commonpb.NotFilter{
+				Filter: metadata,
+			}}},
+			owed: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, test.owed, query.AlignmentOwed(test.filter, test.target))
+		})
+	}
+}
+
+// The alignment invariant: the returned snapshot's Raft certificate covers
+// the main handle's applied index, so index leaves can never lag the
+// main-store leaves of the same query (EN-1748). The native sequence remains
+// distinct and continues to drive fold resumption and history trimming.
 func TestAlignedIndexSnapshot(t *testing.T) {
 	t.Parallel()
 
@@ -53,9 +124,12 @@ func TestAlignedIndexSnapshot(t *testing.T) {
 	lastSeq, err := query.ReadLastSequence(handle)
 	require.NoError(t, err)
 	require.Positive(t, lastSeq)
+	lastAppliedIndex, err := query.ReadLastAppliedIndex(handle)
+	require.NoError(t, err)
+	require.Positive(t, lastAppliedIndex)
 
 	t.Run("behind then catches up", func(t *testing.T) {
-		setReadStoreProgress(t, rs, lastSeq-1)
+		setReadStoreProgress(t, rs, lastAppliedIndex-1)
 
 		done := make(chan struct{})
 		go func() {
@@ -65,7 +139,7 @@ func TestAlignedIndexSnapshot(t *testing.T) {
 			// it the wait-and-retake loop — both legal executions of the
 			// invariant. The never-catches-up case is pinned by the
 			// context-bound test below.
-			setReadStoreProgress(t, rs, lastSeq)
+			setReadStoreProgress(t, rs, lastAppliedIndex)
 		}()
 
 		snap, mainSeq, release, err := query.AlignedIndexSnapshot(t.Context(), rs, handle, func() {})
@@ -76,14 +150,14 @@ func TestAlignedIndexSnapshot(t *testing.T) {
 
 		require.Equal(t, lastSeq, mainSeq)
 
-		// The vouched cursor is readable through the snapshot itself.
-		got, err := rs.LastIndexedSequenceFrom(snap)
+		// The vouched certificate is readable through the snapshot itself.
+		got, err := rs.ReadRaftProgressFrom(snap)
 		require.NoError(t, err)
-		require.GreaterOrEqual(t, got, mainSeq)
+		require.GreaterOrEqual(t, got, lastAppliedIndex)
 	})
 
 	t.Run("already aligned", func(t *testing.T) {
-		setReadStoreProgress(t, rs, lastSeq+4)
+		setReadStoreProgress(t, rs, lastAppliedIndex+4)
 
 		snap, mainSeq, release, err := query.AlignedIndexSnapshot(t.Context(), rs, handle, func() {})
 		require.NoError(t, err)
@@ -120,6 +194,70 @@ func TestAlignedIndexSnapshot_WaitsOnlyAsLongAsTheCallerAllows(t *testing.T) {
 
 	require.ErrorIs(t, err, context.DeadlineExceeded, "the caller's deadline is what ends the wait")
 	require.Less(t, time.Since(start), time.Second, "it must not outlive the caller's deadline")
+}
+
+func TestAlignedIndexSnapshotRejectsMainSnapshotBehindReadBarrier(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	registerLedger(t, store, "l")
+	appendLogs(t, store, 3, createTestLogsForLedger("l", 1)...)
+
+	rs := newTestReadStore(t)
+	handle, err := store.NewReadHandle()
+	require.NoError(t, err)
+	defer func() { _ = handle.Close() }()
+
+	horizon, err := query.ReadLastAppliedIndex(handle)
+	require.NoError(t, err)
+	setReadStoreProgress(t, rs, horizon+1)
+
+	ctx := query.WithReadBarrierHorizon(t.Context(), horizon+1)
+	_, _, _, err = query.AlignedIndexSnapshot(ctx, rs, handle, func() {})
+	require.ErrorContains(t, err, "behind ReadIndex horizon",
+		"a projection certificate must not hide a main snapshot older than R")
+}
+
+func TestAlignedIndexSnapshotFrozenProjectionMustCoverMainHorizon(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	registerLedger(t, store, "l")
+	appendLogs(t, store, 3, createTestLogsForLedger("l", 1)...)
+
+	handle, err := store.NewReadHandle()
+	require.NoError(t, err)
+	defer func() { _ = handle.Close() }()
+
+	horizon, err := query.ReadLastAppliedIndex(handle)
+	require.NoError(t, err)
+
+	for name, progress := range map[string]uint64{
+		"aligned": horizon,
+		"behind":  horizon - 1,
+	} {
+		t.Run(name, func(t *testing.T) {
+			rs := newTestReadStore(t)
+			setReadStoreProgress(t, rs, progress)
+
+			checkpointDir := filepath.Join(t.TempDir(), "readindex")
+			require.NoError(t, rs.CreateCheckpoint(checkpointDir))
+			frozen, err := readstore.OpenReadOnly(checkpointDir, logging.NopZap())
+			require.NoError(t, err)
+			defer func() { _ = frozen.Close() }()
+
+			snap, _, release, err := query.AlignedIndexSnapshot(t.Context(), frozen, handle, func() {})
+			if progress < horizon {
+				require.ErrorContains(t, err, "frozen read projection")
+
+				return
+			}
+
+			require.NoError(t, err)
+			release()
+			require.NoError(t, snap.Close())
+		})
+	}
 }
 
 // A committed transaction whose index rows have not folded yet must be
@@ -224,6 +362,24 @@ func TestOpenQueryHandle_UnalignedReadHoldsNoFloor(t *testing.T) {
 
 	require.Equal(t, uint64(500), rs.Leases().BeginGC(500),
 		"an unaligned read must not hold the event GC back")
+}
+
+func TestOpenReservedQueryHandleHoldsReclaimFloor(t *testing.T) {
+	t.Parallel()
+
+	store := newTestStore(t)
+	registerLedger(t, store, "l")
+	appendLogs(t, store, 3, createTestLogsForLedger("l", 1)...)
+
+	rs := newTestReadStore(t)
+	setReadStoreProgress(t, rs, 2)
+
+	handle, releaseHold, err := query.OpenReservedQueryHandle(rs, store)
+	require.NoError(t, err)
+	defer releaseHold()
+	defer func() { _ = handle.Close() }()
+
+	require.Equal(t, uint64(2), rs.Leases().BeginGC(1_000))
 }
 
 // The reservation covers the window before the read's pin exists, and no

--- a/internal/query/audit_filter.go
+++ b/internal/query/audit_filter.go
@@ -21,6 +21,20 @@ type AuditIndexReader interface {
 	AuditSeqsByUint64Range(field byte, lo, hi uint64) ([]uint64, error)
 }
 
+type auditValidationIndex struct{}
+
+func (auditValidationIndex) AuditSeqsByString(byte, string) ([]uint64, error) {
+	return nil, nil
+}
+
+func (auditValidationIndex) AuditSeqsByOutcome(bool) ([]uint64, error) {
+	return nil, nil
+}
+
+func (auditValidationIndex) AuditSeqsByUint64Range(byte, uint64, uint64) ([]uint64, error) {
+	return nil, nil
+}
+
 // auditSeqUniverse is the sentinel returned by leaf compilation when a
 // condition does not narrow the candidate set to an index-backed sequence
 // list — specifically AUDIT_FIELD_SEQUENCE, which is served by bounding the
@@ -47,8 +61,9 @@ type auditCompiled struct {
 // AuditFilterNeedsIndex reports whether answering an audit filter may require
 // the asynchronous audit secondary index. A nil filter and a conjunction made
 // exclusively of valid sequence bounds use the authoritative audit-zone scan
-// directly. Every other shape returns true conservatively, including malformed,
-// unknown, OR, or over-depth trees; validation and compilation remain
+// directly. An empty OR is also index-independent because it is the empty set.
+// Every other shape returns true conservatively, including malformed, unknown,
+// non-empty OR, or over-depth trees; validation and compilation remain
 // responsible for returning the precise client error later.
 //
 // This predicate deliberately performs no index reads. The gRPC handler uses it
@@ -56,6 +71,16 @@ type auditCompiled struct {
 // candidates before the barrier intended to make them fresh.
 func AuditFilterNeedsIndex(filter *commonpb.QueryFilter) bool {
 	return auditFilterNeedsIndex(filter, 0)
+}
+
+// ValidateAuditFilter checks the complete audit-filter grammar and leaf values
+// without consulting the asynchronous audit index. Callers use it before a
+// readiness gate so malformed input keeps its InvalidArgument contract even
+// while the projection is disabled or rebuilding.
+func ValidateAuditFilter(filter *commonpb.QueryFilter) error {
+	_, _, _, _, err := CompileAuditFilter(auditValidationIndex{}, filter)
+
+	return err
 }
 
 func auditFilterNeedsIndex(filter *commonpb.QueryFilter, depth int) bool {
@@ -87,6 +112,11 @@ func auditFilterNeedsIndex(filter *commonpb.QueryFilter, depth int) bool {
 		}
 
 		return false
+	case *commonpb.QueryFilter_Or:
+		// OR() compiles to the empty set without consulting an index. Every
+		// non-empty OR remains conservative here: validation/compilation owns
+		// the precise grammar error or index dispatch after the barrier.
+		return f.Or == nil || len(f.Or.GetFilters()) > 0
 	default:
 		return true
 	}
@@ -103,10 +133,10 @@ func auditFilterNeedsIndex(filter *commonpb.QueryFilter, depth int) bool {
 // Only AUDIT_FIELD_* conditions and And/Or over them are accepted. Every other
 // QueryFilter variant — NOT, metadata/address/ledger/log conditions, a
 // non-indexed audit field — is rejected with InvalidArgument. There is no
-// scan-time predicate fallback: the audit trail is queried exclusively through
-// its access paths, so an expression the index cannot answer is refused rather
-// than silently degrading to a full-chain scan (EN-1241 / invariant: audit is
-// the source of truth, projections are the only query surface).
+// scan-time predicate fallback: nil and sequence-only filters scan the
+// authoritative audit zone; indexed fields use the audit secondary index. An
+// expression neither access path can answer is refused rather than silently
+// degrading to a full-chain predicate scan (EN-1241).
 func CompileAuditFilter(idx AuditIndexReader, filter *commonpb.QueryFilter) (seqs []uint64, loSeq, hiSeq uint64, narrowed bool, err error) {
 	if filter == nil {
 		return nil, 0, math.MaxUint64, false, nil

--- a/internal/query/audit_filter_test.go
+++ b/internal/query/audit_filter_test.go
@@ -93,6 +93,15 @@ func TestAuditFilterNeedsIndex(t *testing.T) {
 			outcome,
 		}}},
 	}
+	mixedOr := &commonpb.QueryFilter{
+		Filter: &commonpb.QueryFilter_Or{Or: &commonpb.OrFilter{Filters: []*commonpb.QueryFilter{
+			seqLower,
+			outcome,
+		}}},
+	}
+	indexedNot := &commonpb.QueryFilter{
+		Filter: &commonpb.QueryFilter_Not{Not: &commonpb.NotFilter{Filter: outcome}},
+	}
 
 	tooDeep := seqLower
 	for range MaxFilterDepth {
@@ -109,8 +118,11 @@ func TestAuditFilterNeedsIndex(t *testing.T) {
 		{name: "nil", input: nil, want: false},
 		{name: "sequence bound", input: seqLower, want: false},
 		{name: "and of sequence bounds", input: seqAnd, want: false},
+		{name: "empty or", input: &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Or{Or: &commonpb.OrFilter{}}}, want: false},
 		{name: "indexed field", input: outcome, want: true},
 		{name: "sequence and indexed field", input: mixedAnd, want: true},
+		{name: "sequence or indexed field", input: mixedOr, want: true},
+		{name: "not indexed field", input: indexedNot, want: true},
 		{name: "malformed sequence condition", input: auditString(commonpb.AuditField_AUDIT_FIELD_SEQUENCE, "bad"), want: true},
 		{name: "missing filter arm", input: &commonpb.QueryFilter{}, want: true},
 		{name: "over depth", input: tooDeep, want: true},
@@ -123,6 +135,24 @@ func TestAuditFilterNeedsIndex(t *testing.T) {
 			require.Equal(t, tt.want, AuditFilterNeedsIndex(tt.input))
 		})
 	}
+}
+
+func TestValidateAuditFilterExercisesIndexBackedGrammarWithoutIndexReads(t *testing.T) {
+	t.Parallel()
+
+	minimum := uint64(3)
+	for name, filter := range map[string]*commonpb.QueryFilter{
+		"string":  auditString(commonpb.AuditField_AUDIT_FIELD_LEDGER, "main"),
+		"outcome": auditString(commonpb.AuditField_AUDIT_FIELD_OUTCOME, "success"),
+		"numeric": auditUint(commonpb.AuditField_AUDIT_FIELD_PROPOSAL_ID, &minimum, nil),
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			require.NoError(t, ValidateAuditFilter(filter))
+		})
+	}
+
+	require.Error(t, ValidateAuditFilter(&commonpb.QueryFilter{}))
 }
 
 func TestCompileAuditFilter_Outcome(t *testing.T) {

--- a/pkg/grpcprotocol/protocol.go
+++ b/pkg/grpcprotocol/protocol.go
@@ -12,7 +12,7 @@ const (
 	// Version must change when the client-facing wire format or semantics break.
 	// See docs/technical/architecture/subsystems/api/protocol-compatibility.md.
 	// A compiled constant also identifies local builds without release ldflags.
-	Version = "1"
+	Version = "2"
 	// MetadataKey carries the protocol version, not authentication credentials.
 	MetadataKey = "ledger-protocol-version"
 )

--- a/tests/e2e/business/cross_store_value_skew_test.go
+++ b/tests/e2e/business/cross_store_value_skew_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // Cross-store value skew (EN-1748, metadata-flip half): a row selected by a
@@ -131,10 +133,30 @@ var _ = Describe("Cross-store value skew", Ordered, func() {
 		for time.Now().Before(deadline) {
 			probes++
 
-			accs, err := actions.ListAccountsFiltered(ctx, client, ledgerName, 0, "", gold)
-			// Alignment waits out a lagging fold rather than rejecting, so an
-			// error here is a real failure, not a freshness condition.
-			Expect(err).To(Succeed())
+			// EN-1946 waits for the fixed main-snapshot horizon until the caller's
+			// context ends. Bound each probe so sustained pressure cannot keep the
+			// producers alive while this read waits for its fixed target.
+			probeCtx, cancelProbe := context.WithTimeout(ctx, 250*time.Millisecond)
+			accs, err := actions.ListAccountsFiltered(probeCtx, client, ledgerName, 0, "", gold)
+			cancelProbe()
+			if err != nil {
+				// A lagging fold may reach the client deadline directly, or the
+				// server may wrap that same expired alignment wait as Unavailable.
+				// Keep the latter narrow so unrelated availability failures remain
+				// test failures.
+				switch status.Code(err) {
+				case codes.DeadlineExceeded:
+				case codes.Unavailable:
+					Expect(err.Error()).To(ContainSubstring("waiting for read projection alignment"))
+					Expect(err.Error()).To(Or(
+						ContainSubstring("context deadline exceeded"),
+						ContainSubstring("context canceled"),
+					))
+				default:
+					Fail(fmt.Sprintf("probe %d returned unexpected error: %v", probes, err))
+				}
+				continue
+			}
 
 			served++
 


### PR DESCRIPTION
## Summary

- consume the preceding projection certificates at a fixed main-store Raft horizon;
- align only the read/audit projections actually used by each query;
- propagate the local ReadIndex horizon into controller execution;
- distinguish disabled audit projection (permanent FailedPrecondition) from rebuilding (retryable Unavailable);
- preserve main-horizon trimming and snapshot lifecycle guarantees.

## Stack

EN-1946 stack 3/8. Depends on #1889 (feat/en-1946-projection-certificates).

Merge/review order: #1897 → #1889 → #1890 → #1894 → #1891 → #1893 → #1892 → #1881.

## Validation

Final base: 01f5df313ad6cc82e6cfd84fcbd75ad621d721f0.
Final head: de64081212f63bb07407a5c1eb53fbb4b533f9db.
Canonical PR validation: PASS, including full race validation, business/cluster E2E, and Schemathesis 62/62.
Independent exact diff review: APPROVE (residual risk MEDIUM).

Jira: EN-1946. Do not merge automatically.

### Service protocol compatibility

Incompatible semantic change: service protocol revision `1` → `2`.