### PR TITLE
fix(replication): close HTTP exporter response bodies

### DIFF
--- a/internal/replication/drivers/http/driver.go
+++ b/internal/replication/drivers/http/driver.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -17,13 +18,19 @@ import (
 	"github.com/formancehq/ledger/internal/replication/drivers"
 )
 
-// maxResponseDrainBytes caps how much of an exporter's response body Accept reads
-// before closing it; ingest endpoints answer with a few bytes at most.
-const maxResponseDrainBytes = 64 << 10
+const (
+	// maxResponseDrainBytes caps how much of an exporter's response body Accept reads
+	// before closing it; ingest endpoints answer with a few bytes at most.
+	maxResponseDrainBytes = 64 << 10
+	// responseDrainTimeout caps how long Accept waits for those bytes. A stalled body
+	// costs the connection, not the worker.
+	responseDrainTimeout = 5 * time.Second
+)
 
 type Driver struct {
-	config     Config
-	httpClient *http.Client
+	config       Config
+	httpClient   *http.Client
+	drainTimeout time.Duration
 }
 
 func (c *Driver) Stop(_ context.Context) error {
@@ -45,6 +52,8 @@ func (c *Driver) Accept(ctx context.Context, logs ...drivers.LogWithLedger) ([]e
 	if err != nil {
 		return nil, err
 	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	req = req.WithContext(ctx)
 
 	rsp, err := c.httpClient.Do(req)
@@ -52,10 +61,13 @@ func (c *Driver) Accept(ctx context.Context, logs ...drivers.LogWithLedger) ([]e
 		return nil, err
 	}
 	defer func() {
-		// Drain (bounded) and close so the underlying connection is released back to
-		// the transport instead of leaking one socket per push. A body larger than
-		// the bound is closed unread: the transport then drops that connection, which
-		// is preferable to blocking the worker on a misbehaving exporter.
+		// Drain and close so the underlying connection is released back to the
+		// transport instead of leaking one socket per push. The drain is bounded in
+		// bytes and in time: cancelling the request context interrupts a stalled body
+		// read, and the transport then drops that connection, which is preferable to
+		// blocking the worker on a misbehaving exporter.
+		stop := time.AfterFunc(c.drainTimeout, cancel)
+		defer stop.Stop()
 		_, _ = io.Copy(io.Discard, io.LimitReader(rsp.Body, maxResponseDrainBytes))
 		_ = rsp.Body.Close()
 	}()
@@ -69,8 +81,9 @@ func (c *Driver) Accept(ctx context.Context, logs ...drivers.LogWithLedger) ([]e
 
 func NewDriver(config Config, _ logging.Logger) (*Driver, error) {
 	return &Driver{
-		config:     config,
-		httpClient: http.DefaultClient,
+		config:       config,
+		httpClient:   http.DefaultClient,
+		drainTimeout: responseDrainTimeout,
 	}, nil
 }
 

--- a/internal/replication/drivers/http/driver.go
+++ b/internal/replication/drivers/http/driver.go
@@ -17,6 +17,10 @@ import (
 	"github.com/formancehq/ledger/internal/replication/drivers"
 )
 
+// maxResponseDrainBytes caps how much of an exporter's response body Accept reads
+// before closing it; ingest endpoints answer with a few bytes at most.
+const maxResponseDrainBytes = 64 << 10
+
 type Driver struct {
 	config     Config
 	httpClient *http.Client
@@ -48,9 +52,11 @@ func (c *Driver) Accept(ctx context.Context, logs ...drivers.LogWithLedger) ([]e
 		return nil, err
 	}
 	defer func() {
-		// Drain and close so the underlying connection is released back to the
-		// transport instead of leaking one socket per push.
-		_, _ = io.Copy(io.Discard, rsp.Body)
+		// Drain (bounded) and close so the underlying connection is released back to
+		// the transport instead of leaking one socket per push. A body larger than
+		// the bound is closed unread: the transport then drops that connection, which
+		// is preferable to blocking the worker on a misbehaving exporter.
+		_, _ = io.Copy(io.Discard, io.LimitReader(rsp.Body, maxResponseDrainBytes))
 		_ = rsp.Body.Close()
 	}()
 

--- a/internal/replication/drivers/http/driver.go
+++ b/internal/replication/drivers/http/driver.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -46,6 +47,12 @@ func (c *Driver) Accept(ctx context.Context, logs ...drivers.LogWithLedger) ([]e
 	if err != nil {
 		return nil, err
 	}
+	defer func() {
+		// Drain and close so the underlying connection is released back to the
+		// transport instead of leaking one socket per push.
+		_, _ = io.Copy(io.Discard, rsp.Body)
+		_ = rsp.Body.Close()
+	}()
 
 	if rsp.StatusCode < 200 || rsp.StatusCode > 299 {
 		return nil, fmt.Errorf("invalid status code, expect something between 200 and 299, got %d", rsp.StatusCode)

--- a/internal/replication/drivers/http/driver_test.go
+++ b/internal/replication/drivers/http/driver_test.go
@@ -4,8 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -64,4 +67,40 @@ func TestHTTPDriver(t *testing.T) {
 	default:
 		require.Fail(t, fmt.Sprintf("should have received %d messages", numberOfLogs))
 	}
+}
+
+func TestHTTPDriverReusesConnections(t *testing.T) {
+	// Not parallel: the driver uses http.DefaultClient, whose transport is shared with the
+	// other tests in this package; the assertion below is about connection reuse.
+
+	var newConns atomic.Int32
+	testServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"accepted":true}`))
+	}))
+	testServer.Config.ConnState = func(c net.Conn, state http.ConnState) {
+		t.Logf("conn %s -> %s", c.RemoteAddr(), state)
+		if state == http.StateNew {
+			newConns.Add(1)
+		}
+	}
+	testServer.Start()
+	t.Cleanup(testServer.Close)
+
+	driver, err := NewDriver(Config{URL: testServer.URL}, logging.Testing())
+	require.NoError(t, err)
+
+	const pushes = 20
+	for i := 0; i < pushes; i++ {
+		_, err := driver.Accept(context.TODO(), drivers.NewLogWithLedger(
+			"module",
+			ledger.NewLog(ledger.CreatedTransaction{Transaction: ledger.NewTransaction()}),
+		))
+		require.NoError(t, err)
+	}
+
+	// Each push must drain and close the response body, otherwise the keep-alive
+	// connection cannot be reused and every push opens (and leaks) a new socket.
+	require.EqualValues(t, 1, newConns.Load(), "expected a single reused connection for %d pushes", pushes)
 }

--- a/internal/replication/drivers/http/driver_test.go
+++ b/internal/replication/drivers/http/driver_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -103,4 +104,52 @@ func TestHTTPDriverReusesConnections(t *testing.T) {
 	// Each push must drain and close the response body, otherwise the keep-alive
 	// connection cannot be reused and every push opens (and leaks) a new socket.
 	require.EqualValues(t, 1, newConns.Load(), "expected a single reused connection for %d pushes", pushes)
+}
+
+func TestHTTPDriverBoundsResponseDrain(t *testing.T) {
+	t.Parallel()
+
+	// The exporter streams an endless body; Accept must still return promptly and the
+	// driver must keep working for the next push.
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusAccepted)
+		chunk := make([]byte, 32<<10)
+		for {
+			if _, err := w.Write(chunk); err != nil {
+				return
+			}
+			if f, ok := w.(http.Flusher); ok {
+				f.Flush()
+			}
+			select {
+			case <-r.Context().Done():
+				return
+			default:
+			}
+		}
+	}))
+	t.Cleanup(func() {
+		// Force the streaming handler to stop even if a client is still reading.
+		testServer.CloseClientConnections()
+		testServer.Close()
+	})
+
+	driver, err := NewDriver(Config{URL: testServer.URL}, logging.Testing())
+	require.NoError(t, err)
+	log := drivers.NewLogWithLedger("module", ledger.NewLog(ledger.CreatedTransaction{Transaction: ledger.NewTransaction()}))
+
+	for i := 0; i < 2; i++ {
+		done := make(chan error, 1)
+		go func() {
+			_, err := driver.Accept(context.TODO(), log)
+			done <- err
+		}()
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(10 * time.Second):
+			require.Fail(t, "Accept did not return: response body draining is not bounded")
+		}
+	}
 }

--- a/internal/replication/drivers/http/driver_test.go
+++ b/internal/replication/drivers/http/driver_test.go
@@ -153,3 +153,42 @@ func TestHTTPDriverBoundsResponseDrain(t *testing.T) {
 		}
 	}
 }
+
+func TestHTTPDriverDrainIsTimeBounded(t *testing.T) {
+	t.Parallel()
+
+	// The exporter sends headers and a few bytes, then stalls without closing. Accept
+	// must give up on the body after the drain timeout and the next push must still work.
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte("{"))
+		if f, ok := w.(http.Flusher); ok {
+			f.Flush()
+		}
+		<-r.Context().Done()
+	}))
+	t.Cleanup(func() {
+		testServer.CloseClientConnections()
+		testServer.Close()
+	})
+
+	driver, err := NewDriver(Config{URL: testServer.URL}, logging.Testing())
+	require.NoError(t, err)
+	driver.drainTimeout = 200 * time.Millisecond
+	log := drivers.NewLogWithLedger("module", ledger.NewLog(ledger.CreatedTransaction{Transaction: ledger.NewTransaction()}))
+
+	for i := 0; i < 2; i++ {
+		done := make(chan error, 1)
+		go func() {
+			_, err := driver.Accept(context.TODO(), log)
+			done <- err
+		}()
+		select {
+		case err := <-done:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "Accept did not return: response body draining is not time-bounded")
+		}
+	}
+}


### PR DESCRIPTION
Report and reproduction: https://github.com/orgs/formancehq/discussions/2006

## Problem

`Driver.Accept` never reads or closes the response body from `httpClient.Do`, so keep-alive
connections are never reused. Each push leaks one connection, 3 goroutines and ~27 KB of heap for
the life of the worker.

## Change

- Drain `rsp.Body` in a deferred block and close it. The drain is bounded in bytes (64 KiB) and in
  time (5 s, by cancelling the request context from a timer, which interrupts the body read). A
  larger, endless or stalled body is closed unread, so the transport drops that connection instead
  of stalling the worker on a misbehaving exporter.
- `TestHTTPDriverReusesConnections`: 20 pushes against an `httptest` server must open exactly one
  connection. Fails on `main` (20), passes with the fix.
- `TestHTTPDriverBoundsResponseDrain`: the server streams an endless body; `Accept` must return and
  the next push must succeed. Fails without the byte cap, passes with it.
- `TestHTTPDriverDrainIsTimeBounded`: the server sends a few bytes then stalls; `Accept` must return
  and the next push must succeed. Fails without the timer, passes with it.

## Reproduction

From a clone of `main`, using only this branch:

```bash
git fetch https://github.com/imtiazmangerah/ledger.git fix/http-exporter-close-response-body
PKG=./internal/replication/drivers/http

# analyzer and the new test against main (test file only)
go run github.com/timakin/bodyclose@latest $PKG
#   internal/replication/drivers/http/driver.go:45:29: response body must be closed
git checkout FETCH_HEAD -- $PKG/driver_test.go
go test $PKG -run TestHTTPDriverReusesConnections -count=1
#   expected: 1   actual: 20   FAIL

# same against the branch
git checkout FETCH_HEAD
go run github.com/timakin/bodyclose@latest $PKG        # no output
go test $PKG -run TestHTTPDriverReusesConnections -count=1
#   ok
```

Measured with 200 pushes (probe in the report linked at the top): server connections 200 → 1,
goroutines
+600 → +3, heap in use +5.5 MB → +0.5 MB.

`bodyclose` is built into golangci-lint and reports nothing else in the repository once this is
applied; enabling it in `.golangci.yml` would prevent a recurrence.

The driver is identical on `release/v2.4`; the commit cherry-picks cleanly if you want a backport.

Triaged with Claude Fable 5.1 (Anthropic, model id `claude-fable-5-1`, via Claude Code). The
finding comes from a production symptom. Every number and the fix were reproduced by running the
commands above and reviewed and verified by the author.
