### PR TITLE
fix(EN-1958): fail-stop force removal on WAL failure

### DIFF
--- a/docs/ops/cluster-operations.md
+++ b/docs/ops/cluster-operations.md
@@ -496,8 +496,20 @@ off-cluster backup instead. See
 
 1. `ForceRemoveNode` directly calls `rawNode.ApplyConfChange()` on the leader, bypassing the Raft log
 2. The updated `ConfState` is persisted to the WAL snapshot immediately (before the peer row is deleted, so a crash between the two heals to "voter absent, orphan address" rather than "voter present, unreachable")
-3. `Membership.Unregister` then deletes the peer row from Pebble (`[ZoneGlobal][SubGlobPeers]`) and drops the peer from the in-memory cache + transport + service pool in lockstep
+3. Membership cleanup then deletes the peer row from Pebble (`[ZoneGlobal][SubGlobPeers]`), atomically writes the removed-member tombstone when the peer has an instance identity, and drops the peer from the in-memory cache + transport + service pool in lockstep
 4. The reduced voter set immediately recalculates quorum, allowing the leader to resume normal operations
+
+The live etcd/raft tracker mutation in step 1 cannot be rolled back safely. If
+the WAL persistence in step 2 fails, the command returns an error and the node
+immediately enters a terminal state: it rejects new Raft commands and proposals,
+stops its Raft tasks, and terminates. The peer cleanup in step 3 is not attempted.
+Restart uses the membership in the latest durable snapshot. A failure before
+the atomic snapshot-file replacement restores the previous voter set; a later
+WAL-record failure can restart with the new voter set because the replacement
+file matches the snapshot's existing term/index. Both outcomes are safe because
+the failed process stops before accepting more work. After restart, inspect the
+cluster state and retry only if the target is still present and the storage
+fault has been resolved.
 
 **When to use:**
 

--- a/docs/ops/cluster-operations.md
+++ b/docs/ops/cluster-operations.md
@@ -494,10 +494,10 @@ off-cluster backup instead. See
 
 **How it works:**
 
-1. `ForceRemoveNode` directly calls `rawNode.ApplyConfChange()` on the leader, bypassing the Raft log
+1. `ForceRemoveNode` directly calls `rawNode.ApplyConfChange()` on the leader, bypassing the Raft log. This immediately recalculates the live quorum and can advance the live commit index before persistence.
 2. The updated `ConfState` is persisted to the WAL snapshot immediately (before the peer row is deleted, so a crash between the two heals to "voter absent, orphan address" rather than "voter present, unreachable")
 3. Membership cleanup then deletes the peer row from Pebble (`[ZoneGlobal][SubGlobPeers]`), atomically writes the removed-member tombstone when the peer has an instance identity, and drops the peer from the in-memory cache + transport + service pool in lockstep
-4. The reduced voter set immediately recalculates quorum, allowing the leader to resume normal operations
+4. After the command succeeds, Raft processing resumes with the reduced quorum.
 
 The live etcd/raft tracker mutation in step 1 cannot be rolled back safely. If
 the WAL persistence in step 2 fails, the command returns an error and the node
@@ -507,7 +507,7 @@ Restart uses the membership in the latest durable snapshot. A failure before
 the atomic snapshot-file replacement restores the previous voter set; a later
 WAL-record failure can restart with the new voter set because the replacement
 file matches the snapshot's existing term/index. Both outcomes are safe because
-the failed process stops before accepting more work. After restart, inspect the
+the failed process stops before executing more work. After restart, inspect the
 cluster state and retry only if the target is still present and the storage
 fault has been resolved.
 

--- a/docs/technical/architecture/subsystems/consensus/README.md
+++ b/docs/technical/architecture/subsystems/consensus/README.md
@@ -6,10 +6,10 @@ The replication and ordering layer (`internal/infra/node`, `internal/infra/trans
 
 | Document | Description |
 |----------|-------------|
-| [raft-consensus.md](raft-consensus.md) | Raft consensus implementation, CP failure model, quorum sizing, leader election, retained-log catch-up, and snapshot transfer. |
+| [raft-consensus.md](raft-consensus.md) | Raft consensus implementation, CP failure model, quorum sizing, leader election, retained-log catch-up, snapshot transfer, and fail-stop on force-removal persistence failure. |
 | [global-log.md](global-log.md) | Two-level log architecture enabling system-level atomic bulk operations. |
 | [hybrid-logical-clock.md](hybrid-logical-clock.md) | Monotonic HLC timestamps across leader changes and clock skew. |
-| [removed-member-registry.md](removed-member-registry.md) | Replicated `(nodeID, instanceID)` set that prevents a removed member from silently rejoining and being auto-promoted. |
+| [removed-member-registry.md](removed-member-registry.md) | Replicated `(nodeID, instanceID)` set that prevents a removed member from silently rejoining and being auto-promoted; force-removal write ordering and durable restart states. |
 
 ## Related
 

--- a/docs/technical/architecture/subsystems/consensus/raft-consensus.md
+++ b/docs/technical/architecture/subsystems/consensus/raft-consensus.md
@@ -275,6 +275,15 @@ unreachable and its old state cannot run or rejoin. If an isolated former
 leader force-removes voters that remain live, the reduced local configuration
 and the original majority can both commit, creating divergent histories.
 
+The force path applies the local etcd/raft configuration before it can persist
+the resulting ConfState. That live tracker transition has no safe rollback. If
+ConfState persistence fails, the node fail-stops and rejects further commands
+and proposals. Work queued while persistence is in flight is failed during
+terminal publication. Restart reconstructs whichever membership reached the
+latest durable snapshot: the old configuration before snapshot-file replacement,
+or the new configuration if replacement completed before a later WAL-record
+failure. It must never continue serving with the reduced, unpersisted quorum.
+
 For normal consensus operations, the guarantee applies to committed state,
 which is the boundary visible to a successful write response. A request that
 times out while consensus is being lost has an unknown outcome from the

--- a/docs/technical/architecture/subsystems/consensus/removed-member-registry.md
+++ b/docs/technical/architecture/subsystems/consensus/removed-member-registry.md
@@ -103,20 +103,50 @@ On the leader serving `RemoveNode`, `ProposalID` — together with the expected 
 
 This path is intentionally leader-local: `rawNode.ApplyConfChange` mutates only the leader's raft state; followers (if any survive) will learn about it via the next snapshot they receive to catch up. The design extends the existing two-write sequence to atomically embed the blacklist write in the second one:
 
-1. `wal.UpdateSnapshotConfState(cs)` — WAL write, ordered first per EN-1413 (unchanged).
-2. **Extended** `membership.Unregister(nodeID)` — Pebble batch, atomic between:
+1. `rawNode.ApplyConfChange(cc)` — irreversible live tracker mutation; returns the new `ConfState`.
+2. `wal.UpdateSnapshotConfState(cs)` — WAL write, ordered before Pebble per EN-1413.
+3. When the peer has a valid instance identity, `membership.UnregisterAndBlacklist(nodeID, instanceID, removedAt)` performs a Pebble batch atomic between:
    - Delete of the peer row.
    - Put of `RemovedMembers[nodeID, instanceID]`.
 
+   A phantom learner or bootstrap peer without an instance identity instead
+   uses `membership.Unregister(nodeID)` because there is no identity to
+   blacklist.
+
 The `instanceID` is read from the peer's Membership row just before the delete, so no explicit parameter needs to travel on the ledgerctl RPC. `membership.Unregister` reads from its own in-memory cache (populated at boot from Pebble), which is outside the FSM hot path and therefore not subject to invariants #3/#6/#9.
 
-`internal/infra/node/` and `internal/infra/membership/` are added to the `forbidigo` exception list of [invariant #4](../../../../../CLAUDE.md#invariants), justified as *"cluster-topology lifecycle path: force-remove writes ConfState (WAL) + peer tombstone (Pebble) outside the FSM hot path by necessity — see docs/technical/architecture/subsystems/consensus/removed-member-registry.md"*. The node/membership exception already exists de facto for the WAL/peer-row writes; the new Pebble mutation reuses the same exception scope.
+The file-scoped `forbidigo` exceptions for the membership peer-store lifecycle
+are justified as *"cluster-topology lifecycle path: force-remove writes
+ConfState (WAL) + peer tombstone (Pebble) outside the FSM hot path by necessity
+— see docs/technical/architecture/subsystems/consensus/removed-member-registry.md"*.
+
+`ApplyConfChange` replaces etcd/raft's active tracker and deletes the removed
+member's `Progress`; etcd/raft exposes no rollback operation that restores that
+tracker state. If `UpdateSnapshotConfState` fails, Ledger therefore marks the
+node terminal before returning the persistence error, rejects subsequent Raft
+commands and proposals, fails work queued while the persistence call was in
+flight, and stops the orchestrate task. Once a force-removal command is admitted,
+caller cancellation cannot release it before that definitive result is known.
+`Node.Run` propagates the task failure to the bootstrap runner, which terminates
+the process. The Pebble batch is not attempted. Applying an inverse add change
+is deliberately not used: it would create new progress, not restore the removed
+member's prior replication state.
+
+`UpdateSnapshotConfState` has two durable writes. It atomically replaces the
+snapshot file, then appends the matching etcd WAL snapshot record. Because a
+ConfState-only update retains the same snapshot term/index, a failure before the
+file replacement restarts with the old ConfState, while a failure after the
+replacement can restart with the new ConfState even if the following record
+write reports an error. Restart makes that durable snapshot authoritative. The
+running node is terminated for either error outcome, so neither residual state
+can serve concurrently with a contradictory live tracker.
 
 #### Crash windows (force path only)
 
 | Crash between... | Resulting state on reboot | Impact |
 |---|---|---|
-| in-memory `ApplyConfChange` and WAL write | ConfState unchanged; peer still voter. | Statu quo, no harm. |
+| in-memory `ApplyConfChange` and atomic snapshot-file replacement | ConfState unchanged; peer still voter. A returned persistence error fail-stops the running node and fails queued work. | Restart reconstructs the old membership; the reduced live quorum is never used by a continuing node. |
+| snapshot-file replacement and WAL snapshot-record write | The replacement file contains the reduced ConfState at the snapshot's existing term/index. A record-write error still fail-stops the node and skips peer cleanup. | Restart may reconstruct the new membership from the durable replacement file; no contradictory process continues serving. |
 | WAL write and Pebble batch | ConfState says "removed"; peer row still present (harmless per EN-1413); `RemovedMembers` empty. | Peer is out of quorum but not blacklisted. If the pod is still alive and rejoins **within this window**, EN-1045 loop briefly possible until the operator retries `remove-node`. |
 | After Pebble batch | Nominal. | — |
 

--- a/docs/technical/architecture/subsystems/consensus/removed-member-registry.md
+++ b/docs/technical/architecture/subsystems/consensus/removed-member-registry.md
@@ -127,13 +127,19 @@ node terminal before returning the persistence error, rejects subsequent Raft
 commands and proposals, fails work queued while the persistence call was in
 flight, and stops the orchestrate task. Once a force-removal command is admitted,
 caller cancellation cannot release it before that definitive result is known.
+If `Node.Run` stops before an admitted command executes, its waiter receives
+`raft.ErrStopped` after all node tasks have stopped; a result already produced
+by the command is preserved, with terminal persistence failure taking precedence.
 `Node.Run` propagates the task failure to the bootstrap runner, which terminates
 the process. The Pebble batch is not attempted. Applying an inverse add change
 is deliberately not used: it would create new progress, not restore the removed
 member's prior replication state.
 
-`UpdateSnapshotConfState` has two durable writes. It atomically replaces the
-snapshot file, then appends the matching etcd WAL snapshot record. Because a
+`UpdateSnapshotConfState` first replaces its in-memory snapshot, then performs
+two durable writes: it atomically replaces the snapshot file, then appends the
+matching etcd WAL snapshot record. A failure before file replacement leaves both
+the live Raft tracker and the WAL's in-memory ConfState reduced, while the old
+snapshot file remains the restart authority. Because a
 ConfState-only update retains the same snapshot term/index, a failure before the
 file replacement restarts with the old ConfState, while a failure after the
 replacement can restart with the new ConfState even if the following record

--- a/internal/infra/node/applier_test.go
+++ b/internal/infra/node/applier_test.go
@@ -78,6 +78,7 @@ type testApplierSetup struct {
 	applier      *Applier
 	store        *dal.Store
 	wal          wal.WAL
+	walDir       string
 	spool        *spool.Default
 	fsm          *state.Machine
 	stop         chan struct{}
@@ -160,6 +161,7 @@ func newTestApplierSetupWithSink(t *testing.T, sink LocalResponses) *testApplier
 		applier:      applier,
 		store:        pebbleStore,
 		wal:          w,
+		walDir:       walDir,
 		spool:        defaultSpool,
 		fsm:          fsm,
 		stop:         stop,

--- a/internal/infra/node/force_remove_durability_test.go
+++ b/internal/infra/node/force_remove_durability_test.go
@@ -1,0 +1,542 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/raft/v3"
+	"go.etcd.io/raft/v3/raftpb"
+	"go.opentelemetry.io/otel/metric/noop"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/infra/membership"
+	"github.com/formancehq/ledger/v3/internal/storage/wal"
+)
+
+type forceRemoveFailureStage int
+
+const (
+	forceRemoveNoFailure forceRemoveFailureStage = iota
+	forceRemoveBeforeSnapshotPersistence
+	forceRemoveAfterSnapshotFilePersistence
+)
+
+type forceRemoveWAL struct {
+	wal.WAL
+
+	mu           sync.Mutex
+	failureStage forceRemoveFailureStage
+	updateErr    error
+	updates      int
+	started      chan struct{}
+	startOnce    sync.Once
+	release      chan struct{}
+	releaseOnce  sync.Once
+}
+
+func (w *forceRemoveWAL) UpdateSnapshotConfState(cs *raftpb.ConfState) error {
+	w.mu.Lock()
+	w.updates++
+	w.mu.Unlock()
+
+	w.startOnce.Do(func() { close(w.started) })
+	if w.release != nil {
+		<-w.release
+	}
+
+	switch w.failureStage {
+	case forceRemoveNoFailure:
+		return w.WAL.UpdateSnapshotConfState(cs)
+	case forceRemoveBeforeSnapshotPersistence:
+		return w.updateErr
+	case forceRemoveAfterSnapshotFilePersistence:
+		// Closing the real etcd WAL makes its SaveSnapshot call fail while
+		// leaving Snapshotter.Save operational. This drives the production
+		// UpdateSnapshotConfState sequence through its atomic snapshot-file
+		// replacement and fails at the following WAL-record write.
+		if err := w.Close(); err != nil {
+			return fmt.Errorf("closing WAL for failure injection: %w", err)
+		}
+
+		err := w.WAL.UpdateSnapshotConfState(cs)
+		if err == nil {
+			return errors.New("invariant: closed WAL accepted snapshot record")
+		}
+
+		return fmt.Errorf("%w after snapshot-file persistence: %w", w.updateErr, err)
+	default:
+		return errors.New("invariant: unknown force-remove failure stage")
+	}
+}
+
+func (w *forceRemoveWAL) updateCount() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	return w.updates
+}
+
+type forceRemoveHarness struct {
+	n               *Node
+	rawNode         *raft.RawNode
+	durableWAL      wal.WAL
+	injectedWAL     *forceRemoveWAL
+	membership      *membership.Membership
+	walDir          string
+	baselineCommit  uint64
+	stagedIndex     uint64
+	stop            chan struct{}
+	orchestrateDone chan error
+	stopped         bool
+}
+
+func newForceRemoveTransport(t *testing.T) Transport {
+	t.Helper()
+
+	transport := NewMockTransport(gomock.NewController(t))
+	transport.EXPECT().Unreachable().AnyTimes().Return((<-chan uint64)(nil))
+	transport.EXPECT().RecvHighPriority().AnyTimes().Return((<-chan []*raftpb.Message)(nil))
+	transport.EXPECT().RecvMediumPriority().AnyTimes().Return((<-chan []*raftpb.Message)(nil))
+	transport.EXPECT().RecvLowPriority().AnyTimes().Return((<-chan []*raftpb.Message)(nil))
+	transport.EXPECT().Send(gomock.Any()).AnyTimes()
+
+	return transport
+}
+
+func newForceRemoveHarness(
+	t *testing.T,
+	voters []uint64,
+	failureStage forceRemoveFailureStage,
+	updateErr error,
+	blockUpdate bool,
+) *forceRemoveHarness {
+	t.Helper()
+
+	setup := newTestApplierSetup(t)
+	initial := &raftpb.ConfState{Voters: voters}
+	require.NoError(t, setup.wal.UpdateSnapshotConfState(initial))
+
+	rawNode, err := raft.NewRawNode(&raft.Config{
+		ID:              1,
+		ElectionTick:    10,
+		HeartbeatTick:   1,
+		Storage:         setup.wal,
+		MaxSizePerMsg:   1024 * 1024,
+		MaxInflightMsgs: 256,
+		Logger:          NewLoggerAdapter(logging.Testing()),
+	})
+	require.NoError(t, err)
+
+	// Elect node 1 using the real voter tracker. A candidate needs quorum
+	// including its own vote, so supply exactly quorum-1 peer votes.
+	require.NoError(t, rawNode.Campaign())
+	persistReadyAndAdvance(t, rawNode, setup.wal)
+	quorum := len(voters)/2 + 1
+	for i := 1; i < quorum; i++ {
+		require.NoError(t, rawNode.Step(&raftpb.Message{
+			Type: new(raftpb.MsgVoteResp),
+			From: new(voters[i]),
+			To:   proto.Uint64(1),
+			Term: new(rawNode.Status().GetTerm()),
+		}))
+		persistReadyAndAdvance(t, rawNode, setup.wal)
+	}
+	require.Equal(t, raft.StateLeader, rawNode.Status().RaftState)
+
+	// Commit the leader's no-op so later tests have a stable durable baseline.
+	leaderIndex := rawNode.Status().Progress[1].Match
+	for i := 1; i < quorum; i++ {
+		require.NoError(t, rawNode.Step(&raftpb.Message{
+			Type:  new(raftpb.MsgAppResp),
+			From:  new(voters[i]),
+			To:    proto.Uint64(1),
+			Term:  new(rawNode.Status().GetTerm()),
+			Index: new(leaderIndex),
+		}))
+		persistReadyAndAdvance(t, rawNode, setup.wal)
+	}
+	require.Equal(t, leaderIndex, rawNode.Status().GetCommit())
+	baselineCommit := rawNode.Status().GetCommit()
+	var stagedIndex uint64
+	if len(voters) == 4 {
+		// Stage an entry with only A and B acknowledging it. That is not a
+		// quorum of four, but becomes a quorum after D is force-removed.
+		require.NoError(t, rawNode.Propose([]byte("committable only after quorum shrinks")))
+		persistReadyAndAdvance(t, rawNode, setup.wal)
+		stagedIndex = rawNode.Status().Progress[1].Match
+		require.Greater(t, stagedIndex, baselineCommit)
+		require.NoError(t, rawNode.Step(&raftpb.Message{
+			Type:  new(raftpb.MsgAppResp),
+			From:  proto.Uint64(2),
+			To:    proto.Uint64(1),
+			Term:  new(rawNode.Status().GetTerm()),
+			Index: new(stagedIndex),
+		}))
+		require.Equal(t, baselineCommit, rawNode.Status().GetCommit(),
+			"two acknowledgements are not a quorum of four")
+	}
+
+	m := newTestMembership(t)
+	for _, id := range voters {
+		require.NoError(t, m.Register(
+			id,
+			fmt.Sprintf("node-%d:7000", id),
+			fmt.Sprintf("node-%d:8000", id),
+			fmt.Appendf(nil, "%016d", id),
+		))
+	}
+
+	injectedWAL := &forceRemoveWAL{
+		WAL:          setup.wal,
+		failureStage: failureStage,
+		updateErr:    updateErr,
+		started:      make(chan struct{}),
+	}
+	if blockUpdate {
+		injectedWAL.release = make(chan struct{})
+	}
+
+	n := &Node{
+		rawNode:          rawNode,
+		logger:           logging.Testing(),
+		wal:              injectedWAL,
+		fsm:              setup.fsm,
+		transport:        newForceRemoveTransport(t),
+		config:           NodeConfig{NodeID: 1, TickInterval: time.Hour},
+		proposeCh:        make(chan *Proposal, 16),
+		clusterCommandCh: make(chan *clusterCommand, 16),
+		readyTerminated:  make(chan readyResult),
+		localResponseCh:  make(LocalResponses),
+		applier:          setup.applier,
+		membership:       m,
+		indexTracker:     NewIndexTracker(initialIndex(setup.wal)),
+		terminalCh:       make(chan struct{}),
+	}
+	n.confState.Store(initial)
+
+	h := &forceRemoveHarness{
+		n:               n,
+		rawNode:         rawNode,
+		durableWAL:      setup.wal,
+		injectedWAL:     injectedWAL,
+		membership:      m,
+		walDir:          setup.walDir,
+		baselineCommit:  baselineCommit,
+		stagedIndex:     stagedIndex,
+		stop:            make(chan struct{}),
+		orchestrateDone: make(chan error, 1),
+	}
+	go func() {
+		h.orchestrateDone <- n.orchestrate(context.Background(), h.stop)
+	}()
+
+	t.Cleanup(func() {
+		h.releaseUpdate()
+		if !h.stopped {
+			require.NoError(t, h.stopAndWait(t))
+		}
+	})
+
+	return h
+}
+
+func persistReadyAndAdvance(t *testing.T, rawNode *raft.RawNode, w wal.WAL) {
+	t.Helper()
+
+	for rawNode.HasReady() {
+		ready := rawNode.Ready()
+		require.NoError(t, w.Append(ready.HardState, ready.Entries))
+		rawNode.Advance(ready)
+	}
+}
+
+func (h *forceRemoveHarness) stopAndWait(t *testing.T) error {
+	t.Helper()
+
+	if !h.stopped {
+		close(h.stop)
+		h.stopped = true
+	}
+
+	select {
+	case err := <-h.orchestrateDone:
+		return err
+	case <-time.After(time.Second):
+		t.Fatal("orchestrate did not stop")
+
+		return nil
+	}
+}
+
+func (h *forceRemoveHarness) waitForTerminal(t *testing.T) error {
+	t.Helper()
+
+	select {
+	case err := <-h.orchestrateDone:
+		h.stopped = true
+
+		return err
+	case <-time.After(time.Second):
+		t.Fatal("orchestrate continued after terminal force-remove failure")
+
+		return nil
+	}
+}
+
+func (h *forceRemoveHarness) waitForUpdate(t *testing.T) {
+	t.Helper()
+
+	select {
+	case <-h.injectedWAL.started:
+	case <-time.After(time.Second):
+		t.Fatal("ForceRemoveNode did not reach UpdateSnapshotConfState")
+	}
+}
+
+func (h *forceRemoveHarness) releaseUpdate() {
+	if h.injectedWAL.release != nil {
+		h.injectedWAL.releaseOnce.Do(func() { close(h.injectedWAL.release) })
+	}
+}
+
+func receiveForceRemoveError(t *testing.T, ch <-chan error) error {
+	t.Helper()
+
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(time.Second):
+		t.Fatal("operation did not receive terminal force-remove error")
+
+		return nil
+	}
+}
+
+func durableState(t *testing.T, w wal.WAL) (*raftpb.HardState, []uint64) {
+	t.Helper()
+
+	hardState, confState, err := w.InitialState()
+	require.NoError(t, err)
+
+	return hardState, confState.GetVoters()
+}
+
+func (h *forceRemoveHarness) restartedState(t *testing.T) (*raftpb.HardState, map[uint64]struct{}) {
+	t.Helper()
+
+	_ = h.durableWAL.Close()
+	reopened, err := wal.New(
+		h.walDir,
+		logging.Testing(),
+		noop.NewMeterProvider().Meter("force-remove-restart"),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = reopened.Close() })
+
+	hardState, _, err := reopened.InitialState()
+	require.NoError(t, err)
+	restarted, err := raft.NewRawNode(&raft.Config{
+		ID:              1,
+		ElectionTick:    10,
+		HeartbeatTick:   1,
+		Storage:         reopened,
+		MaxSizePerMsg:   1024 * 1024,
+		MaxInflightMsgs: 256,
+		Logger:          NewLoggerAdapter(logging.Testing()),
+	})
+	require.NoError(t, err)
+
+	return hardState, restarted.Status().Config.Voters.IDs()
+}
+
+func TestForceRemoveNodeDurabilityFailureContract(t *testing.T) {
+	t.Run("validation failure happens before live mutation", func(t *testing.T) {
+		t.Parallel()
+
+		h := newForceRemoveHarness(t, []uint64{1, 2, 3}, forceRemoveNoFailure, nil, false)
+
+		err := h.n.ForceRemoveNode(context.Background(), 99)
+		require.ErrorIs(t, err, ErrNodeNotInCluster)
+		require.Zero(t, h.injectedWAL.updateCount())
+		require.Contains(t, h.rawNode.Status().Progress, uint64(3))
+		require.Equal(t, []uint64{1, 2, 3}, h.n.confState.Load().GetVoters())
+		_, voters := durableState(t, h.durableWAL)
+		require.Equal(t, []uint64{1, 2, 3}, voters)
+
+		_, err = h.n.GetClusterState(context.Background())
+		require.NoError(t, err, "a pre-mutation validation error must not stop the node")
+	})
+
+	t.Run("failure before snapshot persistence fail-stops and restarts old membership", func(t *testing.T) {
+		t.Parallel()
+
+		injected := errors.New("injected before snapshot persistence")
+		h := newForceRemoveHarness(
+			t, []uint64{1, 2, 3}, forceRemoveBeforeSnapshotPersistence, injected, false,
+		)
+
+		err := h.n.ForceRemoveNode(context.Background(), 3)
+		require.ErrorIs(t, err, injected)
+		require.Equal(t, 1, h.injectedWAL.updateCount())
+		require.NotContains(t, h.rawNode.Status().Progress, uint64(3))
+		require.Equal(t, []uint64{1, 2}, h.n.confState.Load().GetVoters())
+		_, voters := durableState(t, h.durableWAL)
+		require.Equal(t, []uint64{1, 2, 3}, voters)
+		require.Contains(t, h.membership.PeerAddresses(), uint64(3))
+		removed, lookupErr := h.membership.IsRemoved(3, []byte("0000000000000003"))
+		require.NoError(t, lookupErr)
+		require.False(t, removed, "peer cleanup must not write the tombstone after persistence fails")
+
+		runErr := h.waitForTerminal(t)
+		require.ErrorIs(t, runErr, injected)
+		_, err = h.n.GetClusterState(context.Background())
+		require.ErrorIs(t, err, injected)
+		_, err = h.n.Propose(context.Background(), NewProposal(100, []byte("must not be admitted")))
+		require.ErrorIs(t, err, injected)
+
+		_, restartedVoters := h.restartedState(t)
+		require.Equal(t, map[uint64]struct{}{1: {}, 2: {}, 3: {}}, restartedVoters)
+	})
+
+	t.Run("failure after snapshot file persistence fail-stops and restarts new membership", func(t *testing.T) {
+		t.Parallel()
+
+		injected := errors.New("injected WAL snapshot-record failure")
+		h := newForceRemoveHarness(
+			t, []uint64{1, 2, 3}, forceRemoveAfterSnapshotFilePersistence, injected, false,
+		)
+
+		err := h.n.ForceRemoveNode(context.Background(), 3)
+		require.ErrorIs(t, err, injected)
+		require.NotContains(t, h.rawNode.Status().Progress, uint64(3))
+		require.Equal(t, []uint64{1, 2}, h.n.confState.Load().GetVoters())
+		require.Contains(t, h.membership.PeerAddresses(), uint64(3),
+			"peer cleanup must not run after a persistence error")
+		removed, lookupErr := h.membership.IsRemoved(3, []byte("0000000000000003"))
+		require.NoError(t, lookupErr)
+		require.False(t, removed, "peer cleanup must not write the tombstone after persistence fails")
+		require.ErrorIs(t, h.waitForTerminal(t), injected)
+
+		_, restartedVoters := h.restartedState(t)
+		require.Equal(t, map[uint64]struct{}{1: {}, 2: {}}, restartedVoters,
+			"the atomically replaced snapshot file is the restart authority for its existing term/index")
+	})
+
+	t.Run("concurrent admissions receive terminal failure", func(t *testing.T) {
+		t.Parallel()
+
+		injected := errors.New("blocked snapshot persistence failure")
+		h := newForceRemoveHarness(
+			t, []uint64{1, 2, 3}, forceRemoveBeforeSnapshotPersistence, injected, true,
+		)
+
+		forceCtx, cancelForce := context.WithCancel(context.Background())
+		defer cancelForce()
+		forceErr := make(chan error, 1)
+		go func() { forceErr <- h.n.ForceRemoveNode(forceCtx, 3) }()
+		h.waitForUpdate(t)
+
+		commandErr := make(chan error, 1)
+		go func() {
+			_, err := h.n.GetClusterState(context.Background())
+			commandErr <- err
+		}()
+		require.Eventually(t, func() bool { return len(h.n.clusterCommandCh) == 1 }, time.Second, time.Millisecond)
+
+		proposal := NewProposal(101, []byte("queued before terminal publication"))
+		trackerBefore := h.n.indexTracker.Next()
+		h.n.indexTracker.Lock()
+		fsmFuture, err := h.n.Propose(context.Background(), proposal)
+		h.n.indexTracker.Unlock()
+		require.NoError(t, err)
+		require.NotNil(t, fsmFuture)
+		require.Len(t, h.n.proposeCh, 1)
+
+		cancelForce()
+		select {
+		case err := <-forceErr:
+			t.Fatalf("force-remove returned before its persistence outcome: %v", err)
+		default:
+		}
+
+		h.releaseUpdate()
+		require.ErrorIs(t, receiveForceRemoveError(t, forceErr), injected)
+		require.ErrorIs(t, receiveForceRemoveError(t, commandErr), injected)
+		require.ErrorIs(t, h.waitForTerminal(t), injected)
+
+		waitCtx, cancelWait := context.WithTimeout(context.Background(), time.Second)
+		defer cancelWait()
+		_, err = fsmFuture.Wait(waitCtx)
+		require.ErrorIs(t, err, injected)
+		_, err = proposal.Wait(waitCtx)
+		require.ErrorIs(t, err, injected)
+		require.Equal(t, trackerBefore, h.n.indexTracker.Next())
+	})
+
+	t.Run("reduced live quorum cannot durably commit staged work after failure", func(t *testing.T) {
+		t.Parallel()
+
+		injected := errors.New("injected four-to-three persistence failure")
+		h := newForceRemoveHarness(
+			t, []uint64{1, 2, 3, 4}, forceRemoveBeforeSnapshotPersistence, injected, false,
+		)
+
+		baselineHardState, _ := durableState(t, h.durableWAL)
+		baselineApplied := h.n.fsm.LastAppliedIndex()
+		require.Equal(t, h.baselineCommit, baselineHardState.GetCommit())
+		require.Greater(t, h.stagedIndex, h.baselineCommit)
+		require.Equal(t, h.baselineCommit, h.rawNode.Status().GetCommit())
+
+		err := h.n.ForceRemoveNode(context.Background(), 4)
+		require.ErrorIs(t, err, injected)
+		require.Equal(t, map[uint64]struct{}{1: {}, 2: {}, 3: {}}, h.rawNode.Status().Config.Voters.IDs())
+		require.Equal(t, h.stagedIndex, h.rawNode.Status().GetCommit(),
+			"the irreversible four-to-three transition makes the staged entry live-committed")
+		require.ErrorIs(t, h.waitForTerminal(t), injected)
+		require.Equal(t, baselineApplied, h.n.fsm.LastAppliedIndex(),
+			"terminal exit must prevent business application")
+
+		durableHardState, durableVoters := durableState(t, h.durableWAL)
+		require.Equal(t, baselineHardState.GetCommit(), durableHardState.GetCommit(),
+			"the live-only commit must not reach durable HardState")
+		require.Equal(t, []uint64{1, 2, 3, 4}, durableVoters)
+
+		restartedHardState, restartedVoters := h.restartedState(t)
+		require.Equal(t, baselineHardState.GetCommit(), restartedHardState.GetCommit())
+		require.Equal(t, map[uint64]struct{}{1: {}, 2: {}, 3: {}, 4: {}}, restartedVoters)
+	})
+
+	t.Run("successful persistence remains live durable and restartable", func(t *testing.T) {
+		t.Parallel()
+
+		h := newForceRemoveHarness(t, []uint64{1, 2, 3}, forceRemoveNoFailure, nil, false)
+
+		require.NoError(t, h.n.ForceRemoveNode(context.Background(), 3))
+		require.Equal(t, 1, h.injectedWAL.updateCount())
+		require.NotContains(t, h.rawNode.Status().Progress, uint64(3))
+		require.Equal(t, []uint64{1, 2}, h.n.confState.Load().GetVoters())
+		_, voters := durableState(t, h.durableWAL)
+		require.Equal(t, []uint64{1, 2}, voters)
+		require.NotContains(t, h.membership.PeerAddresses(), uint64(3))
+		removed, err := h.membership.IsRemoved(3, []byte("0000000000000003"))
+		require.NoError(t, err)
+		require.True(t, removed)
+
+		err = h.n.ForceRemoveNode(context.Background(), 3)
+		require.ErrorIs(t, err, ErrNodeNotInCluster)
+		require.Equal(t, 1, h.injectedWAL.updateCount())
+		_, err = h.n.GetClusterState(context.Background())
+		require.NoError(t, err)
+
+		_, restartedVoters := h.restartedState(t)
+		require.Equal(t, map[uint64]struct{}{1: {}, 2: {}}, restartedVoters)
+	})
+}

--- a/internal/infra/node/force_remove_durability_test.go
+++ b/internal/infra/node/force_remove_durability_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -33,6 +35,8 @@ type forceRemoveWAL struct {
 	wal.WAL
 
 	mu           sync.Mutex
+	walDir       string
+	closed       bool
 	failureStage forceRemoveFailureStage
 	updateErr    error
 	updates      int
@@ -56,7 +60,26 @@ func (w *forceRemoveWAL) UpdateSnapshotConfState(cs *raftpb.ConfState) error {
 	case forceRemoveNoFailure:
 		return w.WAL.UpdateSnapshotConfState(cs)
 	case forceRemoveBeforeSnapshotPersistence:
-		return w.updateErr
+		// Fail the real snapshot-file write after UpdateSnapshotConfState has
+		// replaced its in-memory snapshot. The existing durable file survives.
+		snapshot, err := w.Snapshot()
+		if err != nil {
+			return fmt.Errorf("reading snapshot for failure injection: %w", err)
+		}
+		tmpPath := filepath.Join(w.walDir, "snap", fmt.Sprintf("%016x-%016x.snap.tmp",
+			snapshot.GetMetadata().GetTerm(), snapshot.GetMetadata().GetIndex()))
+		if err := os.Mkdir(tmpPath, 0700); err != nil {
+			return fmt.Errorf("blocking snapshot file creation: %w", err)
+		}
+		err = w.WAL.UpdateSnapshotConfState(cs)
+		if cleanupErr := os.Remove(tmpPath); cleanupErr != nil {
+			return fmt.Errorf("removing snapshot failure injection: %w", cleanupErr)
+		}
+		if err == nil {
+			return errors.New("invariant: snapshot write accepted a directory")
+		}
+
+		return fmt.Errorf("%w before snapshot-file persistence: %w", w.updateErr, err)
 	case forceRemoveAfterSnapshotFilePersistence:
 		// Closing the real etcd WAL makes its SaveSnapshot call fail while
 		// leaving Snapshotter.Save operational. This drives the production
@@ -65,6 +88,7 @@ func (w *forceRemoveWAL) UpdateSnapshotConfState(cs *raftpb.ConfState) error {
 		if err := w.Close(); err != nil {
 			return fmt.Errorf("closing WAL for failure injection: %w", err)
 		}
+		w.closed = true
 
 		err := w.WAL.UpdateSnapshotConfState(cs)
 		if err == nil {
@@ -196,6 +220,7 @@ func newForceRemoveHarness(
 
 	injectedWAL := &forceRemoveWAL{
 		WAL:          setup.wal,
+		walDir:       setup.walDir,
 		failureStage: failureStage,
 		updateErr:    updateErr,
 		started:      make(chan struct{}),
@@ -320,7 +345,7 @@ func receiveForceRemoveError(t *testing.T, ch <-chan error) error {
 	}
 }
 
-func durableState(t *testing.T, w wal.WAL) (*raftpb.HardState, []uint64) {
+func walState(t *testing.T, w wal.WAL) (*raftpb.HardState, []uint64) {
 	t.Helper()
 
 	hardState, confState, err := w.InitialState()
@@ -332,14 +357,20 @@ func durableState(t *testing.T, w wal.WAL) (*raftpb.HardState, []uint64) {
 func (h *forceRemoveHarness) restartedState(t *testing.T) (*raftpb.HardState, map[uint64]struct{}) {
 	t.Helper()
 
-	_ = h.durableWAL.Close()
+	if !h.stopped {
+		require.NoError(t, h.stopAndWait(t))
+	}
+	// The post-file failure already closed the WAL to fail its record write.
+	if !h.injectedWAL.closed {
+		require.NoError(t, h.durableWAL.Close())
+	}
 	reopened, err := wal.New(
 		h.walDir,
 		logging.Testing(),
 		noop.NewMeterProvider().Meter("force-remove-restart"),
 	)
 	require.NoError(t, err)
-	t.Cleanup(func() { _ = reopened.Close() })
+	t.Cleanup(func() { require.NoError(t, reopened.Close()) })
 
 	hardState, _, err := reopened.InitialState()
 	require.NoError(t, err)
@@ -358,6 +389,8 @@ func (h *forceRemoveHarness) restartedState(t *testing.T) (*raftpb.HardState, ma
 }
 
 func TestForceRemoveNodeDurabilityFailureContract(t *testing.T) {
+	t.Parallel()
+
 	t.Run("validation failure happens before live mutation", func(t *testing.T) {
 		t.Parallel()
 
@@ -368,7 +401,7 @@ func TestForceRemoveNodeDurabilityFailureContract(t *testing.T) {
 		require.Zero(t, h.injectedWAL.updateCount())
 		require.Contains(t, h.rawNode.Status().Progress, uint64(3))
 		require.Equal(t, []uint64{1, 2, 3}, h.n.confState.Load().GetVoters())
-		_, voters := durableState(t, h.durableWAL)
+		_, voters := walState(t, h.durableWAL)
 		require.Equal(t, []uint64{1, 2, 3}, voters)
 
 		_, err = h.n.GetClusterState(context.Background())
@@ -385,11 +418,13 @@ func TestForceRemoveNodeDurabilityFailureContract(t *testing.T) {
 
 		err := h.n.ForceRemoveNode(context.Background(), 3)
 		require.ErrorIs(t, err, injected)
+		require.ErrorContains(t, err, "creating temp snap file")
 		require.Equal(t, 1, h.injectedWAL.updateCount())
 		require.NotContains(t, h.rawNode.Status().Progress, uint64(3))
 		require.Equal(t, []uint64{1, 2}, h.n.confState.Load().GetVoters())
-		_, voters := durableState(t, h.durableWAL)
-		require.Equal(t, []uint64{1, 2, 3}, voters)
+		_, voters := walState(t, h.durableWAL)
+		require.Equal(t, []uint64{1, 2}, voters,
+			"the real WAL mutates its in-memory snapshot before attempting the file write")
 		require.Contains(t, h.membership.PeerAddresses(), uint64(3))
 		removed, lookupErr := h.membership.IsRemoved(3, []byte("0000000000000003"))
 		require.NoError(t, lookupErr)
@@ -481,38 +516,56 @@ func TestForceRemoveNodeDurabilityFailureContract(t *testing.T) {
 		require.Equal(t, trackerBefore, h.n.indexTracker.Next())
 	})
 
-	t.Run("reduced live quorum cannot durably commit staged work after failure", func(t *testing.T) {
-		t.Parallel()
+	for _, tc := range []struct {
+		name            string
+		stage           forceRemoveFailureStage
+		restartedVoters map[uint64]struct{}
+	}{
+		{
+			name:            "before snapshot-file persistence",
+			stage:           forceRemoveBeforeSnapshotPersistence,
+			restartedVoters: map[uint64]struct{}{1: {}, 2: {}, 3: {}, 4: {}},
+		},
+		{
+			name:            "after snapshot-file persistence",
+			stage:           forceRemoveAfterSnapshotFilePersistence,
+			restartedVoters: map[uint64]struct{}{1: {}, 2: {}, 3: {}},
+		},
+	} {
+		t.Run("reduced live quorum cannot durably commit staged work/"+tc.name, func(t *testing.T) {
+			t.Parallel()
 
-		injected := errors.New("injected four-to-three persistence failure")
-		h := newForceRemoveHarness(
-			t, []uint64{1, 2, 3, 4}, forceRemoveBeforeSnapshotPersistence, injected, false,
-		)
+			injected := errors.New("injected four-to-three persistence failure")
+			h := newForceRemoveHarness(
+				t, []uint64{1, 2, 3, 4}, tc.stage, injected, false,
+			)
 
-		baselineHardState, _ := durableState(t, h.durableWAL)
-		baselineApplied := h.n.fsm.LastAppliedIndex()
-		require.Equal(t, h.baselineCommit, baselineHardState.GetCommit())
-		require.Greater(t, h.stagedIndex, h.baselineCommit)
-		require.Equal(t, h.baselineCommit, h.rawNode.Status().GetCommit())
+			baselineHardState, _ := walState(t, h.durableWAL)
+			baselineApplied := h.n.fsm.LastAppliedIndex()
+			require.Equal(t, h.baselineCommit, baselineHardState.GetCommit())
+			require.Greater(t, h.stagedIndex, h.baselineCommit)
+			require.Equal(t, h.baselineCommit, h.rawNode.Status().GetCommit())
 
-		err := h.n.ForceRemoveNode(context.Background(), 4)
-		require.ErrorIs(t, err, injected)
-		require.Equal(t, map[uint64]struct{}{1: {}, 2: {}, 3: {}}, h.rawNode.Status().Config.Voters.IDs())
-		require.Equal(t, h.stagedIndex, h.rawNode.Status().GetCommit(),
-			"the irreversible four-to-three transition makes the staged entry live-committed")
-		require.ErrorIs(t, h.waitForTerminal(t), injected)
-		require.Equal(t, baselineApplied, h.n.fsm.LastAppliedIndex(),
-			"terminal exit must prevent business application")
+			err := h.n.ForceRemoveNode(context.Background(), 4)
+			require.ErrorIs(t, err, injected)
+			require.Equal(t, map[uint64]struct{}{1: {}, 2: {}, 3: {}}, h.rawNode.Status().Config.Voters.IDs())
+			require.Equal(t, h.stagedIndex, h.rawNode.Status().GetCommit(),
+				"the irreversible four-to-three transition makes the staged entry live-committed")
+			require.ErrorIs(t, h.waitForTerminal(t), injected)
+			require.Equal(t, baselineApplied, h.n.fsm.LastAppliedIndex(),
+				"terminal exit must prevent business application")
 
-		durableHardState, durableVoters := durableState(t, h.durableWAL)
-		require.Equal(t, baselineHardState.GetCommit(), durableHardState.GetCommit(),
-			"the live-only commit must not reach durable HardState")
-		require.Equal(t, []uint64{1, 2, 3, 4}, durableVoters)
+			durableHardState, memoryVoters := walState(t, h.durableWAL)
+			require.Equal(t, baselineHardState.GetCommit(), durableHardState.GetCommit(),
+				"the live-only commit must not reach durable HardState")
+			require.Equal(t, []uint64{1, 2, 3}, memoryVoters,
+				"WAL memory advances before snapshot-file persistence; restart below proves durable membership")
 
-		restartedHardState, restartedVoters := h.restartedState(t)
-		require.Equal(t, baselineHardState.GetCommit(), restartedHardState.GetCommit())
-		require.Equal(t, map[uint64]struct{}{1: {}, 2: {}, 3: {}, 4: {}}, restartedVoters)
-	})
+			restartedHardState, restartedVoters := h.restartedState(t)
+			require.Equal(t, baselineHardState.GetCommit(), restartedHardState.GetCommit())
+			require.Equal(t, tc.restartedVoters, restartedVoters)
+		})
+	}
 
 	t.Run("successful persistence remains live durable and restartable", func(t *testing.T) {
 		t.Parallel()
@@ -523,7 +576,7 @@ func TestForceRemoveNodeDurabilityFailureContract(t *testing.T) {
 		require.Equal(t, 1, h.injectedWAL.updateCount())
 		require.NotContains(t, h.rawNode.Status().Progress, uint64(3))
 		require.Equal(t, []uint64{1, 2}, h.n.confState.Load().GetVoters())
-		_, voters := durableState(t, h.durableWAL)
+		_, voters := walState(t, h.durableWAL)
 		require.Equal(t, []uint64{1, 2}, voters)
 		require.NotContains(t, h.membership.PeerAddresses(), uint64(3))
 		removed, err := h.membership.IsRemoved(3, []byte("0000000000000003"))

--- a/internal/infra/node/force_remove_run_test.go
+++ b/internal/infra/node/force_remove_run_test.go
@@ -1,0 +1,106 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/raft/v3/raftpb"
+	"go.opentelemetry.io/otel/metric/noop"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+func TestForceRemoveNodeDurabilityFailureStopsRun(t *testing.T) {
+	t.Parallel()
+
+	setup := newTestApplierSetup(t)
+	// A sole voter can elect itself through the real Run loops. Removing its
+	// learner exercises the terminal lifecycle independently of quorum sizing.
+	require.NoError(t, setup.wal.UpdateSnapshotConfState(&raftpb.ConfState{
+		Voters:   []uint64{1},
+		Learners: []uint64{2},
+	}))
+	injected := errors.New("force-remove snapshot persistence failed")
+	w := &forceRemoveWAL{
+		WAL:          setup.wal,
+		walDir:       setup.walDir,
+		failureStage: forceRemoveBeforeSnapshotPersistence,
+		updateErr:    injected,
+		started:      make(chan struct{}),
+	}
+	n, err := NewNode(
+		NodeConfig{
+			NodeID:                 1,
+			AdvertiseAddr:          "node-1:7000",
+			ServiceAdvertiseAddr:   "node-1:8000",
+			InstanceID:             []byte("0000000000000001"),
+			TickInterval:           time.Millisecond,
+			ProcessingTickInterval: time.Millisecond,
+			MaintenanceInterval:    time.Hour,
+		},
+		newForceRemoveTransport(t), setup.applier, logging.Testing(),
+		noop.NewMeterProvider().Meter("force-remove-run"), w, setup.fsm,
+		setup.applier.recovery, setup.applier.synchronizer,
+		newTestMembership(t), setup.responseSink,
+	)
+	require.NoError(t, err)
+
+	ready := make(chan struct{})
+	runErr := make(chan error, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		runErr <- n.Run(context.Background(), ready)
+	}()
+	t.Cleanup(func() {
+		// Also stop and join Run when an earlier assertion fails, before the
+		// shared fixture closes the WAL, spool, and Pebble store.
+		select {
+		case <-done:
+			return
+		case n.stopChannel <- make(chan struct{}):
+		case <-time.After(5 * time.Second):
+			t.Error("could not request node shutdown")
+
+			return
+		}
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("Node.Run did not finish shutdown")
+		}
+	})
+
+	select {
+	case <-ready:
+	case err := <-runErr:
+		t.Fatalf("Node.Run exited before readiness: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Node.Run did not become ready")
+	}
+	require.Eventually(t, n.IsLeader, 5*time.Second, time.Millisecond)
+
+	forceErr := make(chan error, 1)
+	go func() {
+		forceErr <- n.ForceRemoveNode(context.Background(), 2)
+	}()
+	require.ErrorIs(t, receiveForceRemoveError(t, forceErr), injected)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Node.Run continued after terminal force-remove failure")
+	}
+	err = <-runErr
+	require.ErrorIs(t, err, injected)
+	require.ErrorContains(t, err, "task pool error: persisting confstate after force-remove")
+	require.Equal(t, 1, w.updateCount())
+	select {
+	case <-n.runDone:
+	default:
+		t.Fatal("Node.Run did not publish lifecycle completion")
+	}
+}

--- a/internal/infra/node/force_remove_shutdown_test.go
+++ b/internal/infra/node/force_remove_shutdown_test.go
@@ -1,0 +1,90 @@
+package node
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/raft/v3"
+)
+
+func TestForceRemoveNodeAdmittedCommandStopsBeforeExecution(t *testing.T) {
+	t.Parallel()
+
+	n := &Node{
+		clusterCommandCh: make(chan *clusterCommand, 1),
+		terminalCh:       make(chan struct{}),
+		runDone:          make(chan struct{}),
+	}
+	t.Cleanup(func() {
+		select {
+		case <-n.runDone:
+		default:
+			close(n.runDone)
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	result := make(chan error, 1)
+	go func() { result <- n.ForceRemoveNode(ctx, 2) }()
+
+	// Observe actual admission, then model Run stopping before orchestrate
+	// executes the command. A nil rawNode ensures execution cannot be hidden.
+	select {
+	case <-n.clusterCommandCh:
+	case <-time.After(time.Second):
+		t.Fatal("force-removal was not admitted")
+	}
+	cancel()
+	close(n.runDone)
+	require.ErrorIs(t, receiveForceRemoveError(t, result), raft.ErrStopped)
+
+	// The caller must release the shared configuration-change lock, allowing
+	// later operations to observe shutdown instead of blocking behind it.
+	locked := n.confChangeMu.TryLock()
+	require.True(t, locked, "shutdown must release the configuration-change lock")
+	n.confChangeMu.Unlock()
+	require.ErrorIs(t, n.ForceRemoveNode(context.Background(), 3), raft.ErrStopped)
+	require.Empty(t, n.clusterCommandCh, "an already stopped node must reject admission")
+}
+
+func TestClusterCommandResultAfterStopPreservesCompletedOutcome(t *testing.T) {
+	t.Parallel()
+
+	commandErr := errors.New("command completed with a validation error")
+	terminalErr := &terminalNodeError{cause: errors.New("terminal persistence failure")}
+	for _, tc := range []struct {
+		name     string
+		result   error
+		terminal *terminalNodeError
+		want     error
+	}{
+		{name: "successful result"},
+		{name: "command error", result: commandErr, want: commandErr},
+		{name: "terminal failure takes precedence", terminal: terminalErr, want: terminalErr},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			n := &Node{runDone: make(chan struct{})}
+			cmd := &clusterCommand{errCh: make(chan error, 1)}
+			cmd.errCh <- tc.result
+			if tc.terminal != nil {
+				n.terminalFailure.Store(tc.terminal)
+			}
+			close(n.runDone)
+
+			// Invoke the shutdown branch directly with both signals ready;
+			// scheduler choice cannot turn this into a result-only test.
+			err := n.clusterCommandResultAfterStop(cmd)
+			if tc.want == nil {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tc.want)
+			}
+		})
+	}
+}

--- a/internal/infra/node/node.go
+++ b/internal/infra/node/node.go
@@ -109,29 +109,153 @@ const StaleRaftProgressReason = "STALE_RAFT_PROGRESS"
 // clusterCommand represents an operation that must execute in the orchestrate loop
 // because rawNode is not thread-safe. Implementations return an error via errCh.
 type clusterCommand struct {
-	fn    func() error
-	errCh chan error
+	fn                func() error
+	errCh             chan error
+	waitForCompletion bool
+}
+
+// terminalNodeError marks a command failure that leaves rawNode unsafe to use.
+// The command's caller still receives the underlying error, while orchestrate
+// treats the marker as a task failure and stops the node instead of accepting
+// more work against state that cannot be recovered in place.
+type terminalNodeError struct {
+	cause error
+}
+
+func (e *terminalNodeError) Error() string {
+	return e.cause.Error()
+}
+
+func (e *terminalNodeError) Unwrap() error {
+	return e.cause
 }
 
 // execClusterCommand dispatches a function to the orchestrate loop and waits for its result.
 func (node *Node) execClusterCommand(ctx context.Context, fn func() error) error {
+	return node.execClusterCommandWithOptions(ctx, fn, false)
+}
+
+// execClusterCommandToCompletion honors cancellation until the command is
+// admitted, then waits for its definitive result. ForceRemoveNode uses this
+// because caller cancellation after the irreversible live mutation must not
+// release the caller before a terminal persistence outcome is published.
+func (node *Node) execClusterCommandToCompletion(ctx context.Context, fn func() error) error {
+	return node.execClusterCommandWithOptions(ctx, fn, true)
+}
+
+func (node *Node) execClusterCommandWithOptions(
+	ctx context.Context,
+	fn func() error,
+	waitForCompletion bool,
+) error {
+	if err := node.terminalError(); err != nil {
+		return err
+	}
+
 	cmd := &clusterCommand{
-		fn:    fn,
-		errCh: make(chan error, 1),
+		fn:                fn,
+		errCh:             make(chan error, 1),
+		waitForCompletion: waitForCompletion,
 	}
 
 	select {
 	case node.clusterCommandCh <- cmd:
+	case <-node.terminalCh:
+		return node.terminalErrorFromSignal()
 	case <-ctx.Done():
+		if err := node.terminalError(); err != nil {
+			return err
+		}
+
 		return ctx.Err()
+	}
+
+	if cmd.waitForCompletion {
+		select {
+		case err := <-cmd.errCh:
+			return err
+		case <-node.terminalCh:
+			return node.terminalErrorFromSignal()
+		}
 	}
 
 	select {
 	case err := <-cmd.errCh:
 		return err
+	case <-node.terminalCh:
+		return node.terminalErrorFromSignal()
 	case <-ctx.Done():
+		if err := node.terminalError(); err != nil {
+			return err
+		}
+
 		return ctx.Err()
 	}
+}
+
+func (node *Node) terminalError() error {
+	if failure := node.terminalFailure.Load(); failure != nil {
+		return failure
+	}
+
+	return nil
+}
+
+func (node *Node) terminalErrorFromSignal() error {
+	err := node.terminalError()
+	if err == nil {
+		return errors.New("invariant: terminal signal closed without a node failure")
+	}
+
+	return err
+}
+
+// executeClusterCommand runs on the orchestrate goroutine. A terminal marker
+// is published before the caller is released so no later command or proposal
+// can be admitted in the interval before Run observes the task failure.
+func (node *Node) executeClusterCommand(cmd *clusterCommand) error {
+	err := cmd.fn()
+
+	var terminalErr *terminalNodeError
+	if errors.As(err, &terminalErr) {
+		var rejected []*Proposal
+		node.terminalOnce.Do(func() {
+			node.terminalFailure.Store(terminalErr)
+
+			// No proposal may race the terminal close and escape the drain.
+			// Propose holds proposalAdmissionMu from its terminal check through
+			// enqueue; after terminalFailure is stored, later admissions reject.
+			node.proposalAdmissionMu.Lock()
+			close(node.terminalCh)
+			for {
+				select {
+				case proposal := <-node.proposeCh:
+					rejected = append(rejected, proposal)
+				default:
+					node.proposalAdmissionMu.Unlock()
+
+					return
+				}
+			}
+		})
+
+		for _, proposal := range rejected {
+			node.rejectQueuedProposal(proposal, terminalErr)
+		}
+
+		node.logger.WithFields(map[string]any{
+			"error":             terminalErr,
+			"rejectedProposals": len(rejected),
+		}).Errorf("Terminal Raft command failure; stopping node")
+	}
+
+	cmd.errCh <- err
+
+	if terminalErr != nil {
+		return terminalErr
+	}
+
+	return nil
 }
 
 // LocalResponses is the channel through which the Applier signals to the
@@ -233,6 +357,15 @@ type Node struct {
 	tasks           *taskSet
 	stopChannel     chan chan struct{}
 	runDone         chan struct{} // closed when Run() exits
+	// terminalCh closes when an irreversible live Raft mutation could not be
+	// durably established. New work is rejected immediately while the task
+	// failure propagates through Run and terminates the process.
+	terminalCh      chan struct{}
+	terminalOnce    sync.Once
+	terminalFailure atomic.Pointer[terminalNodeError]
+	// proposalAdmissionMu makes the terminal check plus proposeCh enqueue
+	// atomic with terminal publication and its queued-proposal drain.
+	proposalAdmissionMu sync.Mutex
 	// membership owns the Raft peer-address state (Pebble + in-memory
 	// cache) and the OnSnapshotInstalled / WriteConfChange callbacks
 	// wired into Applier and Machine. EN-1413.
@@ -530,6 +663,7 @@ func NewNode(
 		localResponseCh:  localResponses,
 		tasks:            newTaskSet(),
 		stopChannel:      make(chan chan struct{}),
+		terminalCh:       make(chan struct{}),
 		pendingReads:     &SyncMap[uint64, *readIndexRequest]{},
 		membership:       membership,
 		lastAutoPromote:  make(map[uint64]time.Time),
@@ -1755,7 +1889,9 @@ func (node *Node) orchestrate(ctx context.Context, stop chan struct{}) error {
 			case p := <-node.proposeCh:
 				node.handleProposal(p)
 			case cmd := <-node.clusterCommandCh:
-				cmd.errCh <- cmd.fn()
+				if err := node.executeClusterCommand(cmd); err != nil {
+					return err
+				}
 			default:
 				select {
 				case result := <-node.readyTerminated:
@@ -1835,7 +1971,9 @@ func (node *Node) orchestrate(ctx context.Context, stop chan struct{}) error {
 				case p := <-node.proposeCh:
 					node.handleProposal(p)
 				case cmd := <-node.clusterCommandCh:
-					cmd.errCh <- cmd.fn()
+					if err := node.executeClusterCommand(cmd); err != nil {
+						return err
+					}
 				case err := <-node.applier.TaskError():
 					return fmt.Errorf("task executor error: %w", err)
 				}
@@ -1925,6 +2063,13 @@ func (node *Node) Propose(ctx context.Context, proposal *Proposal) (*futures.Fut
 	ctx, cancel := context.WithTimeout(ctx, proposeTimeout)
 	defer cancel()
 
+	node.proposalAdmissionMu.Lock()
+	defer node.proposalAdmissionMu.Unlock()
+
+	if err := node.terminalError(); err != nil {
+		return nil, err
+	}
+
 	// Create a separate future for Machine results.
 	// The proposal's embedded Future is for Raft consensus (resolved by rawNode.Propose).
 	// The fsmFuture is for Machine processing (resolved when entry is applied).
@@ -1954,6 +2099,16 @@ func (node *Node) Propose(ctx context.Context, proposal *Proposal) (*futures.Fut
 
 		return nil, ctx.Err()
 	}
+}
+
+// rejectQueuedProposal resolves a proposal that was admitted before a terminal
+// command failure but can no longer be handed to rawNode. The admission caller
+// has released the tracker guard before this runs, so Decrement takes the
+// regular synchronized rollback path.
+func (node *Node) rejectQueuedProposal(proposal *Proposal, err error) {
+	node.indexTracker.Decrement(1)
+	node.applier.ResolveDroppedFuture(proposal.commandID, err)
+	proposal.Resolve(nil, err)
 }
 
 // handleProposal sends a proposal to rawNode and rolls back the IndexTracker
@@ -2941,7 +3096,7 @@ func (node *Node) ForceRemoveNode(ctx context.Context, nodeID uint64) error {
 	node.confChangeMu.Lock()
 	defer node.confChangeMu.Unlock()
 
-	return node.execClusterCommand(ctx, func() error {
+	return node.execClusterCommandToCompletion(ctx, func() error {
 		status := node.rawNode.Status()
 		if status.RaftState != raft.StateLeader {
 			return ErrNotLeader
@@ -2988,7 +3143,13 @@ func (node *Node) ForceRemoveNode(ctx context.Context, nodeID uint64) error {
 		// EN-1413.
 		err := node.wal.UpdateSnapshotConfState(cs)
 		if err != nil {
-			return fmt.Errorf("persisting confstate after force-remove: %w", err)
+			// ApplyConfChange has already replaced etcd/raft's active tracker
+			// and removed the peer's Progress. The library has no rollback
+			// primitive; applying an AddNode would create new progress rather
+			// than restore the previous replication state. Continuing would use
+			// a quorum that restart cannot reconstruct, so fail-stop is the only
+			// safe recovery contract.
+			return &terminalNodeError{cause: fmt.Errorf("persisting confstate after force-remove: %w", err)}
 		}
 
 		// EN-1045: when we know the target's identity, land the

--- a/internal/infra/node/node.go
+++ b/internal/infra/node/node.go
@@ -109,9 +109,8 @@ const StaleRaftProgressReason = "STALE_RAFT_PROGRESS"
 // clusterCommand represents an operation that must execute in the orchestrate loop
 // because rawNode is not thread-safe. Implementations return an error via errCh.
 type clusterCommand struct {
-	fn                func() error
-	errCh             chan error
-	waitForCompletion bool
+	fn    func() error
+	errCh chan error
 }
 
 // terminalNodeError marks a command failure that leaves rawNode unsafe to use.
@@ -130,38 +129,38 @@ func (e *terminalNodeError) Unwrap() error {
 	return e.cause
 }
 
-// execClusterCommand dispatches a function to the orchestrate loop and waits for its result.
-func (node *Node) execClusterCommand(ctx context.Context, fn func() error) error {
-	return node.execClusterCommandWithOptions(ctx, fn, false)
-}
-
-// execClusterCommandToCompletion honors cancellation until the command is
-// admitted, then waits for its definitive result. ForceRemoveNode uses this
-// because caller cancellation after the irreversible live mutation must not
-// release the caller before a terminal persistence outcome is published.
-func (node *Node) execClusterCommandToCompletion(ctx context.Context, fn func() error) error {
-	return node.execClusterCommandWithOptions(ctx, fn, true)
-}
-
-func (node *Node) execClusterCommandWithOptions(
+// execClusterCommand dispatches a function to the orchestrate loop and waits for
+// its result. With waitForCompletion, cancellation is honored only until admission.
+// ForceRemoveNode needs the definitive result after its irreversible live mutation
+// so cancellation cannot release its caller before a terminal outcome is published.
+// Run termination also releases waiters: its tasks have stopped, so a command
+// that has no result can no longer execute its mutation.
+func (node *Node) execClusterCommand(
 	ctx context.Context,
-	fn func() error,
 	waitForCompletion bool,
+	fn func() error,
 ) error {
 	if err := node.terminalError(); err != nil {
 		return err
 	}
 
 	cmd := &clusterCommand{
-		fn:                fn,
-		errCh:             make(chan error, 1),
-		waitForCompletion: waitForCompletion,
+		fn:    fn,
+		errCh: make(chan error, 1),
+	}
+
+	select {
+	case <-node.runDone:
+		return node.clusterCommandResultAfterStop(cmd)
+	default:
 	}
 
 	select {
 	case node.clusterCommandCh <- cmd:
 	case <-node.terminalCh:
 		return node.terminalErrorFromSignal()
+	case <-node.runDone:
+		return node.clusterCommandResultAfterStop(cmd)
 	case <-ctx.Done():
 		if err := node.terminalError(); err != nil {
 			return err
@@ -170,12 +169,14 @@ func (node *Node) execClusterCommandWithOptions(
 		return ctx.Err()
 	}
 
-	if cmd.waitForCompletion {
+	if waitForCompletion {
 		select {
 		case err := <-cmd.errCh:
 			return err
 		case <-node.terminalCh:
 			return node.terminalErrorFromSignal()
+		case <-node.runDone:
+			return node.clusterCommandResultAfterStop(cmd)
 		}
 	}
 
@@ -184,12 +185,30 @@ func (node *Node) execClusterCommandWithOptions(
 		return err
 	case <-node.terminalCh:
 		return node.terminalErrorFromSignal()
+	case <-node.runDone:
+		return node.clusterCommandResultAfterStop(cmd)
 	case <-ctx.Done():
 		if err := node.terminalError(); err != nil {
 			return err
 		}
 
 		return ctx.Err()
+	}
+}
+
+// clusterCommandResultAfterStop preserves a definitive result when Run exits
+// before the waiter consumes it. Only a command without a result is stopped;
+// an irreversible persistence failure always takes precedence.
+func (node *Node) clusterCommandResultAfterStop(cmd *clusterCommand) error {
+	if err := node.terminalError(); err != nil {
+		return err
+	}
+
+	select {
+	case err := <-cmd.errCh:
+		return err
+	default:
+		return raft.ErrStopped
 	}
 }
 
@@ -2014,7 +2033,7 @@ func (node *Node) TransferLeader(ctx context.Context, transferee uint64) error {
 		return nil
 	}
 
-	err := node.execClusterCommand(ctx, func() error {
+	err := node.execClusterCommand(ctx, false, func() error {
 		return node.handleTransferLeader(transferee)
 	})
 	if err != nil {
@@ -2233,7 +2252,7 @@ func (node *Node) GetClusterState(ctx context.Context) (*clusterpb.ClusterState,
 		lastPersistedIndex uint64
 	)
 
-	err := node.execClusterCommand(ctx, func() error {
+	err := node.execClusterCommand(ctx, false, func() error {
 		status = node.rawNode.Status()
 		lastPersistedIndex = node.fsm.LastPersistedIndex()
 
@@ -2393,7 +2412,7 @@ func (node *Node) IsStarted() bool {
 func (node *Node) pickBestTransferee(ctx context.Context) (uint64, error) {
 	var best uint64
 
-	err := node.execClusterCommand(ctx, func() error {
+	err := node.execClusterCommand(ctx, false, func() error {
 		status := node.rawNode.Status()
 		if status.RaftState != raft.StateLeader {
 			return ErrNotLeader
@@ -2508,7 +2527,7 @@ func (node *Node) proposeConfChangeAndWait(
 	node.pendingConfChanges.Store(proposalID, pending)
 	defer node.pendingConfChanges.CompareAndDelete(proposalID, pending)
 
-	err := node.execClusterCommand(ctx, proposeFn)
+	err := node.execClusterCommand(ctx, false, proposeFn)
 	if err != nil {
 		return 0, false, err
 	}
@@ -3096,7 +3115,7 @@ func (node *Node) ForceRemoveNode(ctx context.Context, nodeID uint64) error {
 	node.confChangeMu.Lock()
 	defer node.confChangeMu.Unlock()
 
-	return node.execClusterCommandToCompletion(ctx, func() error {
+	return node.execClusterCommand(ctx, true, func() error {
 		status := node.rawNode.Status()
 		if status.RaftState != raft.StateLeader {
 			return ErrNotLeader
@@ -3147,7 +3166,7 @@ func (node *Node) ForceRemoveNode(ctx context.Context, nodeID uint64) error {
 			// and removed the peer's Progress. The library has no rollback
 			// primitive; applying an AddNode would create new progress rather
 			// than restore the previous replication state. Continuing would use
-			// a quorum that restart cannot reconstruct, so fail-stop is the only
+			// a quorum that restart might not reconstruct, so fail-stop is the only
 			// safe recovery contract.
 			return &terminalNodeError{cause: fmt.Errorf("persisting confstate after force-remove: %w", err)}
 		}

--- a/internal/infra/node/read_index.go
+++ b/internal/infra/node/read_index.go
@@ -57,7 +57,7 @@ func (node *Node) ReadIndex(ctx context.Context) (uint64, error) {
 	}
 	node.pendingReads.Store(reqID, req)
 
-	if err := node.execClusterCommand(ctx, func() error {
+	if err := node.execClusterCommand(ctx, false, func() error {
 		// Guard against dispatching ReadIndex when the node is a follower with no
 		// known leader. In that case etcd-raft's stepFollower silently drops the
 		// request and the future would never be resolved, hanging the caller.


### PR DESCRIPTION
## Summary

- fail-stop a node when ForceRemoveNode changes the live raft tracker but snapshot ConfState persistence reports failure
- serialize terminal publication with proposal admission, fail queued proposals and commands, and preserve the definitive force-remove result across caller cancellation
- release an admitted force-removal waiter when the node stops before execution, preserving any completed result
- preserve successful force-removal, pending-removal, normal removal, and restart behavior
- add deterministic live/durable/restart coverage for both snapshot persistence residuals and a four-to-three quorum consequence

Jira: https://formance-team.atlassian.net/browse/EN-1958
Audit: AI-AUDIT:raft-membership-leadership/force-remove-wal-failure-changes-live-quorum

## Bugfix evidence

DISCOVERY: NO_EXISTING_WORK
BEFORE_FIX: BUG_REPRODUCED
AFTER_FIX: PASS
TEST_SENSITIVITY: PASS

The pre-fix probe used the real ForceRemoveNode path and injected failure at UpdateSnapshotConfState. It observed a reduced live RawNode tracker and node ConfState, the previous durable voters, an error response, continued command service, and restart to the previous voter set.

The fixed contract is fail-stop: the irreversible live tracker transition is not rolled back. The persistence error is published as terminal; concurrent queued commands receive that error; queued proposals have both futures failed and their index prediction rolled back; Node.Run propagates the task failure to bootstrap termination.

UpdateSnapshotConfState first replaces its in-memory snapshot, then atomically replaces the snapshot file and appends the etcd WAL snapshot record. The regression drives a real temporary-file creation failure after the in-memory snapshot mutation, which restarts the old membership, and a real failure after replacement at the closed-WAL record write, which restarts the new membership. Neither residual can coexist with a continuing process. A four-to-three test stages an entry that becomes live-committed only after quorum shrinks and proves it is neither durably committed nor applied before fail-stop/restart, for both failure phases. A separate regression runs the complete Node.Run lifecycle and verifies propagation of the original terminal cause.

## Validation

Candidate: `ae204292e5685a78da4e50d225e7fd7522d6acbf`  
Rebased on: `b2b7e7d033daa481cee3f89dfd9669de5b6ed24b` (`release/v3.0`)

- `go test -race ./internal/infra/node -run 'TestForceRemoveNode|TestClusterCommandResultAfterStop' -parallel 2 -count=1 -timeout 5m` — passed under pinned Nix
- `bash scripts/agent-check` — passed
- `AI_REVIEW_BASE_SHA=b2b7e7d033daa481cee3f89dfd9669de5b6ed24b bash scripts/agent-check-pr` — passed, including clean normalization, both lint targets, baseline, and the full node package race suite
- Independent review of this exact candidate: no remaining findings

GitHub CI is the broad clean validation gate. Both blocking review threads are resolved with evidence; a fresh review has been requested from flemzord. No merge has been performed.
