### PR TITLE
refactor(reads): remove leader consistency selector (EN-1946)

### DIFF
--- a/cmd/ledgerctl/main.go
+++ b/cmd/ledgerctl/main.go
@@ -118,8 +118,8 @@ func newRootCommand() *cobra.Command {
 	rootCmd.PersistentFlags().String("response-verify-key", "", "Path to Ed25519 seed file for verifying server response signatures (env: LEDGERCTL_RESPONSE_VERIFY_KEY)")
 
 	// Add persistent flag for read consistency level.
-	rootCmd.PersistentFlags().String("consistency", "", "Read consistency level: stale, leader, or linearizable (default) (env: LEDGERCTL_CONSISTENCY)")
-	cmdutil.RegisterEnumCompletion(rootCmd, "consistency", "stale", "leader", "linearizable")
+	rootCmd.PersistentFlags().String("consistency", "", "Read consistency level: stale or linearizable (default) (env: LEDGERCTL_CONSISTENCY)")
+	cmdutil.RegisterEnumCompletion(rootCmd, "consistency", "stale", "linearizable")
 
 	// Add persistent flag for bearer token authentication.
 	rootCmd.PersistentFlags().String("auth-token", "", "Bearer token for authentication (JWT string or @path-to-file) (env: LEDGERCTL_AUTH_TOKEN)")

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -64,7 +64,7 @@ These flags are available for all commands:
 | `--signing-key` | | Path to Ed25519 private key file (seed: 32 bytes raw or hex-encoded) |
 | `--signing-key-id` | `default` | Key ID for request signatures |
 | `--response-verify-key` | | Path to Ed25519 public key file for verifying server response signatures |
-| `--consistency` | | Read consistency level: `stale`, `leader`, or `linearizable` (default) |
+| `--consistency` | | Read consistency level: `stale` or `linearizable` (default) |
 | `--auth-token` | | Bearer token for authentication (JWT string or `@path-to-file`) |
 
 ### TLS server name (verifying by name while dialing by IP)
@@ -111,29 +111,20 @@ make independently asynchronous projections linearizable; endpoint sections
 document those exceptions. The barrier can block during maintenance windows
 (e.g. mirror sync or snapshot creation) when the FSM is frozen.
 
-Two alternative consistency levels are available:
+One alternative consistency level is available:
 
 - **`stale`** — Skip the Raft ReadIndex barrier and read from local state, which
   may lag behind the latest committed index. A read can still wait for an
   explicitly requested `--min-log-sequence` or for mandatory secondary-index
   alignment. Useful for monitoring, dashboards, and non-critical queries where
   quorum-confirmed freshness is unnecessary.
-- **`leader`** — Route the read to the node currently considered leader. When
-  the request is forwarded, the remote node applies its default ReadIndex
-  barrier. When the receiving node already considers itself leader, it serves
-  the read locally without a barrier. Because `CheckQuorum` is disabled, an
-  isolated former leader can therefore return stale state in this mode; use the
-  default `linearizable` mode when quorum-confirmed freshness is required.
 
-Filtered `audit list` has
-an endpoint-specific asynchronous-index caveat; see its consistency note below.
+Filtered `audit list` has an endpoint-specific asynchronous-index caveat; see
+its consistency note below.
 
 ```bash
 # Stale read (no Raft barrier; may lag)
 ledgerctl --consistency stale ledgers get my-ledger
-
-# Leader-routed read (may be stale from an isolated former leader)
-ledgerctl --consistency leader ledgers list
 
 # Default linearizable read
 ledgerctl ledgers list
@@ -1867,7 +1858,7 @@ ledgerctl version
 
 The **server** exposes the same build metadata over two unauthenticated channels:
 
-- **HTTP** — `GET /_info` returns flat JSON (no `data` envelope): `{"version":"…","commit":"…","buildDate":"…","goVersion":"…","protocolVersion":"2"}`.
+- **HTTP** — `GET /_info` returns flat JSON (no `data` envelope): `{"version":"…","commit":"…","buildDate":"…","goVersion":"…","protocolVersion":"3"}`.
 - **gRPC** — the `Discovery` RPC's `DiscoveryResponse` carries a `ServerInfo` message with the same information, including `protocol_version`.
 
 This is useful for monitoring deployed nodes and spotting version skew across a cluster (the per-node `version` is also surfaced on each `NodeInfo` in `GetClusterState`).

--- a/docs/technical/architecture/data-flows.md
+++ b/docs/technical/architecture/data-flows.md
@@ -553,11 +553,10 @@ config:
 ### Overview
 
 **Write requests** (`Apply`) are always routed to the node currently
-considered leader. Live reads normally use the ReadIndex mechanism (see
-below), but callers can explicitly select `x-consistency: leader`. That mode
-routes the read to the perceived leader; if the receiving node already
-considers itself leader, the local shortcut does not perform a ReadIndex
-barrier.
+considered leader. Live reads normally use the ReadIndex mechanism (see below).
+The unreleased v3 `x-consistency: leader` selector was removed by EN-1946;
+callers choose between the default linearizable route and an explicit `stale`
+local read.
 
 ### Forwarding Flow
 

--- a/docs/technical/architecture/subsystems/api/protocol-compatibility.md
+++ b/docs/technical/architecture/subsystems/api/protocol-compatibility.md
@@ -20,7 +20,7 @@ compatibility of development revisions.
 ## Wire contract and failure behavior
 
 `pkg/grpcprotocol.Version` is the compiled service protocol revision, currently
-`"2"`. `pkg/grpcprotocol.MetadataKey` is `ledger-protocol-version`. Clients send
+`"3"`. `pkg/grpcprotocol.MetadataKey` is `ledger-protocol-version`. Clients send
 exactly one value for this metadata key on every RPC. The Go
 `grpcprotocol.ClientOption()` dial option supplies the local revision for unary
 and streaming calls. Local `dev` builds carry the same constant without release
@@ -61,10 +61,10 @@ servers or support for mixed wire-format upgrades.
 
 Every consumer of the service gRPC endpoint must declare its protocol,
 including SDKs, automation, `grpcurl`, and internal requests forwarded to a
-leader. For example, with a schema implementing revision 2:
+leader. For example, with a schema implementing revision 3:
 
 ```bash
-grpcurl -plaintext -H 'ledger-protocol-version: 2' \
+grpcurl -plaintext -H 'ledger-protocol-version: 3' \
   localhost:8888 cluster.ClusterService.GetClusterState
 ```
 

--- a/docs/technical/architecture/subsystems/consensus/raft-consensus.md
+++ b/docs/technical/architecture/subsystems/consensus/raft-consensus.md
@@ -309,10 +309,10 @@ it hears from a higher term. It still cannot commit or acknowledge new writes,
 and a `ReadOnlySafe` `ReadIndex` cannot complete without quorum confirmation.
 That temporary role disagreement is not a split brain at the committed-state
 level. Explicit `stale` reads intentionally bypass the quorum barrier and may
-return an older local view. An explicit `leader` read can do the same when it
-reaches a node that still considers itself leader: the local-leader routing
-shortcut serves local state without `ReadIndex`. Neither mode should be used
-when quorum-confirmed freshness is required during a partition.
+return an older local view. They should not be used when quorum-confirmed
+freshness is required during a partition. All non-stale reads require a
+successful `ReadIndex`, including reads served on the node that currently
+reports itself as leader.
 
 ### Quorum and Failure Tolerance
 
@@ -553,6 +553,38 @@ The system can pipeline requests:
 - Send multiple `AppendEntries` before receiving confirmations
 - Limited by `MaxInflightMsgs`
 
+### Why v3 has no `leader` read selector (EN-1946)
+
+The product requirement is one predictable default for every non-stale live
+read: the serving node must confirm a quorum-backed horizon before it opens the
+state snapshot, whether that node currently reports itself as leader or
+follower. Routing to the perceived leader is only a location preference; it is
+not a consistency proof. With `CheckQuorum` disabled, an isolated former leader
+can temporarily keep its local leader role and serve old local state if that
+route shortcuts `ReadIndex`.
+
+Because v3 is unreleased, EN-1946 removes the `x-consistency: leader` selector
+instead of preserving that ambiguous contract. The default route always uses
+`ReadIndexAndWait`; `stale` remains the sole explicit opt-out and says exactly
+that it skips quorum confirmation.
+
+Alternatives considered:
+
+- Retain and document `leader`: rejected because a placement hint that can
+  weaken freshness contradicts the common non-stale contract.
+- Reinterpret `leader` to route and then perform `ReadIndex`: rejected because
+  it duplicates the default guarantee while concentrating read load and keeping
+  a selector with no distinct semantic value.
+- Keep the shortcut unchanged: rejected because an isolated former leader can
+  return stale data under a mode callers reasonably read as authoritative.
+
+Validation is split at the contract boundaries:
+`TestExtractConsistency_LeaderIsNotSupported` proves the old token cannot
+select a weaker path, routed-controller tests prove local default reads obtain
+and propagate the `ReadIndex` horizon, and
+`TestRoutedController_FinishLeaderFallback` proves a failed follower barrier
+cannot turn into an unbarriered local read if leadership moves during fallback.
+
 ### Linearizable Reads via ReadIndex
 
 Default live reads routed through `RoutedController.readCtrl` use the etcd/raft
@@ -583,15 +615,6 @@ indexes need their own progress barrier:
 - `x-consistency: stale` bypasses `ReadIndex` and reads the local store directly;
   it may return an older view, but any projection it uses is still aligned to
   the fixed applied index of that local main-store snapshot.
-- `x-consistency: leader` routes the read to the node currently considered
-  leader. A call forwarded to a remote node does not propagate the consistency
-  metadata, so the remote call defaults to linearizable mode and performs its
-  quorum barrier. However, if the receiving node already considers itself
-  leader, `getLeaderCtrl` returns the local controller directly and skips
-  `ReadIndex`. Because `CheckQuorum` is disabled, an isolated former leader can
-  therefore serve stale local state in this mode. Projection-backed reads still
-  align to that local main-store snapshot even though no quorum horizon `R` is
-  available.
 - If a non-leader node is syncing or cannot complete its local barrier,
   `RoutedController` can transparently retry the read against the leader. The
   forwarded attempt can still fail when the leader is unavailable. If

--- a/docs/technical/architecture/subsystems/read-path/README.md
+++ b/docs/technical/architecture/subsystems/read-path/README.md
@@ -7,7 +7,7 @@ and unfiltered account/transaction queries then use the main store only.
 Filtered account/transaction queries, every log query, and `InspectIndex`
 additionally wait for the read index to align with that horizon before iterating
 it. `stale` removes only the Raft barrier, checkpoint pairs are already frozen,
-and leader-local, audit-index, and usagestore exceptions are documented in the
+and audit-index and usagestore exceptions are documented in the
 [consensus matrix](../consensus/raft-consensus.md#linearizable-reads-via-readindex)
 and the pipeline pages.
 

--- a/docs/technical/architecture/subsystems/read-path/prepared-queries.md
+++ b/docs/technical/architecture/subsystems/read-path/prepared-queries.md
@@ -72,10 +72,10 @@ A compile error at FSM time is hash-bound as an `AuditFailure`, so a checker run
 1. Opens the fixed main-store snapshot, then reads both the ledger schema and prepared query from that snapshot. This prevents a concurrent query/schema update or deletion from being combined with entities from a newer state. Because the stored definition determines whether an index will be used, the executor briefly reserves the event-history floor before opening the snapshot and releases it immediately when the loaded shape needs no index alignment.
 2. Verifies the requested mode is compatible with the query's `target` (e.g. `AGGREGATE_VOLUMES` only makes sense for accounts).
 3. Enters the standard read route. Default live consistency establishes a
-   `ReadIndexAndWait` horizon; `stale`, leader-local, and checkpoint reads have
-   the documented exceptions. The executor waits for read-index alignment only
-   when `AlignmentOwed` is true — the filter tree contains a read-index leaf or
-   the target is LOGS — then calls
+   `ReadIndexAndWait` horizon; `stale` and checkpoint reads have the documented
+   exceptions. The executor waits for read-index alignment only when
+   `AlignmentOwed` is true — the filter tree contains a read-index leaf or the
+   target is LOGS — then calls
    `Compile(indexSnap, kb, pq.GetFilter(), ...)` and executes the iterator.
 4. For `LIST`, streams the matching entities through the standard cursor pipeline (see [query-pipeline.md](query-pipeline.md)).
 5. For `AGGREGATE_VOLUMES`, loops over the candidate account set and sums per-asset volumes from the main store. The aggregation is **computed at request time** — there is no materialised aggregate table.

--- a/docs/technical/architecture/subsystems/read-path/query-pipeline.md
+++ b/docs/technical/architecture/subsystems/read-path/query-pipeline.md
@@ -82,7 +82,7 @@ was used.
 
 Once both succeed, the local Pebble snapshot reflects state at least as fresh as the moment the request reached the cluster. This guarantees **linearizable reads on any node**: a read started after a successful write returns at least that write's effects, regardless of which node serves the read.
 
-If the node is syncing or otherwise unable to confirm `ReadIndex`, the call fails — callers either retry or forward to the leader. The explicit `leader` consistency mode remains available at this stage: a remote hop defaults to the linearizable path, while a node that already considers itself leader serves locally without `R` and still aligns every projection it uses to the fixed local `H` below.
+If the node is syncing or otherwise unable to confirm `ReadIndex`, the call fails — callers either retry or forward to the leader.
 
 ## Projection alignment — fixed Raft horizon
 

--- a/docs/technical/architecture/subsystems/read-path/query-profile.md
+++ b/docs/technical/architecture/subsystems/read-path/query-profile.md
@@ -102,23 +102,28 @@ time inside `execute_duration_us`. Always read `barrier_duration_us` together wi
 | true | `0` | no local wait happened. Not "no barrier was needed": the remote node's is inside `execute_duration_us`. |
 | true | non-zero | a local wait happened before the read left this node; the remote barrier is on top of it (see below) |
 
-Two independent things produce the last row, and the value does **not** say
-which:
+The last row always means that a non-stale read entered the syncing-follower
+fallback after its local `ReadIndex` attempt failed. `RoutedController.readCtrl`
+records that attempt before it resolves and marks the remote route. If
+leadership moved local in the meantime, the router returns the failed barrier
+rather than serving locally. Its magnitude differs sharply by cause:
+`ErrNodeSyncing` returns before any wait, so it costs nanoseconds, whereas
+leadership lost mid-`ReadIndex` resolves a pending future and can account for
+the whole quorum attempt.
 
-- **`min_log_sequence` catch-up.** `waitMinLogSequence` charges the
-  `WaitForSequence` wait regardless of consistency level, and it runs before
-  routing — so `--consistency leader --min-log-sequence N` yields a non-zero
-  barrier on a perfectly healthy cluster, with no failed attempt anywhere.
-- **A failed `ReadIndex` attempt.** The syncing-follower fallback in
-  `RoutedController.readCtrl` records the attempt and may then forward after it
-  resolves a remote leader. If leadership moved local in the meantime, the
-  router returns the failed barrier rather than serving locally. Magnitude
-  differs sharply by cause: `ErrNodeSyncing` returns before any wait, so it
-  costs nanoseconds, whereas leadership lost mid-`ReadIndex` resolves a pending
-  future and can account for the whole quorum attempt.
+For handlers that still accept `min_log_sequence`, the same profile may also
+contain an earlier `waitMinLogSequence` catch-up because that wait runs before
+routing. A representative `forwarded=true, non-zero` request therefore uses
+linearizable consistency with `min_log_sequence` on a syncing follower: the
+profile combines the explicit sequence catch-up and the failed local
+`ReadIndex` attempt, and does not attribute the total between them. In
+contrast, `--consistency stale --min-log-sequence N` stays local; any sequence
+wait it records belongs to the `forwarded=false` row.
 
-So do not read cluster health off a non-zero forwarded barrier — the common cause
-is a caller asking for read-your-writes.
+The `forwarded=true` part therefore always signals a failed local barrier. A
+preceding `min_log_sequence` catch-up can inflate the reported duration, so the
+magnitude alone does not identify whether the failure was an immediate syncing
+precheck or an invalidated in-flight `ReadIndex`.
 
 Either way the wait is charged and stays excluded from `server_duration_us`, for
 the same reason a successful barrier is: the caller waited for it, and an
@@ -245,9 +250,10 @@ locally-served one.
 
 ## Known gaps
 
-- **Leader-forwarded reads report only the local hop.** When a follower forwards
-  a read (`ConsistencyLeader`, or the syncing-node fallback in
-  `RoutedController.readCtrl`), the upstream RPC is charged to the local
+- **Leader-forwarded reads report only the local hop.** When a follower falls
+  back to the leader in `RoutedController.readCtrl` because it is syncing or its
+  pending ReadIndex was invalidated by a leader change, the upstream RPC is
+  charged to the local
   `execute` phase, so `execute` there conflates network hops, leader-side
   prepare, leader-side barrier and leader-side execution. `barrier_duration_us`
   covers only what this node attempted locally.

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -13,7 +13,7 @@ This document compares the POC's API with the original Formance ledger API and d
 ### Service protocol compatibility (EN-1851)
 
 The v3 gRPC service requires one `ledger-protocol-version` metadata value per
-business RPC, equal to `pkg/grpcprotocol.Version` (currently `"2"`). Missing,
+business RPC, equal to `pkg/grpcprotocol.Version` (currently `"3"`). Missing,
 invalid, duplicate, or different revisions fail with `FailedPrecondition` before
 business handler execution. This applies to unary and streaming Bucket, Cluster,
 and Restore operations, including internal forwarding. Discovery, gRPC health,

--- a/internal/adapter/grpc/consistency.go
+++ b/internal/adapter/grpc/consistency.go
@@ -15,10 +15,6 @@ const (
 	// ConsistencyStale skips the ReadIndex barrier and reads from the local store directly.
 	// Data may lag behind the latest committed index.
 	ConsistencyStale = "stale"
-	// ConsistencyLeader routes the read to the node currently considered leader.
-	// A remote leader applies the default ReadIndex barrier, but a node that
-	// already considers itself leader serves the read locally without one.
-	ConsistencyLeader = "leader"
 )
 
 const metadataKeyConsistency = "x-consistency"
@@ -86,7 +82,7 @@ func extractConsistency(ctx context.Context) context.Context {
 
 	level := strings.ToLower(strings.TrimSpace(vals[0]))
 	switch level {
-	case ConsistencyStale, ConsistencyLeader:
+	case ConsistencyStale:
 		return WithConsistency(ctx, level)
 	default:
 		return ctx

--- a/internal/adapter/grpc/consistency_test.go
+++ b/internal/adapter/grpc/consistency_test.go
@@ -16,14 +16,6 @@ func TestWithConsistency(t *testing.T) {
 	require.Equal(t, ConsistencyStale, level)
 }
 
-func TestWithConsistency_Leader(t *testing.T) {
-	t.Parallel()
-
-	ctx := WithConsistency(context.Background(), ConsistencyLeader)
-	level := ConsistencyFromContext(ctx)
-	require.Equal(t, ConsistencyLeader, level)
-}
-
 func TestConsistencyFromContext_Default(t *testing.T) {
 	t.Parallel()
 
@@ -82,7 +74,7 @@ func TestExtractConsistency_Stale(t *testing.T) {
 	require.Equal(t, ConsistencyStale, level)
 }
 
-func TestExtractConsistency_Leader(t *testing.T) {
+func TestExtractConsistency_LeaderIsNotSupported(t *testing.T) {
 	t.Parallel()
 
 	md := metadata.New(map[string]string{metadataKeyConsistency: "leader"})
@@ -90,7 +82,7 @@ func TestExtractConsistency_Leader(t *testing.T) {
 
 	ctx = extractConsistency(ctx)
 	level := ConsistencyFromContext(ctx)
-	require.Equal(t, ConsistencyLeader, level)
+	require.Equal(t, ConsistencyLinearizable, level)
 }
 
 func TestExtractConsistency_CaseInsensitive(t *testing.T) {
@@ -119,10 +111,10 @@ func TestExtractConsistency_Linearizable(t *testing.T) {
 func TestExtractConsistency_WhitespaceHandling(t *testing.T) {
 	t.Parallel()
 
-	md := metadata.New(map[string]string{metadataKeyConsistency: "  leader  "})
+	md := metadata.New(map[string]string{metadataKeyConsistency: "  stale  "})
 	ctx := metadata.NewIncomingContext(context.Background(), md)
 
 	ctx = extractConsistency(ctx)
 	level := ConsistencyFromContext(ctx)
-	require.Equal(t, ConsistencyLeader, level)
+	require.Equal(t, ConsistencyStale, level)
 }

--- a/internal/adapter/grpc/protocol_interceptor_test.go
+++ b/internal/adapter/grpc/protocol_interceptor_test.go
@@ -94,7 +94,7 @@ func TestServiceServerProtocolVersion(t *testing.T) {
 				{"missing", nil},
 				{"empty", []string{""}},
 				{"older", []string{"0"}},
-				{"newer", []string{"3"}},
+				{"newer", []string{"4"}},
 				{"invalid", []string{"dev"}},
 				{"duplicate", []string{grpcprotocol.Version, grpcprotocol.Version}},
 				{"conflicting", []string{grpcprotocol.Version, "0"}},

--- a/internal/bootstrap/controller_routed.go
+++ b/internal/bootstrap/controller_routed.go
@@ -57,11 +57,11 @@ func (b *RoutedController) getLeaderCtrl() (ctrl.Controller, error) {
 // The consistency level is determined from the context (set by the gRPC interceptor):
 //   - linearizable (default): ReadIndex+WaitForApplied barrier on the local node
 //   - stale: skip the barrier and read from the local store directly
-//   - leader: route the read to the node currently considered leader; the local
-//     leader shortcut does not perform a ReadIndex barrier
 //
-// For linearizable reads, if the local node is still syncing the read is
-// transparently forwarded to the leader.
+// For linearizable reads, a syncing precheck or an in-flight ReadIndex
+// invalidated by a leadership change transparently falls back to the remote
+// leader. If resolution points back to the local controller, the failed
+// barrier is returned instead of serving an unbarriered local read.
 func (b *RoutedController) readCtrl(ctx context.Context) (ctrl.Controller, *node.ReadBarrierInfo, error) {
 	consistency := grpcadp.ConsistencyFromContext(ctx)
 
@@ -69,30 +69,10 @@ func (b *RoutedController) readCtrl(ctx context.Context) (ctrl.Controller, *node
 		trace.WithAttributes(attribute.String("consistency", consistency)))
 	defer span.End()
 
-	switch consistency {
-	case grpcadp.ConsistencyStale:
+	if consistency == grpcadp.ConsistencyStale {
 		span.SetAttributes(attribute.String("route", "local_stale"))
 
 		return b.localController, nil, nil
-	case grpcadp.ConsistencyLeader:
-		span.SetAttributes(attribute.String("route", "leader"))
-
-		c, err := b.getLeaderCtrl()
-		if err != nil {
-			return nil, nil, err
-		}
-
-		// When getLeaderCtrl returns a remote controller, that node runs its own
-		// ReadIndex barrier (x-consistency is not propagated, so it defaults to
-		// linearizable there). The remote barrier and execution are invisible to
-		// this profile — the whole remote cost arrives as row-production time
-		// inside the local execute phase, and this node's barrier_duration_us stays
-		// 0. Flag it so a reader does not take that 0 to mean "no barrier was
-		// needed" (EN-1859). When this node already considers itself leader,
-		// getLeaderCtrl returns the local controller and no barrier is performed.
-		b.markForwardedIfRemote(ctx, c)
-
-		return c, nil, nil
 	}
 
 	// The ReadIndex quorum round-trip plus the local WaitForApplied catch-up is
@@ -122,9 +102,8 @@ func (b *RoutedController) readCtrl(ctx context.Context) (ctrl.Controller, *node
 		if !b.IsLeader() {
 			span.SetAttributes(attribute.String("route", "leader_fallback"))
 
-			// Same as the explicit-leader branch: the read leaves this node, so
-			// the phase breakdown describes the local hop only. Unlike that
-			// branch, the barrier already recorded above is KEPT: the caller
+			// The read leaves this node, so the phase breakdown describes the
+			// local hop only. The barrier already recorded above is KEPT: the caller
 			// really did wait for a quorum attempt that then failed. Dropping it
 			// would not delete the time — readCtrl runs inside the caller's
 			// EnterExecute/LeaveExecute bracket, so an uncharged wait stays in
@@ -160,15 +139,6 @@ func (b *RoutedController) finishLeaderFallback(ctx context.Context, selected ct
 	query.ProfileFromContext(ctx).MarkForwarded()
 
 	return selected, nil, nil
-}
-
-// markForwardedIfRemote preserves the query-profile contract that Forwarded
-// means another node served the read. The explicit leader-consistency path can
-// resolve to the local controller when this node considers itself leader.
-func (b *RoutedController) markForwardedIfRemote(ctx context.Context, selected ctrl.Controller) {
-	if selected != b.localController {
-		query.ProfileFromContext(ctx).MarkForwarded()
-	}
 }
 
 func (b *RoutedController) withLocalBarrierHorizon(ctx context.Context, selected ctrl.Controller, barrier *node.ReadBarrierInfo) context.Context {

--- a/internal/bootstrap/controller_routed_test.go
+++ b/internal/bootstrap/controller_routed_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
-	grpcadp "github.com/formancehq/ledger/v3/internal/adapter/grpc"
 	"github.com/formancehq/ledger/v3/internal/application/ctrl"
 	"github.com/formancehq/ledger/v3/internal/application/ctrl/ctrlmock"
 	"github.com/formancehq/ledger/v3/internal/infra/node"
@@ -58,35 +57,6 @@ func TestRoutedController_IsHealthy_NilNode(t *testing.T) {
 	// Here we just confirm the method signature matches ctrl.Controller.
 	rc := &RoutedController{}
 	assert.NotNil(t, rc) // RoutedController can be instantiated
-}
-
-func TestRoutedController_MarkForwardedOnlyForRemoteController(t *testing.T) {
-	t.Parallel()
-
-	mockCtrl := gomock.NewController(t)
-	local := ctrlmock.NewMockController(mockCtrl)
-	remote := ctrlmock.NewMockController(mockCtrl)
-	routed := &RoutedController{localController: local}
-
-	localCtx, localProfile := query.WithProfile(context.Background())
-	routed.markForwardedIfRemote(localCtx, local)
-	assert.False(t, localProfile.Forwarded)
-
-	remoteCtx, remoteProfile := query.WithProfile(context.Background())
-	routed.markForwardedIfRemote(remoteCtx, remote)
-	assert.True(t, remoteProfile.Forwarded)
-}
-
-func TestRoutedController_LeaderRoutingErrorIsNotForwarded(t *testing.T) {
-	t.Parallel()
-
-	routed := &RoutedController{Node: &node.Node{}}
-	ctx, profile := query.WithProfile(context.Background())
-	ctx = grpcadp.WithConsistency(ctx, grpcadp.ConsistencyLeader)
-
-	_, _, err := routed.readCtrl(ctx)
-	require.ErrorIs(t, err, commonpb.ErrNoLeader)
-	assert.False(t, profile.Forwarded)
 }
 
 func TestRoutedController_FinishLeaderFallback(t *testing.T) {
@@ -149,7 +119,7 @@ func TestRoutedController_WithLocalBarrierHorizon(t *testing.T) {
 	require.False(t, ok, "the remote hop establishes and checks its own barrier")
 
 	_, ok = query.ReadBarrierHorizon(routed.withLocalBarrierHorizon(context.Background(), local, nil))
-	require.False(t, ok, "stale and explicit leader reads deliberately carry no linearizable horizon")
+	require.False(t, ok, "stale reads deliberately carry no linearizable horizon")
 }
 
 func TestRoutedController_IndexedReadsForwardLocalBarrierHorizon(t *testing.T) {

--- a/internal/proto/servicepb/bucket.pb.go
+++ b/internal/proto/servicepb/bucket.pb.go
@@ -8023,13 +8023,13 @@ type QueryProfile struct {
 	// items_collected and the RPC's own status to tell them apart.
 	FirstRowDurationUs int64 `protobuf:"varint,13,opt,name=first_row_duration_us,json=firstRowDurationUs,proto3" json:"first_row_duration_us,omitempty"`
 	// True when this node did not serve the read itself but forwarded it to
-	// another node — an explicit leader-consistency read, or the fallback taken
-	// when the local replica is still catching up. The remote node's prepare,
-	// barrier and execution all arrive inside execute_duration_us, so the phase
-	// breakdown describes the local hop only. Its purpose is to stop a zero
-	// barrier_duration_us from being misread as "no barrier was needed"; see that
-	// field for the three cases the pair distinguishes — a forwarded read can
-	// report a non-zero local wait.
+	// another node — the fallback taken when the local replica is still catching
+	// up or its in-flight ReadIndex is invalidated by a leadership change. The
+	// remote node's prepare, barrier and execution all arrive inside
+	// execute_duration_us, so the phase breakdown describes the local hop only.
+	// Its purpose is to stop a zero barrier_duration_us from being misread as "no
+	// barrier was needed"; see that field for the three cases the pair
+	// distinguishes — a forwarded read can report a non-zero local wait.
 	Forwarded     bool `protobuf:"varint,14,opt,name=forwarded,proto3" json:"forwarded,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/internal/query/profile.go
+++ b/internal/query/profile.go
@@ -86,8 +86,9 @@ type QueryProfile struct {
 	// BarrierDuration is time blocked on caller-requested read-consistency waits,
 	// LOCAL to this node: the min_log_sequence catch-up and the Raft ReadIndex
 	// quorum. Excluded from ServerDuration. Every local wait counts, including
-	// one that fails or is superseded — a syncing follower burns a quorum wait
-	// before falling back to the leader and reports it here, with Forwarded true.
+	// one that fails or is superseded — a follower that is syncing or loses its
+	// leader mid-quorum burns a local wait before falling back to the leader and
+	// reports it here, with Forwarded true.
 	BarrierDuration time.Duration
 	// DeliverDuration is time spent serialising result rows and handing them to
 	// the transport. Excluded from ServerDuration. On a gRPC server stream it is
@@ -103,18 +104,16 @@ type QueryProfile struct {
 	// ServerDuration is the consumer-independent server cost. Computed by
 	// Finish; zero until then.
 	ServerDuration time.Duration
-	// Forwarded is true when the read was routed to another node (an explicit
-	// leader read, or the syncing-follower fallback). The remote node runs its
-	// own barrier and execution, and that whole cost lands in this profile's
-	// ExecuteDuration.
+	// Forwarded is true when a follower routed the read to the leader because it
+	// was syncing or its pending ReadIndex was invalidated by a leader change. The
+	// remote node runs its own barrier and execution, and that whole cost lands in
+	// this profile's ExecuteDuration.
 	//
 	// Forwarded does NOT imply BarrierDuration == 0, and a non-zero value does
-	// not identify which wait occurred. Two paths produce one: the
-	// syncing-follower fallback attempts a ReadIndex barrier before forwarding,
-	// and waitMinLogSequence charges its catch-up regardless of consistency
-	// level, so an explicit leader read with min_log_sequence set reports a wait
-	// on a healthy cluster. The flag's job is narrower: stop a zero from being
-	// misread as "no barrier was needed".
+	// not identify which wait occurred. A follower fallback can attempt a
+	// ReadIndex barrier before forwarding and keeps that local wait in the
+	// profile. The flag's job is narrower: stop a zero from being misread as "no
+	// barrier was needed".
 	Forwarded bool
 	// Anomaly is non-empty when the phase bookkeeping detected a state that is
 	// impossible by contract (see clampPhase). It is surfaced in the log and on
@@ -491,8 +490,7 @@ func (p *QueryProfile) LogTo(logger logging.Logger) {
 			"wallDurationUs":       p.WallDuration().Microseconds(),
 			// True means the read was served by another node, so the remote node's
 			// whole cost sits inside executeDurationUs. barrierDurationUs then
-			// covers the local attempt only: 0 for an explicit leader read, non-zero
-			// when a local barrier failed before the fallback.
+			// covers the local attempt that failed before the follower fallback.
 			"forwarded": p.Forwarded,
 		}
 		if p.Root != nil {

--- a/misc/proto/bucket.proto
+++ b/misc/proto/bucket.proto
@@ -1350,13 +1350,13 @@ message QueryProfile {
   int64 first_row_duration_us = 13;
 
   // True when this node did not serve the read itself but forwarded it to
-  // another node — an explicit leader-consistency read, or the fallback taken
-  // when the local replica is still catching up. The remote node's prepare,
-  // barrier and execution all arrive inside execute_duration_us, so the phase
-  // breakdown describes the local hop only. Its purpose is to stop a zero
-  // barrier_duration_us from being misread as "no barrier was needed"; see that
-  // field for the three cases the pair distinguishes — a forwarded read can
-  // report a non-zero local wait.
+  // another node — the fallback taken when the local replica is still catching
+  // up or its in-flight ReadIndex is invalidated by a leadership change. The
+  // remote node's prepare, barrier and execution all arrive inside
+  // execute_duration_us, so the phase breakdown describes the local hop only.
+  // Its purpose is to stop a zero barrier_duration_us from being misread as "no
+  // barrier was needed"; see that field for the three cases the pair
+  // distinguishes — a forwarded read can report a non-zero local wait.
   bool forwarded = 14;
 }
 

--- a/pkg/grpcprotocol/protocol.go
+++ b/pkg/grpcprotocol/protocol.go
@@ -12,7 +12,7 @@ const (
 	// Version must change when the client-facing wire format or semantics break.
 	// See docs/technical/architecture/subsystems/api/protocol-compatibility.md.
 	// A compiled constant also identifies local builds without release ldflags.
-	Version = "2"
+	Version = "3"
 	// MetadataKey carries the protocol version, not authentication credentials.
 	MetadataKey = "ledger-protocol-version"
 )


### PR DESCRIPTION
## Summary

- remove the unreleased x-consistency: leader selector while retaining stale;
- keep unknown consistency metadata on the default linearizable route;
- preserve syncing/not-leader fallback behavior and accurate forwarding diagnostics;
- record the durable need, limitation, decision, alternatives, and validation for the API/consistency change.

## Stack

EN-1946 stack 6/8. Depends on #1891 (feat/en-1946-inspect-index-alignment).

Merge/review order: #1897 → #1889 → #1890 → #1894 → #1891 → #1893 → #1892 → #1881.

## Validation

Final base: 453a054681527e831dc2bee382213e43e8531398.
Final head: 0c6dfd33d3093d003990e949866e978951059e3b.
Canonical PR validation: PASS, including full race validation and business/cluster E2E.
Independent exact diff review: APPROVE (residual risk LOW).

Jira: EN-1946. Do not merge automatically.

### Service protocol compatibility

Incompatible semantic change: service protocol revision `2` → `3`.