### PR TITLE
fix(reads): pin prepared query definition to snapshot (EN-1946)

### DIFF
--- a/docs/technical/architecture/subsystems/read-path/prepared-queries.md
+++ b/docs/technical/architecture/subsystems/read-path/prepared-queries.md
@@ -69,7 +69,7 @@ A compile error at FSM time is hash-bound as an `AuditFailure`, so a checker run
 
 `ExecutePreparedQueryRequest` carries the ledger name, the query name, an execution mode (`LIST` or `AGGREGATE_VOLUMES`), and any runtime parameters. The executor:
 
-1. Reads the prepared query via `ReadPreparedQuery` (`internal/query/executor.go:67`).
+1. Opens the fixed main-store snapshot, then reads both the ledger schema and prepared query from that snapshot. This prevents a concurrent query/schema update or deletion from being combined with entities from a newer state. Because the stored definition determines whether an index will be used, the executor briefly reserves the event-history floor before opening the snapshot and releases it immediately when the loaded shape needs no index alignment.
 2. Verifies the requested mode is compatible with the query's `target` (e.g. `AGGREGATE_VOLUMES` only makes sense for accounts).
 3. Enters the standard read route. Default live consistency establishes a
    `ReadIndexAndWait` horizon; `stale`, leader-local, and checkpoint reads have

--- a/internal/query/aligned_snapshot.go
+++ b/internal/query/aligned_snapshot.go
@@ -144,13 +144,13 @@ func filterUsesReadIndex(filter *commonpb.QueryFilter, target commonpb.QueryTarg
 // sequence — the pin the event GC must not reclaim past (read_lease.go). The
 // caller must invoke it when iteration ends, alongside closing the snapshot.
 //
-// Callers must obtain mainReader from OpenQueryHandle, passing the same
-// filter and target, and hand its release closure here as releaseHold: it
-// reserves the reclaim floor before opening the handle, so the pin registered
-// here can never be refused. The reservation is dropped as soon as that pin
-// exists — from then on the read's own lease retains everything it needs,
-// while the reservation would only drag the GC watermark back down to the
-// fold cursor as of the request's start, for every request in flight.
+// Callers must obtain mainReader from OpenQueryHandle or
+// OpenReservedQueryHandle and hand its release closure here as releaseHold.
+// Both helpers reserve the reclaim floor before opening the handle, so the pin
+// registered here can never be refused. The reservation is dropped as soon as
+// that pin exists — from then on the read's own lease retains everything it
+// needs, while the reservation would only drag the GC watermark back down to
+// the fold cursor as of the request's start, for every request in flight.
 //
 // The wait is bounded by the caller's context and nothing else. Alignment is
 // not optional — a filtered read cannot answer correctly until the projection
@@ -179,7 +179,7 @@ func AlignedIndexSnapshot(ctx context.Context, rs *readstore.Store, mainReader d
 		if rs.Frozen() {
 			releaseLease = func() {}
 		} else if lease, ok := rs.Leases().Pin(mainSeq); !ok {
-			// OpenQueryHandle holds the floor across the handle's creation,
+			// The query-handle opener holds the floor across handle creation,
 			// so a pin beneath it means this read bypassed that helper and
 			// may resolve a group whose history is already reclaimed. There is
 			// no recovery here: the pin cannot move (the handle is a fixed
@@ -190,7 +190,7 @@ func AlignedIndexSnapshot(ctx context.Context, rs *readstore.Store, mainReader d
 			})
 
 			return nil, 0, nil, fmt.Errorf(
-				"invariant: aligned read pinned at %d, below the reclaim floor %d — the handle was not opened through OpenQueryHandle",
+				"invariant: aligned read pinned at %d, below the reclaim floor %d — the handle was not opened through a reserving query-handle helper",
 				mainSeq, rs.Leases().ReclaimFloor(),
 			)
 		} else {

--- a/internal/query/executor.go
+++ b/internal/query/executor.go
@@ -60,7 +60,7 @@ type EntityEnricher struct {
 func Execute(
 	ctx context.Context,
 	rs *readstore.Store,
-	pebbleStore *dal.Store,
+	pebbleStore queryHandleStore,
 	volumeAttr *attributes.Attribute[*raftcmdpb.VolumePair],
 	preparedQueryAttr *attributes.Attribute[*commonpb.PreparedQuery],
 	indexAttr *attributes.Attribute[*commonpb.Index],
@@ -75,8 +75,21 @@ func Execute(
 		))
 	defer span.End()
 
-	// Fetch ledger info for schema-based filter validation and ledger ID resolution
-	ledgerInfo, err := GetLedgerByName(ctx, pebbleStore, req.GetLedger())
+	// The prepared-query definition and ledger schema are request-local query
+	// state. Open the main snapshot before loading them so a concurrent update,
+	// deletion, or schema change cannot be combined with entities from a newer
+	// state. The query shape is not known yet, so reserve the event-history floor
+	// until the definition tells us whether index alignment is owed.
+	handle, releaseHold, err := OpenReservedQueryHandle(rs, pebbleStore)
+	if err != nil {
+		return nil, fmt.Errorf("creating read handle: %w", err)
+	}
+
+	defer releaseHold()
+	defer func() { _ = handle.Close() }() // Best-effort cleanup after the response snapshot is consumed.
+
+	// Fetch ledger info for schema-based filter validation and ledger ID resolution.
+	ledgerInfo, err := GetLedgerByName(ctx, handle, req.GetLedger())
 	if err != nil {
 		if errors.Is(err, domain.ErrNotFound) {
 			return nil, &domain.ErrLedgerNotFound{Name: req.GetLedger()}
@@ -85,8 +98,9 @@ func Execute(
 		return nil, fmt.Errorf("reading ledger info: %w", err)
 	}
 
-	// Read the prepared query from Pebble
-	pq, err := ReadPreparedQuery(ctx, preparedQueryAttr, pebbleStore, ledgerInfo.GetName(), req.GetQueryName())
+	// Read the prepared query from the same main snapshot used by compilation,
+	// aggregation, and entity enrichment.
+	pq, err := ReadPreparedQuery(ctx, preparedQueryAttr, handle, ledgerInfo.GetName(), req.GetQueryName())
 	if err != nil {
 		return nil, fmt.Errorf("reading prepared query: %w", err)
 	}
@@ -104,18 +118,6 @@ func Execute(
 	}
 
 	schema := SchemaFieldsForTarget(ledgerInfo.GetMetadataSchema(), pq.GetTarget())
-
-	// Always open a read handle — needed for filter compilation and entity
-	// enrichment. Opened BEFORE the index snapshot: alignment guarantees the
-	// snapshot's fold cursor covers everything the handle sees (EN-1748), and
-	// OpenQueryHandle holds reclamation still across the two steps.
-	handle, releaseHold, err := OpenQueryHandle(rs, pebbleStore, pq.GetFilter(), pq.GetTarget())
-	if err != nil {
-		return nil, fmt.Errorf("creating read handle: %w", err)
-	}
-
-	defer releaseHold()
-	defer func() { _ = handle.Close() }()
 
 	var (
 		indexSnap    *pebble.Snapshot

--- a/internal/query/executor_alignment_test.go
+++ b/internal/query/executor_alignment_test.go
@@ -2,6 +2,7 @@ package query_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -9,6 +10,7 @@ import (
 
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/infra/state"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 	"github.com/formancehq/ledger/v3/internal/query"
@@ -26,6 +28,86 @@ func seedPreparedQuery(t *testing.T, s *dal.Store, attrs *attributes.Attributes,
 	})
 	require.NoError(t, err)
 	require.NoError(t, batch.Commit())
+}
+
+type mutatingQueryHandleStore struct {
+	store     *dal.Store
+	afterOpen func()
+}
+
+type failingQueryHandleStore struct{ err error }
+
+func (s failingQueryHandleStore) NewReadHandle() (*dal.ReadHandle, error) {
+	return nil, s.err
+}
+
+func TestExecutePropagatesMainSnapshotOpenFailure(t *testing.T) {
+	t.Parallel()
+
+	rs := newTestReadStore(t)
+	attrs := attributes.New()
+	wantErr := errors.New("open main snapshot")
+
+	_, err := query.Execute(
+		t.Context(), rs, failingQueryHandleStore{err: wantErr},
+		attrs.Volume, attrs.PreparedQuery, attrs.Index,
+		&servicepb.ExecutePreparedQueryRequest{Ledger: "l", QueryName: "q"}, nil, nil,
+	)
+	require.ErrorIs(t, err, wantErr)
+}
+
+func (s *mutatingQueryHandleStore) NewReadHandle() (*dal.ReadHandle, error) {
+	handle, err := s.store.NewReadHandle()
+	if err != nil {
+		return nil, err
+	}
+
+	s.afterOpen()
+
+	return handle, nil
+}
+
+func TestExecute_ReadsDefinitionAndLedgerFromMainSnapshot(t *testing.T) {
+	t.Parallel()
+
+	for _, mutation := range []string{"prepared query deleted", "ledger deleted"} {
+		t.Run(mutation, func(t *testing.T) {
+			t.Parallel()
+
+			store := newTestStore(t)
+			registerLedger(t, store, "l")
+
+			rs := newTestReadStore(t)
+			attrs := attributes.New()
+			seedPreparedQuery(t, store, attrs, "l", "q", commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, nil)
+
+			opener := &mutatingQueryHandleStore{
+				store: store,
+				afterOpen: func() {
+					batch := store.OpenWriteSession()
+					switch mutation {
+					case "prepared query deleted":
+						require.NoError(t, attrs.PreparedQuery.Delete(batch, domain.PreparedQueryKey{LedgerName: "l", Name: "q"}.Bytes()))
+					case "ledger deleted":
+						require.NoError(t, state.SaveLedger(batch, "l", &commonpb.LedgerInfo{
+							Name:      "l",
+							DeletedAt: &commonpb.Timestamp{},
+						}))
+					default:
+						t.Fatalf("unknown mutation %q", mutation)
+					}
+					require.NoError(t, batch.Commit())
+				},
+			}
+
+			_, err := query.Execute(
+				t.Context(), rs, opener, attrs.Volume, attrs.PreparedQuery, attrs.Index,
+				&servicepb.ExecutePreparedQueryRequest{Ledger: "l", QueryName: "q"}, nil, nil,
+			)
+			require.NoError(t, err,
+				"definition and schema reads must stay on the handle opened before the live mutation")
+		})
+	}
 }
 
 // A prepared query that reads no index leaf must not be gated on the fold.


### PR DESCRIPTION
## Summary

Pin the prepared-query definition and ledger schema to the same main-store snapshot used for execution.

Need: prevent definition or schema state from tearing against the entity snapshot.
Previous limitation: definition state was loaded before the main snapshot, so a concurrent update or deletion could mix causal views.
Requirement: definition, schema, compilation, aggregation, and enrichment share one pinned main-store snapshot while preserving the read-index reclamation floor.
Decision: open a reserved query handle before loading the definition, then transfer or release its lease once the query shape determines whether index alignment is owed.
Validation: deterministic deletion mutations cover both the prepared-query and ledger-schema branches.

DISCOVERY: DIRECT_FIX
BEFORE_FIX: BUG_REPRODUCED
AFTER_FIX: PASS

## Stack

EN-1946 stack 4/8. Depends on #1890 (feat/en-1946-read-alignment).

Merge/review order: #1897 → #1889 → #1890 → #1894 → #1891 → #1893 → #1892 → #1881.

## Validation

Final base: de64081212f63bb07407a5c1eb53fbb4b533f9db.
Final head: 2f0c5c99da8941449d43b3cb6e6f0d16624cd940.
Canonical PR validation and bugfix sensitivity: PASS, including full race validation.
Independent exact diff review: APPROVE (residual risk LOW).

Jira: EN-1946. Do not merge automatically.