### PR TITLE
test(antithesis): use certified projection horizons (EN-1946)

### DIFF
--- a/scripts/agent-check-pr
+++ b/scripts/agent-check-pr
@@ -147,7 +147,11 @@ classify_path() {
             needs_precommit=true
             return
             ;;
-        tests/antithesis/*|tests/oracle/*)
+        tests/antithesis/*)
+            needs_precommit=true
+            return
+            ;;
+        tests/oracle/*)
             needs_precommit=true
             append_package "./$(dirname "$path")"
             return

--- a/scripts/agentcheckpr/selector_test.go
+++ b/scripts/agentcheckpr/selector_test.go
@@ -93,6 +93,14 @@ func TestSelectsLocalValidationGatesFromCompleteDiff(t *testing.T) {
 			expected: []string{"pre-commit", "agent-check", "test-operator"},
 		},
 		{
+			// Top-level Antithesis files are harness configuration, not a Go
+			// package. Selecting their directory for go test fails with "no Go
+			// files" before the actual workload validation can run.
+			name:     "antithesis harness documentation",
+			paths:    []string{"tests/antithesis/README.md"},
+			expected: []string{"pre-commit", "agent-check"},
+		},
+		{
 			name:      "production file renamed outside gated paths",
 			basePaths: []string{"internal/domain/example.go"},
 			renames: [][2]string{

--- a/tests/antithesis/README.md
+++ b/tests/antithesis/README.md
@@ -52,8 +52,7 @@ swallows a stream truncation will silently report "all green" on a real bug.
 The workload uses a layered predicate set (`internal/client.go`):
 
 - `IsTransient(err)` — retry-safe set, what the retry interceptor handles.
-  Covers `Unavailable | DeadlineExceeded | ReadIndexNotCaughtUp |
-  ExternalServiceError`.
+  Covers `Unavailable | DeadlineExceeded | ExternalServiceError`.
 - `IsCanceled(err)` — local ctx is dead (driver shutting down). Not a
   finding; the driver just exits.
 - `IsTolerated(err)` — `nil | IsTransient | IsCanceled`. **This is what
@@ -86,7 +85,7 @@ finding worth triaging.
 
 `IsUnavailable(err)` is deliberately narrow — it backs the gRPC service
 config's retryable-codes list. Using it as a Sometimes tolerance predicate
-masks `DeadlineExceeded` / `ReadIndexNotCaughtUp` / `ExternalServiceError`
+masks `DeadlineExceeded` / `ExternalServiceError`
 and silently shorts the driver — exactly the bug the audit in
 `refactor(antithesis): chaos error classification + workload cleanup`
 caught across ~21 drivers.

--- a/tests/antithesis/README.md
+++ b/tests/antithesis/README.md
@@ -55,7 +55,8 @@ The workload uses a layered predicate set (`internal/client.go`):
   Covers `Unavailable | DeadlineExceeded | ExternalServiceError`.
 - `IsCanceled(err)` — local ctx is dead (driver shutting down). Not a
   finding; the driver just exits.
-- `IsTolerated(err)` — `nil | IsTransient | IsCanceled`. **This is what
+- `IsTolerated(err)` — `nil | IsTransient | IsCanceled | errors.Is(context.DeadlineExceeded) | errors.Is(context.Canceled)`.
+  **This is what
   Sometimes() probes use**: `assert.Sometimes(internal.IsTolerated(err),
   "should be able to X", details)`. Using `IsTransient` directly here would
   flip the per-driver Sometimes to "never true" when ctx cancellation

--- a/tests/antithesis/workload/bin/cmds/main/eventually_cross_node_identity/main.go
+++ b/tests/antithesis/workload/bin/cmds/main/eventually_cross_node_identity/main.go
@@ -152,11 +152,11 @@ type readyNode struct {
 //
 // Retries on any IsTransient error (not just IsUnavailable): Barrier
 // proposes through Raft, and under a clog/restore fault window Raft
-// transients can surface as DeadlineExceeded, Aborted, or
-// FailedPrecondition + READ_INDEX_NOT_CAUGHT_UP — all legitimately
-// retryable. Narrow IsUnavailable matching would trip the assertion
-// below on fault-window noise and undermine the cross-node identity
-// oracle's reliability.
+// transients can surface as DeadlineExceeded or ExternalServiceError.
+// Canceled is a local lifecycle signal and Aborted is deliberately surfaced;
+// neither is part of IsTransient. Narrow IsUnavailable matching would trip
+// the assertion below on retry-safe fault-window noise and undermine the
+// cross-node identity oracle's reliability.
 func waitForQuiescence(ctx context.Context, client servicepb.BucketServiceClient) uint64 {
 	var last uint64
 	for attempt := 1; attempt <= quiescenceAttempts; attempt++ {

--- a/tests/antithesis/workload/bin/cmds/main/parallel_driver_audit/main.go
+++ b/tests/antithesis/workload/bin/cmds/main/parallel_driver_audit/main.go
@@ -43,15 +43,10 @@ func main() {
 			return
 		}
 
-		// Gate on the Apply's log sequence: the audit index is built async from
-		// the log, so wait for it to process our entry before asserting.
-		minLogSeq := resp.GetLogs()[len(resp.GetLogs())-1].GetSequence()
-
-		// List audit entries and verify at least one exists.
+		// List audit entries; the default read aligns any required projection.
 		stream, err := client.ListAuditEntries(ctx, &servicepb.ListAuditEntriesRequest{
 			Options: &commonpb.ListOptions{
 				PageSize: 10,
-				Read:     &commonpb.ReadOptions{MinLogSequence: minLogSeq},
 			},
 		})
 		if err != nil {

--- a/tests/antithesis/workload/bin/cmds/main/parallel_driver_bulk_atomicity/main.go
+++ b/tests/antithesis/workload/bin/cmds/main/parallel_driver_bulk_atomicity/main.go
@@ -20,8 +20,8 @@
 //     count).
 //   - Effects checks run only after a definitive (FailedPrecondition-class)
 //     rejection; ambiguous outcomes are skipped.
-//   - Reads use a MinLogSequence floor from a marker write in a SEPARATE
-//     owned helper ledger: the floor defeats read staleness (#398 class)
+//   - Reads happen after a marker write in a SEPARATE owned helper ledger:
+//     the default linearizable path defeats read staleness (#398 class)
 //     without polluting the primary ledger's audit stream with marker
 //     Success entries.
 //   - Audit history is permanent, so a failed atomic bulk must always
@@ -67,20 +67,19 @@ func isDefinitiveBulkRejection(err error) bool {
 }
 
 // listIsEmpty returns (empty, foundIDs, conclusive) for transactions matching
-// the filter at the MinLogSequence floor. Read errors are inconclusive.
+// the filter after an acknowledged marker. The default linearizable read is
+// aligned to the marker's Raft horizon; read errors are inconclusive.
 func listIsEmpty(
 	ctx context.Context,
 	client servicepb.BucketServiceClient,
 	ledger string,
 	filter *commonpb.QueryFilter,
-	minLogSeq uint64,
 ) (bool, []uint64, bool) {
 	stream, err := client.ListTransactions(ctx, &servicepb.ListTransactionsRequest{
 		Ledger: ledger,
 		Options: &commonpb.ListOptions{
 			PageSize: 10,
 			Filter:   filter,
-			Read:     &commonpb.ReadOptions{MinLogSequence: minLogSeq},
 		},
 	})
 	if err != nil {
@@ -218,20 +217,20 @@ func main() {
 			return
 		}
 
-		minLogSeq := markerResp.GetLogs()[len(markerResp.GetLogs())-1].GetSequence()
-		details["minLogSeq"] = minLogSeq
+		markerSeq := markerResp.GetLogs()[len(markerResp.GetLogs())-1].GetSequence()
+		details["markerSeq"] = markerSeq
 
 		// Business effects: none of the earlier orders' references or account
 		// activity may be visible — the whole proposal failed.
 		for i, ref := range refs {
-			empty, ids, conclusive := listIsEmpty(ctx, client, ledger, actions.ReferenceFilter(ref), minLogSeq)
+			empty, ids, conclusive := listIsEmpty(ctx, client, ledger, actions.ReferenceFilter(ref))
 			if conclusive {
 				assert.Always(empty,
 					"failed atomic bulk leaves no partial transaction effects",
 					details.With(internal.Details{"reference": ref, "txIds": fmt.Sprintf("%v", ids)}))
 			}
 
-			empty, ids, conclusive = listIsEmpty(ctx, client, ledger, actions.AddressExactFilter(accounts[i]), minLogSeq)
+			empty, ids, conclusive = listIsEmpty(ctx, client, ledger, actions.AddressExactFilter(accounts[i]))
 			if conclusive {
 				assert.Always(empty,
 					"failed atomic bulk leaves no partial account activity",
@@ -246,7 +245,6 @@ func main() {
 		// exactly one Failure entry by design, machine.go:1163-1204).
 		auditStream, err := client.ListAuditEntries(ctx, &servicepb.ListAuditEntriesRequest{
 			Options: &commonpb.ListOptions{
-				Read: &commonpb.ReadOptions{MinLogSequence: minLogSeq},
 				// Audit has no dedicated ledger field — scope via the generic filter.
 				Filter: &commonpb.QueryFilter{
 					Filter: &commonpb.QueryFilter_Audit{

--- a/tests/antithesis/workload/bin/cmds/main/parallel_driver_definitive_errors/main.go
+++ b/tests/antithesis/workload/bin/cmds/main/parallel_driver_definitive_errors/main.go
@@ -52,21 +52,19 @@ func isDefinitiveCode(c codes.Code) bool {
 }
 
 // referenceFilterCheck lists transactions matching the reference and returns
-// (found, foundTxID, conclusive). conclusive is false when the read failed
-// (transient error, store lag, mid-stream error) — the ref is then skipped
-// rather than asserted on.
+// (found, foundTxID, conclusive). The caller first commits an acknowledged
+// marker, so this default linearizable read is aligned to that Raft horizon.
+// conclusive is false when the read fails before or during the stream.
 func referenceFilterCheck(
 	ctx context.Context,
 	client servicepb.BucketServiceClient,
 	ledger, ref string,
-	minLogSeq uint64,
 ) (bool, uint64, bool) {
 	stream, err := client.ListTransactions(ctx, &servicepb.ListTransactionsRequest{
 		Ledger: ledger,
 		Options: &commonpb.ListOptions{
 			PageSize: 10,
 			Filter:   actions.ReferenceFilter(ref),
-			Read:     &commonpb.ReadOptions{MinLogSequence: minLogSeq},
 		},
 	})
 	if err != nil {
@@ -185,8 +183,8 @@ func main() {
 		// Consistency barrier with a usable read floor: a successful marker
 		// write is sequenced after any hypothetically-committed rejected
 		// write (its rejection response was received before the marker was
-		// proposed), so MinLogSequence = marker sequence forces the read
-		// store past the window where a committed-but-rejected write could
+		// proposed), so the subsequent linearizable read forces the read store
+		// past the window where a committed-but-rejected write could
 		// hide. Transparent UNAVAILABLE retries of the marker are harmless
 		// (no reference, idempotent for this purpose).
 		markerResp, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", &servicepb.Request{
@@ -213,15 +211,12 @@ func main() {
 			return
 		}
 
-		logs := markerResp.GetLogs()
-		if len(logs) == 0 {
+		if len(markerResp.GetLogs()) == 0 {
 			return
 		}
 
-		minLogSeq := logs[len(logs)-1].GetSequence()
-
 		for _, rej := range rejected {
-			found, foundID, conclusive := referenceFilterCheck(ctx, client, ledger, rej.reference, minLogSeq)
+			found, foundID, conclusive := referenceFilterCheck(ctx, client, ledger, rej.reference)
 			if !conclusive {
 				continue
 			}

--- a/tests/antithesis/workload/bin/cmds/main/parallel_driver_ledger_recreate/main.go
+++ b/tests/antithesis/workload/bin/cmds/main/parallel_driver_ledger_recreate/main.go
@@ -15,9 +15,9 @@
 //     explicit ack; the isolation check runs BEFORE the reference-reuse
 //     write, so an old reference found through the new incarnation can only
 //     be predecessor data.
-//   - All isolation reads go through ListTransactions with a MinLogSequence
-//     floor taken from a marker write in the NEW incarnation. The floor
-//     guarantees the serving store has applied past the delete+recreate, so
+//   - All isolation reads happen after a marker write in the NEW incarnation.
+//     The default linearizable read and projection alignment guarantee the
+//     serving store has applied past the delete+recreate, so
 //     name→ID resolution yields the new LedgerID — without it, a legitimately
 //     stale (prefix-consistent) read could resolve the name to the OLD ID and
 //     "see" old data, a false positive. GetAccount has no freshness floor and
@@ -71,21 +71,20 @@ func createTx(
 	}))
 }
 
-// listMatches lists transactions matching the filter at the MinLogSequence
-// floor and returns (foundIDs, conclusive). Read errors are inconclusive.
+// listMatches lists transactions matching the filter after an acknowledged
+// marker and returns (foundIDs, conclusive). The default linearizable read is
+// aligned to the marker's Raft horizon; read errors are inconclusive.
 func listMatches(
 	ctx context.Context,
 	client servicepb.BucketServiceClient,
 	ledger string,
 	filter *commonpb.QueryFilter,
-	minLogSeq uint64,
 ) ([]uint64, bool) {
 	stream, err := client.ListTransactions(ctx, &servicepb.ListTransactionsRequest{
 		Ledger: ledger,
 		Options: &commonpb.ListOptions{
 			PageSize: 10,
 			Filter:   filter,
-			Read:     &commonpb.ReadOptions{MinLogSequence: minLogSeq},
 		},
 	})
 	if err != nil {
@@ -169,27 +168,27 @@ func main() {
 			return
 		}
 
-		// 4. Marker write in the NEW incarnation: its global log sequence is
-		// the freshness floor for every isolation read below.
+		// 4. Acknowledged marker write in the NEW incarnation. Every default
+		// isolation read below is aligned to at least this Raft horizon.
 		markerResp, err := createTx(ctx, client, ledger, "", "lrec-marker")
 		if err != nil || len(markerResp.GetLogs()) == 0 {
 			return
 		}
 
-		minLogSeq := markerResp.GetLogs()[len(markerResp.GetLogs())-1].GetSequence()
-		details["minLogSeq"] = minLogSeq
+		markerSeq := markerResp.GetLogs()[len(markerResp.GetLogs())-1].GetSequence()
+		details["markerSeq"] = markerSeq
 
 		// 5. Isolation: no predecessor reference or account activity may be
 		// visible through the recreated ledger. Runs BEFORE the reuse write.
 		for i, ref := range ackedRefs {
-			ids, conclusive := listMatches(ctx, client, ledger, actions.ReferenceFilter(ref), minLogSeq)
+			ids, conclusive := listMatches(ctx, client, ledger, actions.ReferenceFilter(ref))
 			if conclusive {
 				assert.Always(len(ids) == 0,
 					"recreated ledger never exposes predecessor transactions",
 					details.With(internal.Details{"reference": ref, "txIds": fmt.Sprintf("%v", ids)}))
 			}
 
-			ids, conclusive = listMatches(ctx, client, ledger, actions.AddressExactFilter(ackedAccounts[i]), minLogSeq)
+			ids, conclusive = listMatches(ctx, client, ledger, actions.AddressExactFilter(ackedAccounts[i]))
 			if conclusive {
 				assert.Always(len(ids) == 0,
 					"recreated ledger never exposes predecessor account activity",

--- a/tests/antithesis/workload/bin/cmds/main/parallel_driver_list_completeness/main.go
+++ b/tests/antithesis/workload/bin/cmds/main/parallel_driver_list_completeness/main.go
@@ -126,8 +126,7 @@ func main() {
 				Options: &commonpb.ListOptions{
 					PageSize: pageSize,
 					Cursor:   cursor,
-					Reverse:  true,                                          // oldest-first, so IDs must increase across pages
-					Read:     &commonpb.ReadOptions{MinLogSequence: maxSeq}, // freshness barrier: index must cover every acked write
+					Reverse:  true, // oldest-first, so IDs must increase across pages
 				},
 			})
 			if err != nil {

--- a/tests/antithesis/workload/bin/cmds/main/parallel_driver_list_transactions/main.go
+++ b/tests/antithesis/workload/bin/cmds/main/parallel_driver_list_transactions/main.go
@@ -41,13 +41,6 @@ func main() {
 		txID := createdTx.Transaction.Id
 		details := internal.Details{"ledger": ledger, "txId": txID}
 
-		// Extract the log sequence from the Apply response to guarantee
-		// read-after-write consistency on subsequent queries.
-		var minLogSeq uint64
-		if logs := resp.GetLogs(); len(logs) > 0 {
-			minLogSeq = logs[len(logs)-1].GetSequence()
-		}
-
 		// 2. Paginate through all transactions until we find the one we created.
 		var (
 			totalCount int
@@ -66,7 +59,6 @@ func main() {
 				Options: &commonpb.ListOptions{
 					PageSize: 50,
 					Cursor:   cursor,
-					Read:     &commonpb.ReadOptions{MinLogSequence: minLogSeq},
 				},
 			})
 			if err != nil {

--- a/tests/antithesis/workload/bin/cmds/main/parallel_driver_logs/main.go
+++ b/tests/antithesis/workload/bin/cmds/main/parallel_driver_logs/main.go
@@ -43,17 +43,11 @@ func main() {
 			return
 		}
 
-		// Gate the read on the Apply's log sequence: ListLogs reads the async
-		// query index, which lags the FSM commit. Waiting for the index to
-		// reach this sequence turns the read-after-write into a guarantee.
-		minLogSeq := resp.GetLogs()[len(resp.GetLogs())-1].GetSequence()
-
-		// 2. List logs for the ledger.
+		// 2. List logs; the default read aligns the asynchronous index.
 		stream, err := client.ListLogs(ctx, &servicepb.ListLogsRequest{
 			Ledger: ledger,
 			Options: &commonpb.ListOptions{
 				PageSize: 20,
-				Read:     &commonpb.ReadOptions{MinLogSequence: minLogSeq},
 			},
 		})
 		if err != nil {
@@ -95,7 +89,7 @@ func main() {
 			return
 		}
 
-		// MinLogSequence guaranteed the index caught up to our write, so the
+		// The default ReadIndex plus projection alignment covers our write, so the
 		// log we just committed must be present.
 		assert.Always(count > 0, "ListLogs should return at least one entry after a confirmed write", details)
 

--- a/tests/antithesis/workload/bin/cmds/main/parallel_driver_projection_alignment/main.go
+++ b/tests/antithesis/workload/bin/cmds/main/parallel_driver_projection_alignment/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/antithesishq/antithesis-sdk-go/assert"
 
+	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 	"github.com/formancehq/ledger/v3/pkg/actions"
@@ -26,6 +27,15 @@ import (
 )
 
 const probeAccount = "minseq-probe:main"
+
+func isInconclusiveProjectionRead(err error) bool {
+	// The workload client load-balances across replicas. The readiness poll can
+	// observe one replica after its local switch while execution lands on
+	// another whose projection is still building. That is setup lag, not an
+	// alignment violation; a successful read must still satisfy the assertion
+	// below. INDEX_NOT_FOUND and every other business error remain findings.
+	return internal.IsTolerated(err) || internal.HasErrorReason(err, domain.ErrReasonIndexBuilding)
+}
 
 func main() {
 	internal.RunDriver("parallel_driver_projection_alignment", func(ctx context.Context, client servicepb.BucketServiceClient, _ string) {
@@ -139,7 +149,7 @@ func main() {
 			PageSize:  100,
 		})
 		if err != nil {
-			if !internal.IsTolerated(err) {
+			if !isInconclusiveProjectionRead(err) {
 				assert.Unreachable("projection-aligned prepared query returned unexpected error",
 					details.With(internal.Details{"error": err}))
 			}

--- a/tests/antithesis/workload/bin/cmds/main/parallel_driver_projection_alignment/main.go
+++ b/tests/antithesis/workload/bin/cmds/main/parallel_driver_projection_alignment/main.go
@@ -1,0 +1,145 @@
+// Driver for the prepared-query projection-alignment property. After a write
+// has been acknowledged, a successful default (linearizable) read must include
+// it: ReadIndex fixes a Raft horizon and the query waits only for the read
+// projection to certify that same horizon.
+//
+// Soundness against benign interleavings:
+//   - Owned "projection-" ledger (restricted prefix) + per-run unique query name:
+//     no foreign writes, deletes, or query-name collisions.
+//   - The probe account is created by the very write whose ack supplies S, so
+//     index coverage of S implies the account row exists.
+//   - Retry-safe infrastructure errors and cancellation are inconclusive;
+//     permanent prepared-query errors are reported as unreachable.
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/antithesishq/antithesis-sdk-go/assert"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+
+	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
+)
+
+const probeAccount = "minseq-probe:main"
+
+func main() {
+	internal.RunDriver("parallel_driver_projection_alignment", func(ctx context.Context, client servicepb.BucketServiceClient, _ string) {
+		r := internal.Rand()
+
+		run := r.Uint64()
+		ledger := internal.PrefixProjectionAlign.WithSeed(run)
+		if err := internal.CreateLedger(ctx, client, ledger); err != nil {
+			return
+		}
+
+		queryName := fmt.Sprintf("projection-q-%d", run)
+		queryIdempotencyKey := fmt.Sprintf("projection-query-%d", run)
+		probeIdempotencyKey := fmt.Sprintf("projection-probe-%d", run)
+		details := internal.Details{"ledger": ledger, "queryName": queryName}
+
+		_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest(queryIdempotencyKey, &servicepb.Request{
+			Type: &servicepb.Request_CreatePreparedQuery{
+				CreatePreparedQuery: &servicepb.CreatePreparedQueryRequest{
+					Ledger: ledger,
+					Query: &commonpb.PreparedQuery{
+						Name:   queryName,
+						Target: commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS,
+						Filter: &commonpb.QueryFilter{
+							// AccountHasAsset is served by the asynchronous read
+							// projection. The acknowledged transaction below creates
+							// exactly this USD/2 membership, so a successful query can
+							// only include the probe after projection certification.
+							Filter: &commonpb.QueryFilter_AccountHasAsset{
+								AccountHasAsset: &commonpb.AccountHasAssetCondition{
+									AssetBase: "USD",
+									Precision: 2,
+								},
+							},
+						},
+					},
+				},
+			},
+		}))
+		if err != nil {
+			if !internal.IsTolerated(err) {
+				assert.Unreachable("projection prepared-query creation returned unexpected error",
+					details.With(internal.Details{"error": err}))
+			}
+
+			return
+		}
+
+		resp, err := client.Apply(ctx, servicepb.UnsignedApplyRequest(probeIdempotencyKey, &servicepb.Request{
+			Type: &servicepb.Request_Apply{
+				Apply: &servicepb.LedgerApplyRequest{
+					Ledger: ledger,
+					Action: &servicepb.LedgerAction{Data: &servicepb.LedgerAction_CreateTransaction{
+						CreateTransaction: &servicepb.CreateTransactionPayload{
+							Postings: []*commonpb.Posting{{
+								Source:      "world",
+								Destination: probeAccount,
+								Amount:      commonpb.NewUint256FromUint64(1),
+								Asset:       "USD/2",
+							}},
+							Reference: fmt.Sprintf("projection-%d", run),
+							Force:     true,
+						},
+					}},
+				},
+			},
+		}))
+		if err != nil {
+			if !internal.IsTolerated(err) {
+				assert.Unreachable("projection probe apply returned unexpected error",
+					details.With(internal.Details{"error": err}))
+			}
+
+			return
+		}
+		if len(resp.GetLogs()) == 0 {
+			assert.Unreachable("projection probe apply succeeded without an audit log", details)
+
+			return
+		}
+		details = details.With(internal.Details{"ackedSeq": resp.GetLogs()[len(resp.GetLogs())-1].GetSequence()})
+
+		execResp, err := client.ExecutePreparedQuery(ctx, &servicepb.ExecutePreparedQueryRequest{
+			Ledger:    ledger,
+			QueryName: queryName,
+			PageSize:  100,
+		})
+		if err != nil {
+			if !internal.IsTolerated(err) {
+				assert.Unreachable("projection-aligned prepared query returned unexpected error",
+					details.With(internal.Details{"error": err}))
+			}
+
+			return
+		}
+		assert.Reachable("projection-aligned prepared query succeeded", details)
+
+		cursor := execResp.GetCursor()
+		if cursor == nil {
+			assert.Unreachable("projection-aligned prepared query returned no cursor result", details)
+
+			return
+		}
+
+		found := false
+		for _, account := range cursor.GetAccountData() {
+			if account.GetAddress() == probeAccount {
+				found = true
+
+				break
+			}
+		}
+
+		assert.Always(found,
+			"projection-aligned read includes the acknowledged write",
+			details.With(internal.Details{"returned": len(cursor.GetAccountData())}))
+	})
+}

--- a/tests/antithesis/workload/bin/cmds/main/parallel_driver_projection_alignment/main.go
+++ b/tests/antithesis/workload/bin/cmds/main/parallel_driver_projection_alignment/main.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
 
 	"github.com/formancehq/ledger/v3/tests/antithesis/workload/internal"
 )
@@ -37,9 +38,34 @@ func main() {
 		}
 
 		queryName := fmt.Sprintf("projection-q-%d", run)
+		indexIdempotencyKey := fmt.Sprintf("projection-index-%d", run)
 		queryIdempotencyKey := fmt.Sprintf("projection-query-%d", run)
 		probeIdempotencyKey := fmt.Sprintf("projection-probe-%d", run)
 		details := internal.Details{"ledger": ledger, "queryName": queryName}
+
+		// AccountHasAsset requires the account asset-presence index. Create it
+		// with a stable idempotency key so a timed-out setup call can be retried
+		// safely by a later driver run, then wait for this replica to switch the
+		// freshly built keyspace before exercising projection alignment.
+		if _, err := client.Apply(ctx, servicepb.UnsignedApplyRequest(
+			indexIdempotencyKey,
+			actions.CreateAccountAssetIndexAction(ledger),
+		)); err != nil {
+			if !internal.IsTolerated(err) {
+				assert.Unreachable("projection asset-index creation returned unexpected error",
+					details.With(internal.Details{"error": err}))
+			}
+
+			return
+		}
+		if err := actions.WaitForAccountAssetIndexReady(ctx, client, ledger); err != nil {
+			if !internal.IsTolerated(err) {
+				assert.Unreachable("projection asset index did not become ready",
+					details.With(internal.Details{"error": err}))
+			}
+
+			return
+		}
 
 		_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest(queryIdempotencyKey, &servicepb.Request{
 			Type: &servicepb.Request_CreatePreparedQuery{

--- a/tests/antithesis/workload/bin/cmds/main/parallel_driver_projection_alignment/main_test.go
+++ b/tests/antithesis/workload/bin/cmds/main/parallel_driver_projection_alignment/main_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestIsInconclusiveProjectionRead_OnlyToleratesReplicaBuildLag(t *testing.T) {
+	t.Parallel()
+
+	withReason := func(t *testing.T, reason string) error {
+		t.Helper()
+
+		st, err := status.New(codes.FailedPrecondition, reason).WithDetails(&errdetails.ErrorInfo{
+			Reason: reason,
+			Domain: "ledger",
+		})
+		if err != nil {
+			t.Fatalf("adding ErrorInfo: %v", err)
+		}
+
+		return st.Err()
+	}
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "other replica still building",
+			err:  withReason(t, domain.ErrReasonIndexBuilding),
+			want: true,
+		},
+		{
+			name: "index missing is a setup defect",
+			err:  withReason(t, domain.ErrReasonIndexNotFound),
+		},
+		{
+			name: "unclassified business failure",
+			err:  errors.New("permanent prepared-query failure"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isInconclusiveProjectionRead(tt.err); got != tt.want {
+				t.Fatalf("isInconclusiveProjectionRead(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/antithesis/workload/bin/cmds/main/parallel_driver_reference_race/main.go
+++ b/tests/antithesis/workload/bin/cmds/main/parallel_driver_reference_race/main.go
@@ -18,8 +18,8 @@
 //     commits a second transaction (two IDs — the genuine violation).
 //   - Ambiguous outcomes (Unavailable after retries, Internal, ledger races)
 //     never participate in conclusive-outcome assertions.
-//   - Reads use a MinLogSequence floor from a post-hoc marker write, so a
-//     stale read store cannot hide a committed duplicate (#398 class).
+//   - Reads happen after a post-hoc marker write; the default ReadIndex and
+//     projection alignment prevent a stale read store from hiding a duplicate.
 package main
 
 import (
@@ -68,11 +68,11 @@ func createWithReference(
 }
 
 // writeMarker commits a reference-less marker transaction and returns its log
-// sequence, usable as a MinLogSequence floor: the marker is proposed after
-// every assertion-relevant response was received, so a read floored at the
-// marker covers any write those responses could correspond to. Returns
+// sequence. The marker is proposed after every assertion-relevant response was
+// received, so a subsequent linearizable read covers any write those responses
+// could correspond to. Returns
 // (0, false) when the barrier could not be established (inconclusive).
-func writeMarker(ctx context.Context, client servicepb.BucketServiceClient, ledger string) (uint64, bool) {
+func writeMarker(ctx context.Context, client servicepb.BucketServiceClient, ledger string) bool {
 	resp, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", &servicepb.Request{
 		Type: &servicepb.Request_Apply{
 			Apply: &servicepb.LedgerApplyRequest{
@@ -92,32 +92,30 @@ func writeMarker(ctx context.Context, client servicepb.BucketServiceClient, ledg
 		},
 	}))
 	if err != nil {
-		return 0, false
+		return false
 	}
 
 	logs := resp.GetLogs()
 	if len(logs) == 0 {
-		return 0, false
+		return false
 	}
 
-	return logs[len(logs)-1].GetSequence(), true
+	return true
 }
 
-// countTransactionsWithReference lists transactions matching ref at a
-// MinLogSequence floor and returns (distinctTxIDs, conclusive). Any read
-// error makes the result inconclusive — never a violation.
+// countTransactionsWithReference lists transactions matching ref after an
+// acknowledged marker. The default linearizable read is aligned to the
+// marker's Raft horizon. Any read error makes the result inconclusive.
 func countTransactionsWithReference(
 	ctx context.Context,
 	client servicepb.BucketServiceClient,
 	ledger, ref string,
-	minLogSeq uint64,
 ) ([]uint64, bool) {
 	stream, err := client.ListTransactions(ctx, &servicepb.ListTransactionsRequest{
 		Ledger: ledger,
 		Options: &commonpb.ListOptions{
 			PageSize: 10,
 			Filter:   actions.ReferenceFilter(ref),
-			Read:     &commonpb.ReadOptions{MinLogSequence: minLogSeq},
 		},
 	})
 	if err != nil {
@@ -151,12 +149,11 @@ func assertReferenceUnique(
 	ledger, ref string,
 	details internal.Details,
 ) {
-	floor, ok := writeMarker(ctx, client, ledger)
-	if !ok {
+	if !writeMarker(ctx, client, ledger) {
 		return
 	}
 
-	ids, conclusive := countTransactionsWithReference(ctx, client, ledger, ref, floor)
+	ids, conclusive := countTransactionsWithReference(ctx, client, ledger, ref)
 	if !conclusive {
 		return
 	}

--- a/tests/antithesis/workload/bin/cmds/main/parallel_driver_timestamp_order/main.go
+++ b/tests/antithesis/workload/bin/cmds/main/parallel_driver_timestamp_order/main.go
@@ -145,7 +145,6 @@ func main() {
 				Options: &commonpb.ListOptions{
 					PageSize: pageSize,
 					Cursor:   cursor,
-					Read:     &commonpb.ReadOptions{MinLogSequence: maxSeq},
 				},
 			})
 			if err != nil {

--- a/tests/antithesis/workload/internal/client.go
+++ b/tests/antithesis/workload/internal/client.go
@@ -58,9 +58,8 @@ func NewGRPCConn() (*grpc.ClientConn, error) {
 		interceptorAttempts = maxAttempts
 	}
 
-	// Service-config retry covers only the raw UNAVAILABLE code; the interceptors
-	// add ReadIndexNotCaughtUp, which is reason-specific and so cannot be matched
-	// here (it would over-retry permanent FailedPrecondition business errors).
+	// Service-config retry covers the raw UNAVAILABLE code; the interceptors also
+	// handle deadline and external-service classifications below.
 	methodConfig := ""
 	if !retryDisabled {
 		methodConfig = fmt.Sprintf(`,
@@ -158,8 +157,8 @@ func retryDelay(attempt int) time.Duration {
 
 // retryUnaryInterceptor retries unary RPCs on the transient set (IsTransient)
 // to a definitive outcome — each code either clears (Unavailable: no leader
-// → elected; ReadIndexNotCaughtUp: lagging read catches up; ExternalServiceError:
-// external service recovers) or is an ambiguous commit (DeadlineExceeded — see
+// → elected; ExternalServiceError: external service recovers) or is an
+// ambiguous commit (DeadlineExceeded — see
 // IsAmbiguousCommit) that a retry resolves via the idempotency cache. None is
 // a permanent business answer, so retrying is safe and cannot loop forever.
 // maxAttempts bounds the loop (~infinite in retry-forever mode); ctx
@@ -337,8 +336,8 @@ func IsCanceled(err error) bool {
 // IsAmbiguousCommit returns true if the error indicates the request may have
 // committed despite the error code — the retry resolves the ambiguity via
 // the idempotency cache. Today: DeadlineExceeded only (Unavailable surfaces
-// before the server sees the request, ReadIndexNotCaughtUp is a read-only
-// answer, ExternalServiceError happens before the audit ack).
+// before the server sees the request and ExternalServiceError happens before
+// the audit ack).
 //
 // IsAmbiguousCommit is a STRICT SUBSET of IsTransient — every member is
 // already retried by the interceptors. The separation exists so drivers
@@ -346,15 +345,6 @@ func IsCanceled(err error) bool {
 // read-after-write even on the "error" branch.
 func IsAmbiguousCommit(err error) bool {
 	return IsDeadlineExceeded(err)
-}
-
-// IsReadIndexNotCaughtUp returns true if the error is the server's
-// FailedPrecondition response carrying the READ_INDEX_NOT_CAUGHT_UP
-// reason. Emitted when a linearizable read targets an index the local
-// read-side store has not yet caught up to — always transient (the read
-// store will eventually catch up).
-func IsReadIndexNotCaughtUp(err error) bool {
-	return HasErrorReason(err, "READ_INDEX_NOT_CAUGHT_UP")
 }
 
 // HasErrorReason returns true if the error is a gRPC status with an
@@ -463,13 +453,12 @@ func IsNoFullCheckpoint(err error) bool {
 
 // IsTransient returns true for a retry-safe infrastructure error — not a
 // definitive business answer, not a local-lifecycle event. Retrying reaches a
-// definitive outcome: the condition clears (no leader → elected, lagging read
-// → caught up) or — since DeadlineExceeded can follow a commit — the retry
-// resolves the ambiguity via the idempotency cache. The retry interceptors
+// definitive outcome: the condition clears (no leader → elected) or — since
+// DeadlineExceeded can follow a commit — the retry resolves the ambiguity via
+// the idempotency cache. The retry interceptors
 // retry exactly this set. Covers:
 //   - Unavailable (cluster unhealthy / no leader / Raft transients)
 //   - DeadlineExceeded (wire-level timeout, also see IsAmbiguousCommit)
-//   - FailedPrecondition + READ_INDEX_NOT_CAUGHT_UP (read store catching up)
 //   - ExternalServiceError (S3 / NATS down, etc.)
 //
 // NOT in IsTransient:
@@ -480,7 +469,6 @@ func IsNoFullCheckpoint(err error) bool {
 func IsTransient(err error) bool {
 	return IsUnavailable(err) ||
 		IsDeadlineExceeded(err) ||
-		IsReadIndexNotCaughtUp(err) ||
 		IsExternalServiceError(err)
 }
 
@@ -495,8 +483,8 @@ func IsTolerated(err error) bool {
 
 // isBusinessError returns true for a definitive business answer the server
 // returns when the request was syntactically valid but the requested action
-// cannot apply (NotFound, AlreadyExists, InvalidArgument, FailedPrecondition
-// minus the two reasons that IsTransient already covers).
+// cannot apply (NotFound, AlreadyExists, InvalidArgument, or a generic
+// FailedPrecondition that is not ExternalServiceError).
 //
 // Unexported because it is only used by IsClassified — drivers that need to
 // validate a specific business outcome check the precise reason via
@@ -506,8 +494,8 @@ func isBusinessError(err error) bool {
 	if err == nil {
 		return false
 	}
-	if IsReadIndexNotCaughtUp(err) || IsExternalServiceError(err) {
-		// These are FailedPrecondition codes but already classified as transient.
+	if IsExternalServiceError(err) {
+		// This is a FailedPrecondition code but already classified as transient.
 		return false
 	}
 	st, ok := status.FromError(err)

--- a/tests/antithesis/workload/internal/client.go
+++ b/tests/antithesis/workload/internal/client.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -472,13 +473,16 @@ func IsTransient(err error) bool {
 		IsExternalServiceError(err)
 }
 
-// IsTolerated returns true for any error the workload should NOT surface as
-// a finding: nil, retry-safe transient, or local-lifecycle Canceled. This is
-// the predicate the Sometimes() probes use (`assert.Sometimes(IsTolerated(err),
-// ...)`) so that a context cancellation late in the run doesn't flip a
-// per-driver Sometimes signal to "never true".
+// IsTolerated returns true for any error the workload should NOT surface as a
+// finding: nil, retry-safe transient, or a local context deadline/cancellation.
+// Local helpers can wrap context errors without converting them to gRPC status;
+// those remain inconclusive lifecycle outcomes. This is the predicate the
+// Sometimes() probes use (`assert.Sometimes(IsTolerated(err), ...)`) so that a
+// context cancellation late in the run doesn't flip a per-driver Sometimes
+// signal to "never true".
 func IsTolerated(err error) bool {
-	return err == nil || IsTransient(err) || IsCanceled(err)
+	return err == nil || IsTransient(err) || IsCanceled(err) ||
+		errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
 }
 
 // isBusinessError returns true for a definitive business answer the server

--- a/tests/antithesis/workload/internal/client_test.go
+++ b/tests/antithesis/workload/internal/client_test.go
@@ -1,0 +1,43 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestIsTolerated_LocalReadinessTimeoutIsInconclusive(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "wrapped readiness deadline",
+			err:  fmt.Errorf("waiting for index readiness: %w (last error: index still building)", context.DeadlineExceeded),
+			want: true,
+		},
+		{
+			name: "wrapped driver cancellation",
+			err:  fmt.Errorf("waiting for index readiness: %w", context.Canceled),
+			want: true,
+		},
+		{
+			name: "permanent readiness error",
+			err:  errors.New("index registry entry is malformed"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := IsTolerated(tt.err); got != tt.want {
+				t.Fatalf("IsTolerated(%v) = %t, want %t", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/antithesis/workload/internal/ledger.go
+++ b/tests/antithesis/workload/internal/ledger.go
@@ -54,6 +54,7 @@ const (
 	PrefixListCompleteness OwnedLedgerPrefix = "listcomp"
 	PrefixTimestampOrder   OwnedLedgerPrefix = "tsorder"
 	PrefixMinLogSeq        OwnedLedgerPrefix = "minseq"
+	PrefixProjectionAlign  OwnedLedgerPrefix = "projection"
 	PrefixStaleReads       OwnedLedgerPrefix = "stale"
 
 	// PrefixSentinel covers the witness-ledger family used by the
@@ -90,6 +91,7 @@ var ownedLedgerPrefixes = []OwnedLedgerPrefix{
 	PrefixListCompleteness,
 	PrefixTimestampOrder,
 	PrefixMinLogSeq,
+	PrefixProjectionAlign,
 	PrefixStaleReads,
 	PrefixSentinel,
 	PrefixModel,


### PR DESCRIPTION
## Summary

- migrate Antithesis assertions from client-selected minimum log sequence to default linearizable reads backed by certified projection horizons;
- keep the existing explicit MinLogSequence regression additive until #1881 removes that public contract;
- add a dedicated projection-alignment driver using an index-backed AccountHasAsset filter;
- keep setup/write failures observable and retried writes idempotent;
- preserve the stale fault scenario unchanged.

## Stack

EN-1946 stack 7/8. Depends on #1893 (feat/en-1946-remove-leader-consistency).

Merge/review order: #1897 → #1889 → #1890 → #1894 → #1891 → #1893 → #1892 → #1881.

## Validation

Final base: 0c6dfd33d3093d003990e949866e978951059e3b.
Final head: 9a054e4e912e1f1eaaf0a1af3bcbea0e19321faf.
Canonical PR validation: PASS, including baseline and complete tooling suites; projection setup/readiness regressions pass.
Independent exact diff review: APPROVE (residual risk LOW).

Jira: EN-1946. Do not merge automatically.