### PR TITLE
fix(reads): align index inspection to Raft horizon (EN-1946)

### DIFF
--- a/docs/technical/architecture/subsystems/indexer/README.md
+++ b/docs/technical/architecture/subsystems/indexer/README.md
@@ -5,7 +5,9 @@ The background workers (`internal/application/indexbuilder` and
 audit entries into queryable read-store keyspaces. They run independently on
 every leader and follower and remain outside the FSM hot path. Both retain a
 native resume cursor and publish a separate Raft applied-index certificate for
-cross-store read alignment.
+cross-store read alignment. `InspectIndex` is a projection consumer under the
+same contract: it certifies the fixed main horizon, resolves the servable index
+version at that pin, and ignores membership events committed after it.
 
 ## Documents
 

--- a/docs/technical/architecture/subsystems/indexer/indexes.md
+++ b/docs/technical/architecture/subsystems/indexer/indexes.md
@@ -87,7 +87,7 @@ A rewrite is driven by `indexbuilder.Builder` (`internal/application/indexbuilde
 - `completeBackfill` — when the cursor reaches the global indexer cursor, the **atomic switch** runs: `CurrentVersion ← PendingVersion`, `PendingVersion ← 0`, in one Pebble batch (`backfill.go:1197+`).
 - `handleDroppedIndexLog` — removes the index from the in-memory config, cancels in-flight work, tombstones `IndexVersionState` while preserving `HighWater`, and purges metadata forward (`0x01`), existence (`0x02`), and reverse-map (`0x03`) rows in the same fold batch (`index_config.go`).
 
-A `SetMetadataFieldType` order bumps the cluster-wide `forward_encoding_version` and triggers a **schema rewrite** — a distinct code path (`schemaRewriteTask` / `processSchemaRewrite`, see [indexer.md](indexer.md#changing-a-metadata-keys-type-setmetadatafieldtype)) that reuses the same versioning strategy: queries continue to serve `v_current` until each replica completes its local rewrite and flips its own switch. Synchronisation across nodes is client-driven through `min_log_sequence` on the read API (note: that pins **log application**, not local rewrite completion — see `api-comparison.md`).
+A `SetMetadataFieldType` order bumps the cluster-wide `forward_encoding_version` and triggers a **schema rewrite** — a distinct code path (`schemaRewriteTask` / `processSchemaRewrite`, see [indexer.md](indexer.md#changing-a-metadata-keys-type-setmetadatafieldtype)) that reuses the same versioning strategy: queries continue to serve `v_current` until each replica completes its local rewrite and flips its own switch. Read-side causal alignment is automatic through the projection's Raft progress certificate, while local rewrite readiness remains explicit in `IndexVersionState` — the certificate does not complete or promote a rewrite (see `api-comparison.md`).
 
 ```mermaid
 stateDiagram-v2
@@ -126,7 +126,18 @@ What is deliberately **not** restored: the per-replica `IndexVersionState` rows 
 
 There is **no persisted statistics structure**. The figures returned by `InspectIndex` are recomputed by scanning the live Pebble keyspace at the version the caller asks for.
 
-`readstore.InspectParams` accepts a `Version` (always `IndexVersionState.CurrentVersion` from the controller — `0` is an invariant the caller must short-circuit), a mode, and pagination parameters. Three modes are supported (`internal/storage/readstore/inspect.go`):
+For a default-consistency call, routing obtains a Raft read barrier and
+`InspectIndex` waits until the local read projection certifies the fixed main
+snapshot horizon before opening the snapshot it scans. `stale` skips the quorum
+barrier but retains the same alignment to its fixed local main horizon.
+
+The controller uses `PinnedVersionResolver` so a version activated after the
+main snapshot cannot leak into the inspection. It holds an event-history lease
+at the main snapshot's native sequence for the duration of the scan.
+`readstore.InspectParams` accepts that resolved `Version`, the native
+`HorizonSequence`, a mode, and pagination parameters. Every mode ignores later
+membership events, including the existence events used by summary counts.
+Three modes are supported (`internal/storage/readstore/inspect.go`):
 
 | Mode | Output | Cost |
 |------|--------|------|
@@ -162,6 +173,22 @@ Source: `internal/storage/readstore/inspect.go:228-296`.
 
 The scan is unbuffered — each call rereads the full prefix. This is fine because inspect is a low-frequency operator/UI tool, not a query-planner input: the v3 query path uses **prepared queries** ([prepared-queries draft](../../../../drafts/prepared-queries.md)) rather than a cost-based planner over statistics.
 
+### Inspect consistency traceability (EN-1946)
+
+- **Need:** operators must not receive index statistics assembled from a main-store
+  state and index membership from a different committed state.
+- **Previous limitation:** `InspectIndex` scanned the current read-index head
+  without proving that it covered, or trimming it back to, the fixed main-store
+  snapshot used by the request.
+- **Requirement:** every inspection mode must use one Raft-certified read-index
+  snapshot and resolve membership at the main snapshot's native sequence.
+- **Decision:** route the request barrier, reserve the event-history floor, obtain
+  the projection snapshot through `AlignedIndexSnapshot`, resolve its pinned
+  version, and pass `HorizonSequence` to each scan.
+- **Validation:** controller-level skew coverage exercises the composed alignment
+  path, routed-controller coverage proves barrier propagation, and readstore tests
+  exercise horizon trimming in distinct-values, facets, and summary modes.
+
 ## API Surface
 
 | Layer | Entry point |
@@ -170,7 +197,11 @@ The scan is unbuffered — each call rereads the full prefix. This is fine becau
 | HTTP | `GET /v3/{ledger}/indexes/{canonicalId}/inspect` with `?mode=distinct-values|facets|summary`. Sibling per-ledger routes: `GET /v3/{ledger}/indexes` (list), `GET /v3/{ledger}/indexes/{canonicalId}` (single entry), `.../status` (IndexEntry), `POST /v3/{ledger}/indexes` (create), `DELETE .../indexes/{canonicalId}` (drop). Bucket-wide / cluster-wide reads live under the reserved system segment `/v3/_/indexes/…`: `GET /v3/_/indexes` (list, `?scope=all\|bucket`), `GET /v3/_/indexes/status` (aggregated status), `GET /v3/_/indexes/{canonicalId}` (single bucket-scoped entry), `GET /v3/_/indexes/{canonicalId}/status`. All responses serialize the protobuf message in protobuf-JSON camelCase, wrapped in the `{data:…}` envelope. |
 | CLI | `ledgerctl indexes inspect --ledger … --key … --mode summary` — see [ops/cli.md §indexes inspect](../../../../ops/cli.md). |
 
-The controller (`internal/application/ctrl/controller_default.go`) gates the inspect call on `state.CurrentVersion != 0` — a replica that has never built the index locally returns "not built locally" rather than scanning an empty keyspace.
+The controller (`internal/application/ctrl/controller_default.go`) gates the
+inspect call on the pin-aware resolved version. A replica with no live local
+version-state record returns `ErrIndexNotFound`. A version that exists locally
+but activates after the main snapshot resolves to version zero and returns the
+retryable `ErrIndexBuilding`; neither case scans an empty or future keyspace.
 
 ## Bloom Filter Metrics (Not Index Stats)
 

--- a/docs/technical/architecture/subsystems/read-path/README.md
+++ b/docs/technical/architecture/subsystems/read-path/README.md
@@ -4,10 +4,10 @@ The CQRS read side (`internal/application/ctrl` reads, `internal/query`,
 `internal/storage/readstore`). Default live reads routed through `readCtrl` use
 a `ReadIndex` quorum barrier to establish an applied-state horizon. Point reads
 and unfiltered account/transaction queries then use the main store only.
-Filtered account/transaction queries and every log query additionally wait for
-the read index to align with that horizon before iterating it. `stale` removes
-only the Raft barrier, checkpoint pairs are already frozen, and leader-local,
-audit-index, and usagestore exceptions are documented in the
+Filtered account/transaction queries, every log query, and `InspectIndex`
+additionally wait for the read index to align with that horizon before iterating
+it. `stale` removes only the Raft barrier, checkpoint pairs are already frozen,
+and leader-local, audit-index, and usagestore exceptions are documented in the
 [consensus matrix](../consensus/raft-consensus.md#linearizable-reads-via-readindex)
 and the pipeline pages.
 

--- a/docs/technical/architecture/subsystems/read-path/read-snapshot-consistency.md
+++ b/docs/technical/architecture/subsystems/read-path/read-snapshot-consistency.md
@@ -136,9 +136,14 @@ the causal cross-projection certificate:
 
 Consumers: `listEntities` (ListTransactions/ListAccounts/ListLogs — including
 the reverse LOGS arm, whose unfiltered scan also iterates the read index),
-`AggregateVolumes`, and the prepared-query executor. Index-introspection
-endpoints (GetIndexStatus, InspectIndex, GetIndexEntryStatus) read only the
-index snapshot and need no alignment.
+`AggregateVolumes`, and the prepared-query executor. `InspectIndex` is a
+projection consumer too: it waits for a read-index Raft certificate covering
+the fixed main snapshot, pins that snapshot's native sequence, resolves the
+servable index version at the pin, and ignores later membership events while
+scanning distinct values, facets, and summaries. The reservation-to-lease
+handoff protects the event history needed by that trimming. Operational status
+endpoints (`GetIndexStatus`, `GetIndexEntryStatus`) report the projection's
+current local state and do not make that data-read freshness promise.
 
 Audit follows the same rule independently. Unfiltered audit reads and filters
 made only of audit `sequence` bounds scan the authoritative main snapshot and

--- a/docs/technical/architecture/subsystems/read-path/typed-metadata.md
+++ b/docs/technical/architecture/subsystems/read-path/typed-metadata.md
@@ -147,11 +147,14 @@ conditions are valid for every declared type.
 
 ### Index inspection
 
-`InspectIndex` pins a read-store snapshot, rejects `CurrentVersion == 0`, and
-scans only the locally served version. Distinct values, facets, and summary
-statistics therefore describe one consistent encoding. The HTTP adapter uses
-the declared type as a rendering hint so signed datetime index values are shown
-as RFC3339 strings.
+`InspectIndex` first fixes the main-store snapshot and waits for a read-store
+certificate covering its Raft horizon. It resolves `CurrentVersion` through a
+pin-aware resolver, rejects a zero or not-yet-activated version, and scans that
+version from the aligned index snapshot while ignoring membership events after
+the main snapshot's native sequence. Distinct values, facets, and summary
+statistics therefore describe the same historical state and one consistent
+encoding. The HTTP adapter uses the declared type as a rendering hint so signed
+datetime index values are shown as RFC3339 strings.
 
 ### Progress and barriers
 

--- a/internal/application/ctrl/controller_default.go
+++ b/internal/application/ctrl/controller_default.go
@@ -986,12 +986,14 @@ func (ctrl *DefaultController) InspectIndex(ctx context.Context, req *servicepb.
 		))
 	defer span.End()
 
-	// One snapshot for the schema gate and the index-registry lookup so they
-	// observe the same committed state.
-	handleForIndex, err := ctrl.store.NewReadHandle()
+	// Reserve event history before opening the main snapshot. Inspect resolves
+	// append-only membership events at that snapshot's native sequence, so the
+	// same reservation-to-lease handoff as an indexed entity query is required.
+	handleForIndex, releaseHold, err := query.OpenReservedQueryHandle(ctrl.readStore, ctrl.store)
 	if err != nil {
 		return nil, fmt.Errorf("creating read handle for index lookup: %w", err)
 	}
+	defer releaseHold()
 	defer func() { _ = handleForIndex.Close() }()
 
 	ledgerInfo, err := query.GetLedgerByName(ctx, handleForIndex, req.GetLedger())
@@ -1039,23 +1041,34 @@ func (ctrl *DefaultController) InspectIndex(ctx context.Context, req *servicepb.
 		}}
 	}
 
-	// Per-replica readiness: the local replica's
-	// IndexVersionState.CurrentVersion decides whether queries can be
-	// served (EN-1323). We take the snapshot FIRST and read the version
-	// state through it so the gate and the subsequent Inspect scan
-	// observe the same point-in-time view — without this the atomic
-	// version switch could promote CurrentVersion between the gate
-	// and the iteration, leaving the scan looking at a keyspace that
-	// has already been GC'd in this snapshot.
-	snap := ctrl.readStore.NewSnapshot()
+	// Wait for a certificate covering this fixed main snapshot, then pin its
+	// native sequence while resolving version and membership history from the
+	// certified index snapshot. The projection may be ahead of the main view;
+	// the sequence returned here is the trimming horizon below.
+	snap, mainSeq, releaseLease, err := query.AlignedIndexSnapshot(ctx, ctrl.readStore, handleForIndex, releaseHold)
+	if err != nil {
+		return nil, err
+	}
+	defer releaseLease()
 	defer func() { _ = snap.Close() }()
 
-	state, _, err := readstore.ReadIndexVersionStateFrom(snap, ledgerInfo.GetName(), indexes.Canonical(indexID))
+	// Per-replica readiness is pin-aware (EN-1323): the snapshot's
+	// CurrentVersion is servable only when its ActivationSequence is at or
+	// below mainSeq. Resolve both through the same snapshot the Inspect scan
+	// uses, so a concurrent atomic version switch cannot make the gate select a
+	// keyspace that was not yet active at the main horizon.
+	version, primed, err := readstore.PinnedVersionResolver(snap, ledgerInfo.GetName(), mainSeq)(indexes.Canonical(indexID))
 	if err != nil {
 		return nil, fmt.Errorf("reading index version state: %w", err)
 	}
 
-	if state.CurrentVersion == 0 {
+	if !primed {
+		return nil, &domain.BusinessError{Err: &domain.ErrIndexNotFound{
+			Index: fmt.Sprintf("metadata[%q] on %s", metaKey, req.GetTargetType()),
+		}}
+	}
+
+	if version.Version == 0 {
 		return nil, &domain.BusinessError{Err: &domain.ErrIndexBuilding{
 			Index: fmt.Sprintf("metadata[%q] on %s", metaKey, req.GetTargetType()),
 		}}
@@ -1080,15 +1093,16 @@ func (ctrl *DefaultController) InspectIndex(ctx context.Context, req *servicepb.
 	}
 
 	inspectResult, err := readstore.InspectIndex(readstore.InspectParams{
-		Reader:      snap,
-		KB:          dal.NewKeyBuilder(),
-		LedgerName:  ledgerInfo.GetName(),
-		Namespace:   namespace,
-		MetadataKey: metaKey,
-		Version:     state.CurrentVersion,
-		Mode:        mode,
-		PageSize:    req.GetPageSize(),
-		CursorBytes: cursorBytes,
+		Reader:          snap,
+		KB:              dal.NewKeyBuilder(),
+		LedgerName:      ledgerInfo.GetName(),
+		Namespace:       namespace,
+		MetadataKey:     metaKey,
+		Version:         version.Version,
+		HorizonSequence: mainSeq,
+		Mode:            mode,
+		PageSize:        req.GetPageSize(),
+		CursorBytes:     cursorBytes,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("inspecting index: %w", err)

--- a/internal/application/ctrl/controller_default_inspect_alignment_test.go
+++ b/internal/application/ctrl/controller_default_inspect_alignment_test.go
@@ -1,0 +1,93 @@
+package ctrl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
+	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/infra/state"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/internal/query"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+func TestInspectIndexUsesRoutedBarrierAndMainSnapshotHorizon(t *testing.T) {
+	t.Parallel()
+
+	const (
+		ledger       = "inspect-alignment"
+		metadataKey  = "tier"
+		mainSequence = uint64(20)
+		raftHorizon  = uint64(42)
+	)
+
+	logger := logging.NopZap()
+	meter := noop.NewMeterProvider().Meter("test")
+	store := newCtrlTestStore(t)
+	attrs := attributes.New()
+	indexID := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, metadataKey)
+
+	mainBatch := store.OpenWriteSession()
+	require.NoError(t, state.SaveLedger(mainBatch, ledger, &commonpb.LedgerInfo{
+		Name: ledger,
+		MetadataSchema: &commonpb.MetadataSchema{AccountFields: map[string]*commonpb.MetadataFieldSchema{
+			metadataKey: {Type: commonpb.MetadataType_METADATA_TYPE_STRING},
+		}},
+	}))
+	_, err := attrs.Index.Set(mainBatch, indexes.KeyFor(ledger, indexID).Bytes(), &commonpb.Index{
+		Id:                     indexID,
+		Ledger:                 ledger,
+		ForwardEncodingVersion: 1,
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.AppendLogs(mainBatch, []*commonpb.Log{{Sequence: mainSequence}}))
+	require.NoError(t, state.SetAppliedIndex(mainBatch, raftHorizon))
+	require.NoError(t, mainBatch.Commit())
+
+	rs, err := readstore.New(t.TempDir(), logger, readstore.DefaultConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rs.Close() })
+
+	gold := readstore.EncodeMetadataValue(nil, commonpb.NewStringValue("gold"))
+	silver := readstore.EncodeMetadataValue(nil, commonpb.NewStringValue("silver"))
+	kb := dal.NewKeyBuilder()
+	indexBatch := rs.NewBatch()
+	require.NoError(t, indexBatch.SetBytes(readstore.MetadataIndexEventKeyV(
+		kb, ledger, readstore.NamespaceAccount, metadataKey, 1, gold, []byte("alice"), 10, readstore.MetadataEventAdd,
+	), nil))
+	require.NoError(t, indexBatch.SetBytes(readstore.MetadataIndexEventKeyV(
+		kb, ledger, readstore.NamespaceAccount, metadataKey, 1, gold, []byte("alice"), 30, readstore.MetadataEventDel,
+	), nil))
+	require.NoError(t, indexBatch.SetBytes(readstore.MetadataIndexEventKeyV(
+		kb, ledger, readstore.NamespaceAccount, metadataKey, 1, silver, []byte("alice"), 30, readstore.MetadataEventAdd,
+	), nil))
+	require.NoError(t, rs.WriteIndexVersionState(indexBatch, ledger, indexes.Canonical(indexID), readstore.IndexVersionState{
+		CurrentVersion: 1,
+		HighWater:      1,
+	}))
+	require.NoError(t, rs.WriteProgress(indexBatch, 30))
+	require.NoError(t, rs.WriteRaftProgress(indexBatch, raftHorizon))
+	require.NoError(t, indexBatch.Commit())
+	rs.NotifyProgress()
+
+	ctrl := NewDefaultController(nil, store, logger, attrs, rs, nil, meter)
+	resp, err := ctrl.InspectIndex(query.WithReadBarrierHorizon(t.Context(), raftHorizon), &servicepb.InspectIndexRequest{
+		Ledger:      ledger,
+		TargetType:  commonpb.TargetType_TARGET_TYPE_ACCOUNT,
+		MetadataKey: metadataKey,
+		Mode:        servicepb.InspectIndexMode_INSPECT_INDEX_MODE_DISTINCT_VALUES,
+		PageSize:    10,
+	})
+	require.NoError(t, err)
+	values := resp.GetDistinctValues().GetValues()
+	require.Len(t, values, 1)
+	require.Equal(t, "gold", values[0].GetStringValue(),
+		"membership committed after the main snapshot must stay invisible")
+}

--- a/internal/bootstrap/controller_routed.go
+++ b/internal/bootstrap/controller_routed.go
@@ -455,12 +455,12 @@ func (b *RoutedController) GetEventsSinks(ctx context.Context) ([]*commonpb.Sink
 }
 
 func (b *RoutedController) InspectIndex(ctx context.Context, req *servicepb.InspectIndexRequest) (*servicepb.InspectIndexResponse, error) {
-	c, _, err := b.readCtrl(ctx)
+	c, barrier, err := b.readCtrl(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return c.InspectIndex(ctx, req)
+	return c.InspectIndex(b.withLocalBarrierHorizon(ctx, c, barrier), req)
 }
 
 func (b *RoutedController) GetIndexStatus(ctx context.Context, req *servicepb.GetIndexStatusRequest) (*servicepb.GetIndexStatusResponse, error) {

--- a/internal/bootstrap/controller_routed_test.go
+++ b/internal/bootstrap/controller_routed_test.go
@@ -232,6 +232,18 @@ func TestRoutedController_IndexedReadsForwardLocalBarrierHorizon(t *testing.T) {
 				return err
 			},
 		},
+		{
+			name: "inspect index",
+			expect: func(local *ctrlmock.MockController) {
+				local.EXPECT().InspectIndex(barrierHorizonMatcher(42), gomock.Any()).
+					Return(&servicepb.InspectIndexResponse{}, nil)
+			},
+			call: func(ctx context.Context, routed *RoutedController) error {
+				_, err := routed.InspectIndex(ctx, &servicepb.InspectIndexRequest{})
+
+				return err
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/storage/readstore/inspect.go
+++ b/internal/storage/readstore/inspect.go
@@ -2,6 +2,7 @@ package readstore
 
 import (
 	"bytes"
+	"encoding/binary"
 	"fmt"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -28,14 +29,18 @@ type InspectParams struct {
 	LedgerName  string
 	Namespace   string // "a:" or "t:"
 	MetadataKey string
-	// Version is the per-replica forward-encoding version to scan
-	// (IndexVersionState.CurrentVersion). 0 is an invariant — callers
-	// must resolve a non-zero current_version before calling Inspect
-	// (or short-circuit and return "index not built locally").
-	Version     uint32
-	Mode        InspectMode
-	PageSize    uint32
-	CursorBytes []byte // decoded opaque cursor (nil = start)
+	// Version is the per-replica forward-encoding version resolved at the
+	// caller's horizon. 0 is an invariant — callers must resolve a non-zero
+	// version before calling Inspect (or short-circuit and return "index not
+	// built locally").
+	Version uint32
+	// HorizonSequence resolves append-only membership events at the fixed main
+	// snapshot's native sequence. Zero preserves the unpinned head view for
+	// callers that have no cross-store horizon.
+	HorizonSequence uint64
+	Mode            InspectMode
+	PageSize        uint32
+	CursorBytes     []byte // decoded opaque cursor (nil = start)
 }
 
 // InspectResult holds the scan results.
@@ -59,13 +64,14 @@ type InspectFacetEntry struct {
 
 // forEachLiveGroup walks event keys in [lower, upper) and invokes fn for
 // every group (the bytes between prefixLen and the entity terminator) whose
-// latest event is an ADD — i.e. current membership. fn returns false to stop
-// early; its argument is only valid for the duration of the call.
+// latest event at or before horizon is an ADD. With horizon zero this means
+// the projection head. fn returns false to stop early; its argument is only
+// valid for the duration of the call.
 //
 // A key it cannot read is an error, not a skipped row: statistics derived from
 // the events around it would be plausible and wrong, hiding the corruption
 // they were computed over.
-func forEachLiveGroup(reader dal.PebbleReader, lower, upper []byte, prefixLen int, fn func(group []byte) bool) error {
+func forEachLiveGroup(reader dal.PebbleReader, lower, upper []byte, prefixLen int, horizon uint64, fn func(group []byte) bool) error {
 	iter, err := reader.NewIter(&pebble.IterOptions{
 		LowerBound: lower,
 		UpperBound: upper,
@@ -100,10 +106,14 @@ func forEachLiveGroup(reader dal.PebbleReader, lower, upper []byte, prefixLen in
 
 			group = append(group[:0], g...)
 			started = true
+			live = false
 		}
 
 		if !validEventOp(key[tpos+9]) {
 			return fmt.Errorf("malformed metadata event key %x", key)
+		}
+		if horizon > 0 && binary.BigEndian.Uint64(key[tpos+1:tpos+9]) > horizon {
+			continue
 		}
 
 		// Events are seq-ascending within a group: the last op wins.
@@ -117,11 +127,11 @@ func forEachLiveGroup(reader dal.PebbleReader, lower, upper []byte, prefixLen in
 	return iter.Error()
 }
 
-// countLiveGroups counts current members under an event prefix.
-func countLiveGroups(reader dal.PebbleReader, prefix []byte) (uint64, error) {
+// countLiveGroups counts members whose latest event at or before horizon is an add.
+func countLiveGroups(reader dal.PebbleReader, prefix []byte, horizon uint64) (uint64, error) {
 	var n uint64
 
-	err := forEachLiveGroup(reader, prefix, IncrementBytes(prefix), len(prefix), func([]byte) bool {
+	err := forEachLiveGroup(reader, prefix, IncrementBytes(prefix), len(prefix), horizon, func([]byte) bool {
 		n++
 
 		return true
@@ -169,7 +179,7 @@ func inspectDistinctValues(params InspectParams) (*InspectResult, error) {
 		decodeErr      error
 	)
 
-	err := forEachLiveGroup(params.Reader, lower, upper, len(prefix), func(group []byte) bool {
+	err := forEachLiveGroup(params.Reader, lower, upper, len(prefix), params.HorizonSequence, func(group []byte) bool {
 		_, consumed, decErr := DecodeValue(group)
 		if decErr != nil {
 			decodeErr = fmt.Errorf("malformed metadata event group %x: %w", group, decErr)
@@ -234,7 +244,7 @@ func inspectFacets(params InspectParams) (*InspectResult, error) {
 		decodeErr      error
 	)
 
-	err := forEachLiveGroup(params.Reader, lower, upper, len(prefix), func(group []byte) bool {
+	err := forEachLiveGroup(params.Reader, lower, upper, len(prefix), params.HorizonSequence, func(group []byte) bool {
 		_, consumed, decErr := DecodeValue(group)
 		if decErr != nil {
 			decodeErr = fmt.Errorf("malformed metadata event group %x: %w", group, decErr)
@@ -304,7 +314,7 @@ func inspectSummary(params InspectParams) (*InspectResult, error) {
 		decodeErr      error
 	)
 
-	err := forEachLiveGroup(params.Reader, prefix, upper, len(prefix), func(group []byte) bool {
+	err := forEachLiveGroup(params.Reader, prefix, upper, len(prefix), params.HorizonSequence, func(group []byte) bool {
 		_, consumed, decErr := DecodeValue(group)
 		if decErr != nil {
 			decodeErr = fmt.Errorf("malformed metadata event group %x: %w", group, decErr)
@@ -342,7 +352,7 @@ func inspectSummary(params InspectParams) (*InspectResult, error) {
 
 	// Count entities with key (non-null).
 	nonNullPrefix := EntityExistsNonNullPrefixV(params.KB, params.LedgerName, params.Namespace, params.MetadataKey, params.Version)
-	result.EntitiesWithKey, err = countLiveGroups(params.Reader, nonNullPrefix)
+	result.EntitiesWithKey, err = countLiveGroups(params.Reader, nonNullPrefix, params.HorizonSequence)
 
 	if err != nil {
 		return nil, fmt.Errorf("counting non-null entities: %w", err)
@@ -350,7 +360,7 @@ func inspectSummary(params InspectParams) (*InspectResult, error) {
 
 	// Count entities with null value.
 	nullPrefix := EntityExistsNullPrefixV(params.KB, params.LedgerName, params.Namespace, params.MetadataKey, params.Version)
-	result.EntitiesWithNull, err = countLiveGroups(params.Reader, nullPrefix)
+	result.EntitiesWithNull, err = countLiveGroups(params.Reader, nullPrefix, params.HorizonSequence)
 
 	if err != nil {
 		return nil, fmt.Errorf("counting null entities: %w", err)

--- a/internal/storage/readstore/iterator_event_resolve_test.go
+++ b/internal/storage/readstore/iterator_event_resolve_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cockroachdb/pebble/v2"
 	"github.com/stretchr/testify/require"
 
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
 
@@ -297,6 +298,100 @@ func TestInspectIndex_RejectsUnknownOp(t *testing.T) {
 		})
 		require.Error(t, err, "mode %d must refuse to report statistics over an unreadable event", mode)
 	}
+}
+
+func TestInspectIndex_ResolvesMembershipAtMainHorizon(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	kb := dal.NewKeyBuilder()
+
+	encoded := func(value *commonpb.MetadataValue) []byte {
+		return EncodeMetadataValue(nil, value)
+	}
+	stringValue := func(value string) *commonpb.MetadataValue {
+		return &commonpb.MetadataValue{
+			Type: &commonpb.MetadataValue_StringValue{StringValue: value},
+		}
+	}
+	nullValue := &commonpb.MetadataValue{
+		Type: &commonpb.MetadataValue_NullValue{NullValue: &commonpb.NullValue{}},
+	}
+	putMetadata := func(value *commonpb.MetadataValue, entity string, seq uint64, op byte) {
+		require.NoError(t, s.DB().Set(
+			MetadataIndexEventKeyV(kb, "l", NamespaceAccount, "k", 1, encoded(value), []byte(entity), seq, op),
+			nil,
+			pebble.NoSync,
+		))
+	}
+	putExists := func(isNull bool, entity string, seq uint64, op byte) {
+		require.NoError(t, s.DB().Set(
+			EntityExistsEventKeyV(kb, "l", NamespaceAccount, "k", 1, isNull, []byte(entity), seq, op),
+			nil,
+			pebble.NoSync,
+		))
+	}
+
+	gold := stringValue("gold")
+	silver := stringValue("silver")
+
+	// At H=20 all three entities are gold and non-null. The projection view
+	// also contains their post-H mutations: a:1 becomes silver and a:3 becomes
+	// null. Inspect must reconstruct H rather than report the projection head.
+	for _, entity := range []string{"a:1", "a:2", "a:3"} {
+		putMetadata(gold, entity, 10, MetadataEventAdd)
+		putExists(false, entity, 10, MetadataEventAdd)
+	}
+	putMetadata(gold, "a:1", 30, MetadataEventDel)
+	putMetadata(silver, "a:1", 30, MetadataEventAdd)
+	putMetadata(gold, "a:3", 30, MetadataEventDel)
+	putMetadata(nullValue, "a:3", 30, MetadataEventAdd)
+	putExists(false, "a:3", 30, MetadataEventDel)
+	putExists(true, "a:3", 30, MetadataEventAdd)
+
+	base := InspectParams{
+		Reader:          s.DB(),
+		KB:              kb,
+		LedgerName:      "l",
+		Namespace:       NamespaceAccount,
+		MetadataKey:     "k",
+		Version:         1,
+		HorizonSequence: 20,
+	}
+
+	distinct, err := InspectIndex(func() InspectParams {
+		params := base
+		params.Mode = InspectDistinctValuesMode
+
+		return params
+	}())
+	require.NoError(t, err)
+	require.Len(t, distinct.Values, 1)
+	require.Equal(t, "gold", distinct.Values[0].GetStringValue())
+
+	facets, err := InspectIndex(func() InspectParams {
+		params := base
+		params.Mode = InspectFacetsMode
+
+		return params
+	}())
+	require.NoError(t, err)
+	require.Len(t, facets.Facets, 1)
+	require.Equal(t, "gold", facets.Facets[0].Value.GetStringValue())
+	require.Equal(t, uint64(3), facets.Facets[0].Count)
+
+	summary, err := InspectIndex(func() InspectParams {
+		params := base
+		params.Mode = InspectSummaryMode
+
+		return params
+	}())
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), summary.Cardinality)
+	require.Equal(t, "gold", summary.Min.GetStringValue())
+	require.Equal(t, "gold", summary.Max.GetStringValue())
+	require.Equal(t, uint64(3), summary.EntitiesWithKey)
+	require.Zero(t, summary.EntitiesWithNull)
 }
 
 // The unreadable event can arrive after the group has already been judged:


### PR DESCRIPTION
## Summary

Align InspectIndex with a fixed Raft/main-store horizon, pinned index version, and native-sequence trimming.

Need: keep operator-facing inspection consistent with the committed main-store state selected for the request.
Previous limitation: inspection scanned the current projection head without proving coverage or trimming it to the fixed main snapshot.
Requirement: every inspection mode uses a certified read-index snapshot and resolves membership at the main snapshot native sequence.
Decision: propagate the routed barrier, reserve event history, align the projection snapshot, resolve its pinned version, and pass the horizon sequence to every scan.
Validation: controller skew, routed-barrier, distinct-values, facets, and summary regressions cover the composed path.

DISCOVERY: DIRECT_FIX
BEFORE_FIX: BUG_REPRODUCED
AFTER_FIX: PASS

## Stack

EN-1946 stack 5/8. Depends on #1894 (fix/en-1946-prepared-query-snapshot).

Merge/review order: #1897 → #1889 → #1890 → #1894 → #1891 → #1893 → #1892 → #1881.

## Validation

Final base: 2f0c5c99da8941449d43b3cb6e6f0d16624cd940.
Final head: 453a054681527e831dc2bee382213e43e8531398.
Canonical PR validation and bugfix sensitivity: PASS, including focused race suites.
Independent exact diff review: APPROVE (residual risk LOW).

Jira: EN-1946. Do not merge automatically.