### PR TITLE
test(reads): bound cross-store alignment load (EN-1946)

### DIFF
--- a/internal/application/ctrl/list_transactions_alignment_test.go
+++ b/internal/application/ctrl/list_transactions_alignment_test.go
@@ -1,0 +1,139 @@
+package ctrl
+
+import (
+	"context"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
+	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/infra/state"
+	"github.com/formancehq/ledger/v3/internal/pkg/cursor"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+// A complement is the sharp cross-store consistency probe: if the primary
+// snapshot sees a transaction while the independently taken index snapshot
+// does not see its timestamp row, NOT(timestamp) manufactures a result that
+// never existed at one serial point. Exercise the real controller path with
+// the two stores deliberately at different horizons so a separate lag sample
+// cannot race the read it purports to validate.
+func TestListTransactions_AlignsComplementWithPrimaryHorizon(t *testing.T) {
+	t.Parallel()
+
+	const (
+		ledger = "alignment"
+		txID   = uint64(1)
+		logSeq = uint64(1)
+	)
+
+	logger := logging.FromContext(logging.TestingContext())
+	meter := noop.NewMeterProvider().Meter("test")
+	store := newCtrlTestStore(t)
+	attrs := attributes.New()
+
+	seedCreatedTransaction(t, store, attrs, ledger, txID, logSeq, &commonpb.Transaction{Id: txID})
+
+	timestampID := indexes.TxBuiltinID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP)
+	mainBatch := store.OpenWriteSession()
+	_, err := attrs.Index.Set(mainBatch, indexes.KeyFor(ledger, timestampID).Bytes(), &commonpb.Index{
+		Id:                     timestampID,
+		Ledger:                 ledger,
+		ForwardEncodingVersion: 1,
+	})
+	require.NoError(t, err)
+	require.NoError(t, state.SetAppliedIndex(mainBatch, logSeq))
+	require.NoError(t, mainBatch.Commit())
+
+	rs, err := readstore.New(t.TempDir(), logger, readstore.DefaultConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = rs.Close() })
+	readyBatch := rs.NewBatch()
+	require.NoError(t, rs.WriteIndexVersionState(readyBatch, ledger, indexes.Canonical(timestampID), readstore.IndexVersionState{
+		CurrentVersion: 1,
+		HighWater:      1,
+	}))
+	require.NoError(t, readyBatch.Commit())
+
+	ctrl := NewDefaultController(nil, store, logger, attrs, rs, nil, meter)
+	notTimestamp := &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Not{Not: &commonpb.NotFilter{
+		Filter: &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_BuiltinUint{
+			BuiltinUint: &commonpb.BuiltinUintCondition{
+				Field: commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP,
+				Cond:  &commonpb.UintCondition{Min: new(uint64), Max: new(uint64)},
+			},
+		}},
+	}}}
+	*notTimestamp.GetNot().GetFilter().GetBuiltinUint().GetCond().Max = math.MaxUint64
+
+	// The primary handle contains logSeq, but the projection cursor is still
+	// zero and the timestamp row is absent. The same request must wait rather
+	// than compile a complement over those torn views.
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer cancel()
+
+	unexpected, err := ctrl.ListTransactions(ctx, ledger, 100, 0, notTimestamp, false)
+	if unexpected != nil {
+		require.NoError(t, unexpected.Close())
+	}
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+
+	// Fold the missing row and advance progress in one atomic batch, matching
+	// the index builder's publication order. The complement is now decidable
+	// at the primary horizon and must be empty.
+	indexBatch := rs.NewBatch()
+	wb := readstore.NewWriteBatch()
+	wb.Init(indexBatch)
+	require.NoError(t, wb.WriteTransactionTimestampIndex(dal.NewKeyBuilder(), ledger, 42, txID))
+	require.NoError(t, rs.WriteProgress(indexBatch, logSeq))
+	require.NoError(t, indexBatch.Commit())
+	rs.NotifyProgress()
+
+	txs, err := ctrl.ListTransactions(t.Context(), ledger, 100, 0, notTimestamp, false)
+	require.NoError(t, err)
+
+	got, err := cursor.Collect(txs)
+	require.NoError(t, err)
+	require.Empty(t, got)
+}
+
+// seedCreatedTransaction writes the minimum authoritative state required by
+// transaction reads. Keep this fixture independent from optional response
+// features so read-alignment tests survive unrelated API removals.
+func seedCreatedTransaction(
+	t *testing.T,
+	store *dal.Store,
+	attrs *attributes.Attributes,
+	ledger string,
+	txID, logSeq uint64,
+	tx *commonpb.Transaction,
+) {
+	t.Helper()
+
+	batch := store.OpenWriteSession()
+	require.NoError(t, state.SaveLedger(batch, ledger, &commonpb.LedgerInfo{Name: ledger}))
+
+	txKey := domain.TransactionKey{LedgerName: ledger, ID: txID}
+	_, err := attrs.Transaction.Set(batch, txKey.Bytes(), &commonpb.TransactionState{CreatedByLog: logSeq})
+	require.NoError(t, err)
+
+	require.NoError(t, state.AppendLogs(batch, []*commonpb.Log{{
+		Sequence: logSeq,
+		Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_Apply{Apply: &commonpb.ApplyLedgerLog{
+			LedgerName: ledger,
+			Log: &commonpb.LedgerLog{Data: &commonpb.LedgerLogPayload{
+				Payload: &commonpb.LedgerLogPayload_CreatedTransaction{CreatedTransaction: &commonpb.CreatedTransaction{Transaction: tx}},
+			}},
+		}}},
+	}}))
+	require.NoError(t, batch.Commit())
+}

--- a/tests/e2e/business/cross_store_snapshot_alignment_test.go
+++ b/tests/e2e/business/cross_store_snapshot_alignment_test.go
@@ -4,17 +4,20 @@ package business
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"sync"
 	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 	"github.com/formancehq/ledger/v3/pkg/actions"
 	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 )
 
 // Cross-store snapshot alignment (EN-1748): a transaction visible in the
@@ -25,9 +28,9 @@ import (
 //
 // The fold is made to lag by throughput asymmetry, with no artificial hooks:
 // many live indexes multiply the fold cost of every log while apply cost
-// stays flat, so sustained apply pressure drives the read-store fold hundreds
-// of sequences behind the primary head — the natural condition (load, faults,
-// backfill storms) under which unaligned snapshots serve torn responses.
+// stays flat, so sustained apply pressure drives the read-store fold a
+// measurable distance behind the primary head — the natural condition (load,
+// faults, backfill storms) under which unaligned snapshots serve torn responses.
 var _ = Describe("Cross-store snapshot alignment", Ordered, func() {
 	// The apply pressure this spec generates would linger in the shared
 	// server's store and tax every later spec that walks it (checker
@@ -66,6 +69,11 @@ var _ = Describe("Cross-store snapshot alignment", Ordered, func() {
 	})
 
 	It("never surfaces a committed tx as missing from a READY index", func() {
+		// This is a correctness probe, not a throughput benchmark. A few complete
+		// apply batches establish distinct primary and projection horizons while
+		// remaining portable under race and coverage instrumentation.
+		const minimumObservedLag = 32
+
 		stop := make(chan struct{})
 
 		var pressure sync.WaitGroup
@@ -99,7 +107,16 @@ var _ = Describe("Cross-store snapshot alignment", Ordered, func() {
 						}))
 					}
 					if _, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", reqs...)); err != nil {
-						return
+						select {
+						case <-stop:
+							if ctx.Err() == nil {
+								Fail(fmt.Sprintf("in-flight apply failed after pressure stopped: %v", err))
+							}
+
+							return
+						default:
+							Fail(fmt.Sprintf("apply pressure failed: %v", err))
+						}
 					}
 				}
 			}(w)
@@ -110,49 +127,66 @@ var _ = Describe("Cross-store snapshot alignment", Ordered, func() {
 				stopped = true
 
 				close(stop)
-				pressure.Wait()
 			}
 		}
-		defer stopPressure()
+		waitForPressure := func() {
+			stopPressure()
+			pressure.Wait()
+		}
+		defer waitForPressure()
 
 		notTs := actions.NotFilter(actions.BuiltinUintRangeFilter(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_TIMESTAMP, 0, ^uint64(0)))
-		deadline := time.Now().Add(25 * time.Second)
-		probes, served := 0, 0
-
-		for time.Now().Before(deadline) {
-			probes++
-
-			_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CreateTransactionAction(ledgerName, []*commonpb.Posting{
-				actions.NewPosting("world", fmt.Sprintf("probe:%d", probes%64), big.NewInt(1), "USD"),
-			}, nil, nil)))
-			Expect(err).To(Succeed())
-
-			txs, err := actions.ListTransactionsFiltered(ctx, client, ledgerName, 0, 0, notTs)
-			if err != nil {
-				// A lagging fold legitimately rejects with the retryable
-				// not-caught-up precondition; only phantom ROWS are the bug.
-				continue
-			}
-			served++
-
-			if len(txs) > 0 {
-				Fail(fmt.Sprintf("probe %d: not(ts[_,_]) returned %d row(s), first id=%d — a committed tx surfaced as missing from the READY timestamp index", probes, len(txs), txs[0].GetId()))
-			}
-		}
-
-		Expect(served).To(BeNumerically(">", 0), "every probe was rejected — inconclusive")
-
-		// Drain the fold backlog before the spec ends: teardown stops the
-		// server under a bounded budget, which a deep backlog can exceed on
-		// slow runners.
-		stopPressure()
-		Eventually(func() uint64 {
+		Eventually(func(g Gomega) uint64 {
 			st, err := actions.GetIndexStatus(ctx, client)
-			if err != nil {
-				return ^uint64(0)
-			}
+			g.Expect(err).To(Succeed())
 
 			return st.GetLag()
-		}, 3*time.Minute, 500*time.Millisecond).Should(BeZero(), "fold backlog drained")
+		}, 25*time.Second, 10*time.Millisecond).Should(BeNumerically(">=", minimumObservedLag), "pressure never made the fold lag — inconclusive")
+
+		// Open the streaming RPC while pressure is still live so its request is sent
+		// under the production read-under-lag condition. Stop producers as soon as
+		// the request is on the wire: at most their four in-flight batches remain,
+		// rather than another deadline-sized interval of unbounded submissions.
+		probeCtx, cancelProbe := context.WithTimeout(ctx, 3*time.Minute)
+		probe, err := client.ListTransactions(probeCtx, &servicepb.ListTransactionsRequest{
+			Ledger: ledgerName,
+			Options: &commonpb.ListOptions{
+				Filter: notTs,
+			},
+		})
+		Expect(err).To(Succeed())
+		stopPressure()
+		waitForPressure()
+
+		var (
+			probeTxs []*commonpb.Transaction
+			probeErr error
+		)
+		for {
+			tx, recvErr := probe.Recv()
+			if errors.Is(recvErr, io.EOF) {
+				break
+			}
+			if recvErr != nil {
+				probeErr = recvErr
+
+				break
+			}
+			probeTxs = append(probeTxs, tx)
+		}
+		cancelProbe()
+
+		Expect(probeErr).To(Succeed(), "live-lag probe never produced a conclusive response")
+		Expect(probeTxs).To(BeEmpty(), "live-lag probe surfaced a committed tx as missing from the READY timestamp index")
+
+		// Bound the generated backlog, then prove the same read succeeds once the
+		// fixed projection horizon can catch up.
+		queryCtx, cancelQuery := context.WithTimeout(ctx, 3*time.Minute)
+		defer cancelQuery()
+		txs, err := actions.ListTransactionsFiltered(queryCtx, client, ledgerName, 0, 0, notTs)
+		Expect(err).To(Succeed())
+		if len(txs) > 0 {
+			Fail(fmt.Sprintf("not(ts[_,_]) returned %d row(s), first id=%d — a committed tx surfaced as missing from the READY timestamp index", len(txs), txs[0].GetId()))
+		}
 	})
 })


### PR DESCRIPTION
## Summary

- bound the EN-1748 cross-store alignment load at a 32-sequence native-index lag;
- stop pressure producers as soon as the bound is reached;
- keep the complement-read assertion while adding a deterministic controller regression that proves the read waits when the projection is behind.

## Stack

EN-1946 stack 1/8. Base: release/v3.0 at ef83e61f3ce60fc132611b2ad94e846fa02f3b77.

Merge/review order: #1897 → #1889 → #1890 → #1894 → #1891 → #1893 → #1892 → #1881.

## Validation

Final base: ef83e61f3ce60fc132611b2ad94e846fa02f3b77.
Final head: b9080b6270942237cb2f98fe7aa4b6f90d83fc4c.
Canonical PR validation: PASS.
Independent exact diff review: APPROVE (residual risk LOW).

Jira: EN-1946. Do not merge automatically.