### PR TITLE
fix(restore): join downloads during Fx shutdown

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,10 @@ jobs:
       - name: Run unit tests with coverage
         run: >
           nix develop --command just test-coverage
+      - name: Test restore download Fx lifecycle with the S3 backend
+        run: >
+          nix develop --command go test -race -tags s3 ./internal/bootstrap
+          -run '^TestRestoreDownloadStopsWithFxApplication$' -count=1 -timeout 2m
       - name: Upload coverage profile
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/docs/ops/backup-restore.md
+++ b/docs/ops/backup-restore.md
@@ -377,6 +377,14 @@ The server-side job:
 If the job fails or is cancelled, the staging directory is wiped so the
 operator can retry with a fresh state without restarting the server.
 
+The transfer is detached from the initiating RPC, not from the restore-mode
+application. Fx shutdown first rejects new restore RPCs and cancels any active
+download, then stops the gRPC server, joins admitted RPCs and the download job,
+and finally closes the retained staging Pebble store. Explicit
+`CancelDownload` keeps its client-facing behavior: it cancels only the selected
+job, waits for a bounded drain, and leaves the restore-mode application running
+so the operator can retry.
+
 ### Step 2: Validate
 
 ```bash

--- a/docs/ops/backup-restore.md
+++ b/docs/ops/backup-restore.md
@@ -378,12 +378,23 @@ If the job fails or is cancelled, the staging directory is wiped so the
 operator can retry with a fresh state without restarting the server.
 
 The transfer is detached from the initiating RPC, not from the restore-mode
-application. Fx shutdown first rejects new restore RPCs and cancels any active
-download, then stops the gRPC server, joins admitted RPCs and the download job,
-and finally closes the retained staging Pebble store. Explicit
+application. After any configured shutdown grace period, restore shutdown
+rejects new restore RPCs and cancels any active download, stops the HTTP health
+server and then gRPC, joins admitted RPCs and the download job, and finally
+closes the retained staging Pebble store. Explicit
 `CancelDownload` keeps its client-facing behavior: it cancels only the selected
 job, waits for a bounded drain, and leaves the restore-mode application running
 so the operator can retry.
+
+The join includes failed/canceled-job staging cleanup. Storage-client
+initialization and local filesystem operations do not accept the download
+context, so shutdown waits for them to return. The current service runner
+calls Fx `Stop` with a context without a deadline; `--total-stop-timeout` does
+not bound this path. A slow cleanup or backend can therefore delay process
+exit. Forced termination can interrupt cleanup and leave staging files or an
+uncleanly closed staging store; size the process termination grace period
+accordingly. Staging-store close errors are logged under the existing close
+policy and are not returned by the restore stop hook.
 
 ### Step 2: Validate
 

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -3599,7 +3599,9 @@ detached from any individual RPC and therefore survives ingress / load-balancer
 idle or max-stream timeouts (1.2 TB restores routinely take several hours).
 Press `Ctrl+C` to cancel the running download cleanly — the CLI issues a
 server-side `CancelDownload` so the staging directory is wiped before the
-process exits.
+process exits. Stopping the restore-mode server also cancels and joins the
+active job before its staging resources are closed; RPC detachment never lets
+the transfer outlive the server application.
 
 The server downloads files in parallel; tune the worker count with the server
 flag `--restore-download-parallelism` (default 16, clamped to `[1, 64]`).

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -3600,8 +3600,11 @@ idle or max-stream timeouts (1.2 TB restores routinely take several hours).
 Press `Ctrl+C` to cancel the running download cleanly — the CLI issues a
 server-side `CancelDownload` so the staging directory is wiped before the
 process exits. Stopping the restore-mode server also cancels and joins the
-active job before its staging resources are closed; RPC detachment never lets
-the transfer outlive the server application.
+active job before its staging resources are closed. The current service runner
+passes no deadline to Fx `Stop`, so `--total-stop-timeout` does not bound this
+join. Backend initialization or staging cleanup can delay exit; forced process
+termination can leave staging files or an uncleanly closed staging store. See
+[restore shutdown](backup-restore.md#step-1-download) for the cleanup sequence.
 
 The server downloads files in parallel; tune the worker count with the server
 flag `--restore-download-parallelism` (default 16, clamped to `[1, 64]`).

--- a/docs/technical/architecture/subsystems/api/README.md
+++ b/docs/technical/architecture/subsystems/api/README.md
@@ -6,7 +6,7 @@ Client-facing transport layers (`internal/adapter/grpc`, `internal/adapter/http`
 
 | Document | Description |
 |----------|-------------|
-| [grpc-api.md](grpc-api.md) | gRPC service, methods, request/response types, and client examples. |
+| [grpc-api.md](grpc-api.md) | gRPC service, methods, request/response types, client examples, and restore-mode service lifetime. |
 | [grpc-connections.md](grpc-connections.md) | gRPC connection mechanics, reconnection, and rolling deployment optimizations. |
 | [http-api.md](http-api.md) | HTTP REST API endpoints, response formats, and error handling. |
 | [auth.md](auth.md) | Client JWT authentication (OIDC + Ed25519), scope-based authorization, and the Raft inter-node cluster-secret auth layer. |

--- a/docs/technical/architecture/subsystems/api/grpc-api.md
+++ b/docs/technical/architecture/subsystems/api/grpc-api.md
@@ -8,6 +8,20 @@ The gRPC API provides a programmatic interface for interacting with the ledger c
 2. **Inter-node communication**: Request forwarding from followers to the leader
 3. **CLI tools**: The `ledgerctl` command-line tool uses gRPC
 
+### Restore-mode service lifetime
+
+`RestoreService.StartDownloadBackup` deliberately detaches the transfer from
+the initiating RPC so multi-hour downloads survive intermediary timeouts. The
+job remains a child of the restore-mode application's lifetime. On Fx shutdown,
+restore admission closes and the job context is canceled before the network
+servers stop; after gRPC stops, the service joins every admitted RPC and the
+download job before closing its retained staging Pebble store. No join waits
+while holding the service mutex used by job completion.
+
+Explicit `CancelDownload` is narrower: it cancels the selected job, performs a
+bounded wait for that job to drain, and leaves the restore-mode application
+running so another download can be attempted.
+
 ## Connection
 
 ### Default Port

--- a/docs/technical/architecture/subsystems/api/grpc-api.md
+++ b/docs/technical/architecture/subsystems/api/grpc-api.md
@@ -13,10 +13,20 @@ The gRPC API provides a programmatic interface for interacting with the ledger c
 `RestoreService.StartDownloadBackup` deliberately detaches the transfer from
 the initiating RPC so multi-hour downloads survive intermediary timeouts. The
 job remains a child of the restore-mode application's lifetime. On Fx shutdown,
-restore admission closes and the job context is canceled before the network
-servers stop; after gRPC stops, the service joins every admitted RPC and the
+restore admission closes and the job context is canceled after any configured
+grace period and before the HTTP health server and then gRPC stop. The service
+then joins every admitted RPC and the
 download job before closing its retained staging Pebble store. No join waits
 while holding the service mutex used by job completion.
+
+Each completed job cancels its own child context before signaling completion,
+so retries do not retain completed jobs under the service lifetime context.
+The production runner calls Fx `Stop` with no deadline, so its configured
+`StopTimeout` does not bound this join. Synchronous client initialization and
+filesystem cleanup must return before shutdown can finish. A custom embedder
+that supplies a deadline to Fx `Stop` can receive a deadline error while a hook
+is still running, and remaining hooks may be skipped. Forced process exit can
+therefore leave staging files or an uncleanly closed staging store.
 
 Explicit `CancelDownload` is narrower: it cancels the selected job, performs a
 bounded wait for that job to drain, and leaves the restore-mode application

--- a/docs/technical/contributing/testing.md
+++ b/docs/technical/contributing/testing.md
@@ -655,6 +655,16 @@ plain `-tags e2e` run neither builds nor runs them:
 | `nats` | NATS event sink | none (embedded in-process server) |
 | `databricks` | Databricks event sink | real workspace credentials; skips itself when unset |
 
+The bootstrap regression `TestRestoreDownloadStopsWithFxApplication` also needs
+the `s3` tag to compile the production S3 backend, but uses an in-process HTTP
+server and requires no MinIO or Docker. CI's `Tests` job runs it separately with
+the race detector:
+
+```bash
+nix develop --command go test -race -tags s3 ./internal/bootstrap \
+  -run '^TestRestoreDownloadStopsWithFxApplication$' -count=1 -timeout 2m
+```
+
 `just test-e2e` runs the light set for a fast local loop. **CI runs the full tag
 set** through separate isolated Business and Cluster invocations of
 `just test-e2e-coverage`, so a green `just test-e2e` does not guarantee a green

--- a/internal/adapter/grpc/server_restore.go
+++ b/internal/adapter/grpc/server_restore.go
@@ -127,13 +127,17 @@ func clampParallelism(v int) int {
 type RestoreServiceServerImpl struct {
 	restorepb.UnimplementedRestoreServiceServer
 
-	mu          sync.Mutex
-	dataDir     string
-	clusterID   string
-	parallelism int // effective per-job worker count, already clamped
-	logger      logging.Logger
-	downloading bool
-	downloaded  bool
+	mu             sync.Mutex
+	activeRequests sync.WaitGroup
+	dataDir        string
+	clusterID      string
+	parallelism    int // effective per-job worker count, already clamped
+	logger         logging.Logger
+	lifetimeCtx    context.Context
+	lifetimeCancel context.CancelFunc
+	stopping       bool
+	downloading    bool
+	downloaded     bool
 
 	// job holds the single active download (if any). Only one job runs at a
 	// time because the staging directory is a singleton. Successive Start
@@ -165,12 +169,81 @@ type RestoreServiceServerImpl struct {
 // caps concurrent S3 file downloads during the async download phase; 0 falls
 // back to the default and out-of-range values are clamped to [1, 64].
 func NewRestoreServiceServer(dataDir, clusterID string, parallelism int, logger logging.Logger) *RestoreServiceServerImpl {
+	lifetimeCtx, lifetimeCancel := context.WithCancel(context.Background())
+
 	return &RestoreServiceServerImpl{
-		dataDir:     dataDir,
-		clusterID:   clusterID,
-		parallelism: clampParallelism(parallelism),
-		logger:      logger,
+		dataDir:        dataDir,
+		clusterID:      clusterID,
+		parallelism:    clampParallelism(parallelism),
+		logger:         logger,
+		lifetimeCtx:    lifetimeCtx,
+		lifetimeCancel: lifetimeCancel,
 	}
+}
+
+// beginRequest admits a restore RPC while the service is running. The
+// stopping check and WaitGroup registration share s.mu with BeginShutdown, so
+// shutdown cannot observe zero requests and then race with a late Add.
+func (s *RestoreServiceServerImpl) beginRequest() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.stopping {
+		return status.Error(codes.Unavailable, "restore service is shutting down")
+	}
+
+	s.activeRequests.Add(1)
+
+	return nil
+}
+
+func (s *RestoreServiceServerImpl) endRequest() {
+	s.activeRequests.Done()
+}
+
+// BeginShutdown closes restore admission and cancels the application-owned
+// context used by asynchronous downloads. It is idempotent and deliberately
+// does not wait: restore mode calls it before stopping gRPC, then calls
+// Shutdown after gRPC has stopped accepting requests.
+func (s *RestoreServiceServerImpl) BeginShutdown() {
+	s.mu.Lock()
+	if s.stopping {
+		s.mu.Unlock()
+
+		return
+	}
+
+	s.stopping = true
+	cancel := s.lifetimeCancel
+	s.mu.Unlock()
+
+	cancel()
+}
+
+// Shutdown joins every request admitted before BeginShutdown and the one
+// asynchronous download job, then closes the retained staging store. Waiting
+// happens without s.mu because job completion takes that mutex in finishJob.
+//
+// The join intentionally does not stop at the Fx deadline: returning while a
+// storage client is still unwinding would let later teardown outlive and race
+// the application's restore resources. Download backends are required to
+// honor the canceled context; if one violates that contract, shutdown must
+// remain visibly stuck rather than claim that teardown completed safely.
+func (s *RestoreServiceServerImpl) Shutdown() {
+	s.BeginShutdown()
+	s.activeRequests.Wait()
+
+	s.mu.Lock()
+	job := s.job
+	s.mu.Unlock()
+
+	if job != nil {
+		<-job.done
+	}
+
+	s.mu.Lock()
+	s.closeStagingStore()
+	s.mu.Unlock()
 }
 
 func (s *RestoreServiceServerImpl) stagingDir() string {
@@ -193,6 +266,11 @@ func (s *RestoreServiceServerImpl) closeStagingStore() {
 
 // ValidateRestore runs integrity checks on the staged backup data.
 func (s *RestoreServiceServerImpl) ValidateRestore(_ *restorepb.ValidateRestoreRequest, stream ggrpc.ServerStreamingServer[restorepb.ValidateRestoreEvent]) error {
+	if err := s.beginRequest(); err != nil {
+		return err
+	}
+	defer s.endRequest()
+
 	s.mu.Lock()
 	downloaded := s.downloaded
 	store := s.stagingStore
@@ -250,6 +328,11 @@ func (s *RestoreServiceServerImpl) ValidateRestore(_ *restorepb.ValidateRestoreR
 
 // PreviewRestore returns a summary of the staged backup data.
 func (s *RestoreServiceServerImpl) PreviewRestore(ctx context.Context, _ *restorepb.PreviewRestoreRequest) (*restorepb.PreviewRestoreResponse, error) {
+	if err := s.beginRequest(); err != nil {
+		return nil, err
+	}
+	defer s.endRequest()
+
 	s.mu.Lock()
 	downloaded := s.downloaded
 	store := s.stagingStore
@@ -313,6 +396,11 @@ func (s *RestoreServiceServerImpl) PreviewRestore(ctx context.Context, _ *restor
 
 // FinalizeRestore prepares the staged backup (Global-zone resets) and commits it as the live data.
 func (s *RestoreServiceServerImpl) FinalizeRestore(_ context.Context, _ *restorepb.FinalizeRestoreRequest) (*restorepb.FinalizeRestoreResponse, error) {
+	if err := s.beginRequest(); err != nil {
+		return nil, err
+	}
+	defer s.endRequest()
+
 	s.mu.Lock()
 	downloaded := s.downloaded
 	store := s.stagingStore

--- a/internal/adapter/grpc/server_restore.go
+++ b/internal/adapter/grpc/server_restore.go
@@ -224,11 +224,12 @@ func (s *RestoreServiceServerImpl) BeginShutdown() {
 // asynchronous download job, then closes the retained staging store. Waiting
 // happens without s.mu because job completion takes that mutex in finishJob.
 //
-// The join intentionally does not stop at the Fx deadline: returning while a
+// The join has no internal deadline: returning while a
 // storage client is still unwinding would let later teardown outlive and race
-// the application's restore resources. Download backends are required to
-// honor the canceled context; if one violates that contract, shutdown must
-// remain visibly stuck rather than claim that teardown completed safely.
+// the application's restore resources. The production service runner calls
+// Fx Stop with a context without a deadline. Shutdown also waits for synchronous
+// storage-client initialization and filesystem cleanup to return. A caller that
+// supplies its own Fx Stop deadline can return before teardown finishes.
 func (s *RestoreServiceServerImpl) Shutdown() {
 	s.BeginShutdown()
 	s.activeRequests.Wait()

--- a/internal/adapter/grpc/server_restore_download.go
+++ b/internal/adapter/grpc/server_restore_download.go
@@ -67,7 +67,20 @@ var errCanceled = errors.New("download canceled")
 // happens on a goroutine detached from the calling RPC context so it survives
 // any ingress / load balancer timeout. See issue #349.
 func (s *RestoreServiceServerImpl) StartDownloadBackup(_ context.Context, req *restorepb.StartDownloadBackupRequest) (*restorepb.StartDownloadBackupResponse, error) {
+	if err := s.beginRequest(); err != nil {
+		return nil, err
+	}
+	defer s.endRequest()
+
 	s.mu.Lock()
+	// beginRequest may have admitted this RPC immediately before shutdown set
+	// stopping. Recheck at the job-registration boundary so no job can be
+	// created after BeginShutdown observes the service.
+	if s.stopping {
+		s.mu.Unlock()
+
+		return nil, status.Error(codes.Unavailable, "restore service is shutting down")
+	}
 
 	if s.downloaded {
 		s.mu.Unlock()
@@ -81,7 +94,9 @@ func (s *RestoreServiceServerImpl) StartDownloadBackup(_ context.Context, req *r
 		return nil, status.Error(codes.FailedPrecondition, "another download is already in progress")
 	}
 
-	jobCtx, cancel := context.WithCancel(context.Background())
+	// The job is detached from the initiating RPC but remains a child of the
+	// restore-mode application's lifetime.
+	jobCtx, cancel := context.WithCancel(s.lifetimeCtx)
 
 	job := &downloadJob{
 		id:        uuid.NewString(),
@@ -109,6 +124,11 @@ func (s *RestoreServiceServerImpl) StartDownloadBackup(_ context.Context, req *r
 // StartDownloadBackup. Once the job reaches a terminal state (SUCCEEDED,
 // FAILED, CANCELED) the response stays stable.
 func (s *RestoreServiceServerImpl) GetDownloadStatus(_ context.Context, req *restorepb.GetDownloadStatusRequest) (*restorepb.GetDownloadStatusResponse, error) {
+	if err := s.beginRequest(); err != nil {
+		return nil, err
+	}
+	defer s.endRequest()
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -140,6 +160,11 @@ func (s *RestoreServiceServerImpl) GetDownloadStatus(_ context.Context, req *res
 // directory is wiped so the operator can immediately retry without having to
 // restart the server.
 func (s *RestoreServiceServerImpl) CancelDownload(_ context.Context, req *restorepb.CancelDownloadRequest) (*restorepb.CancelDownloadResponse, error) {
+	if err := s.beginRequest(); err != nil {
+		return nil, err
+	}
+	defer s.endRequest()
+
 	s.mu.Lock()
 
 	job := s.job

--- a/internal/adapter/grpc/server_restore_download.go
+++ b/internal/adapter/grpc/server_restore_download.go
@@ -209,6 +209,9 @@ func (s *RestoreServiceServerImpl) runDownloadJob(
 	factory storageFactory,
 ) {
 	defer close(job.done)
+	// Release this child from the service lifetime context on every terminal
+	// path, including success and failure without an explicit cancellation.
+	defer job.cancel()
 
 	storage, manifest, err := s.prepareDownload(ctx, req, factory)
 	if err != nil {

--- a/internal/adapter/grpc/server_restore_lifecycle_test.go
+++ b/internal/adapter/grpc/server_restore_lifecycle_test.go
@@ -1,0 +1,435 @@
+package grpc
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/formancehq/ledger/v3/internal/infra/backup"
+	"github.com/formancehq/ledger/v3/internal/proto/restorepb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+type cancellationBlockingReader struct {
+	ctx      context.Context
+	started  chan struct{}
+	canceled chan struct{}
+	release  chan struct{}
+	closed   chan struct{}
+	start    sync.Once
+	cancel   sync.Once
+	unblock  sync.Once
+	close    sync.Once
+}
+
+func newCancellationBlockingReader(ctx context.Context) *cancellationBlockingReader {
+	return &cancellationBlockingReader{
+		ctx:      ctx,
+		started:  make(chan struct{}),
+		canceled: make(chan struct{}),
+		release:  make(chan struct{}),
+		closed:   make(chan struct{}),
+	}
+}
+
+func (r *cancellationBlockingReader) Read(_ []byte) (int, error) {
+	r.start.Do(func() { close(r.started) })
+	<-r.ctx.Done()
+	r.cancel.Do(func() { close(r.canceled) })
+	<-r.release
+
+	return 0, r.ctx.Err()
+}
+
+func (r *cancellationBlockingReader) Close() error {
+	r.close.Do(func() { close(r.closed) })
+
+	return nil
+}
+
+func (r *cancellationBlockingReader) allowUnwind() {
+	r.unblock.Do(func() { close(r.release) })
+}
+
+func startBlockedRestoreDownload(t *testing.T) (*RestoreServiceServerImpl, *downloadJob, *cancellationBlockingReader) {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	storage := NewMockStorage(ctrl)
+	readerReady := make(chan *cancellationBlockingReader, 1)
+	storage.EXPECT().
+		GetFile(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, _ string) (io.ReadCloser, error) {
+			reader := newCancellationBlockingReader(ctx)
+			readerReady <- reader
+
+			return reader, nil
+		})
+
+	server := newServerForTest(t, staticFactory(storage))
+	_, err := server.StartDownloadBackup(context.Background(), &restorepb.StartDownloadBackupRequest{})
+	require.NoError(t, err)
+
+	reader := <-readerReady
+	<-reader.started
+
+	server.mu.Lock()
+	job := server.job
+	server.mu.Unlock()
+	require.NotNil(t, job)
+	t.Cleanup(func() {
+		reader.allowUnwind()
+		server.Shutdown()
+	})
+
+	return server, job, reader
+}
+
+func TestRestoreShutdownCancelsAndJoinsActiveDownload(t *testing.T) {
+	t.Parallel()
+
+	server, job, reader := startBlockedRestoreDownload(t)
+	server.BeginShutdown()
+	<-reader.canceled
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		server.Shutdown()
+		close(shutdownDone)
+	}()
+
+	select {
+	case <-shutdownDone:
+		t.Fatal("shutdown returned before the canceled download unwound")
+	default:
+	}
+	select {
+	case <-reader.closed:
+		t.Fatal("the download resource closed before its owner unwound")
+	default:
+	}
+
+	_, err := server.StartDownloadBackup(context.Background(), &restorepb.StartDownloadBackupRequest{})
+	require.Equal(t, codes.Unavailable, status.Code(err))
+
+	reader.allowUnwind()
+	select {
+	case <-shutdownDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("shutdown did not join the canceled download")
+	}
+
+	select {
+	case <-reader.closed:
+	default:
+		t.Fatal("download resource was not closed during unwind")
+	}
+	select {
+	case <-job.done:
+	default:
+		t.Fatal("shutdown returned before the download job terminated")
+	}
+
+	server.mu.Lock()
+	state := job.state
+	server.mu.Unlock()
+	require.Equal(t, restorepb.DownloadState_DOWNLOAD_STATE_CANCELED, state)
+}
+
+func TestRestoreDownloadOutlivesInitiatingRPC(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	storage := NewMockStorage(ctrl)
+	readerReady := make(chan *cancellationBlockingReader, 1)
+	storage.EXPECT().
+		GetFile(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(ctx context.Context, _ string) (io.ReadCloser, error) {
+			reader := newCancellationBlockingReader(ctx)
+			readerReady <- reader
+
+			return reader, nil
+		})
+
+	server := newServerForTest(t, staticFactory(storage))
+	rpcCtx, cancelRPC := context.WithCancel(context.Background())
+	started, err := server.StartDownloadBackup(rpcCtx, &restorepb.StartDownloadBackupRequest{})
+	require.NoError(t, err)
+
+	reader := <-readerReady
+	<-reader.started
+	t.Cleanup(func() {
+		reader.allowUnwind()
+		server.Shutdown()
+	})
+	cancelRPC()
+
+	select {
+	case <-reader.canceled:
+		t.Fatal("initiating RPC cancellation reached the detached download")
+	default:
+	}
+
+	cancelDone := make(chan error, 1)
+	go func() {
+		_, err := server.CancelDownload(context.Background(), &restorepb.CancelDownloadRequest{JobId: started.GetJobId()})
+		cancelDone <- err
+	}()
+	<-reader.canceled
+	reader.allowUnwind()
+
+	select {
+	case err := <-cancelDone:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("explicit cancellation did not join the download")
+	}
+
+	server.Shutdown()
+}
+
+func TestRestoreShutdownWaitsForAdmittedRequestBeforeClosingStagingStore(t *testing.T) {
+	t.Parallel()
+
+	server := NewRestoreServiceServer(t.TempDir(), "test-cluster", 1, noopLogger{})
+	store, err := dal.OpenDirect(server.stagingDir(), noopLogger{})
+	require.NoError(t, err)
+
+	server.mu.Lock()
+	server.stagingStore = store
+	server.downloaded = true
+	server.mu.Unlock()
+	require.NoError(t, server.beginRequest())
+
+	server.BeginShutdown()
+	shutdownDone := make(chan struct{})
+	go func() {
+		server.Shutdown()
+		close(shutdownDone)
+	}()
+
+	select {
+	case <-shutdownDone:
+		t.Fatal("shutdown returned while an admitted restore request was active")
+	default:
+	}
+
+	handle, err := store.NewDirectReadHandle()
+	require.NoError(t, err, "staging store must remain valid while the request unwinds")
+	require.NoError(t, handle.Close())
+
+	server.endRequest()
+	select {
+	case <-shutdownDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("shutdown did not finish after the request drained")
+	}
+
+	server.mu.Lock()
+	retained := server.stagingStore
+	server.mu.Unlock()
+	require.Nil(t, retained)
+
+	_, err = store.NewDirectReadHandle()
+	require.Error(t, err, "shutdown must close the retained staging store")
+
+	// Repeated shutdown is a no-op: it must not double-close or panic.
+	server.BeginShutdown()
+	server.Shutdown()
+}
+
+func TestRestoreShutdownWithoutActiveWorkClosesStagingStore(t *testing.T) {
+	t.Parallel()
+
+	server := NewRestoreServiceServer(t.TempDir(), "test-cluster", 1, noopLogger{})
+	store, err := dal.OpenDirect(server.stagingDir(), noopLogger{})
+	require.NoError(t, err)
+
+	server.mu.Lock()
+	server.stagingStore = store
+	server.downloaded = true
+	server.mu.Unlock()
+
+	server.Shutdown()
+
+	server.mu.Lock()
+	retained := server.stagingStore
+	server.mu.Unlock()
+	require.Nil(t, retained)
+
+	_, err = store.NewDirectReadHandle()
+	require.Error(t, err)
+}
+
+func TestRestoreDownloadRemainsAsynchronousAndSucceeds(t *testing.T) {
+	t.Parallel()
+
+	manifest, objects := restoreCheckpointFixture(t)
+	manifestData, err := json.Marshal(manifest)
+	require.NoError(t, err)
+
+	ctrl := gomock.NewController(t)
+	storage := NewMockStorage(ctrl)
+	manifestRequested := make(chan struct{})
+	releaseManifest := make(chan struct{})
+	var requested sync.Once
+
+	storage.EXPECT().
+		GetFile(gomock.Any(), gomock.Any()).
+		AnyTimes().
+		DoAndReturn(func(_ context.Context, key string) (io.ReadCloser, error) {
+			if strings.HasSuffix(key, "/backups/manifest.json") {
+				requested.Do(func() { close(manifestRequested) })
+				<-releaseManifest
+
+				return io.NopCloser(bytes.NewReader(manifestData)), nil
+			}
+
+			data, ok := objects[key]
+			if !ok {
+				return nil, fmt.Errorf("unexpected storage key %q", key)
+			}
+
+			return io.NopCloser(bytes.NewReader(data)), nil
+		})
+
+	server := newServerForTest(t, staticFactory(storage))
+	t.Cleanup(server.Shutdown)
+	started, err := server.StartDownloadBackup(context.Background(), &restorepb.StartDownloadBackupRequest{})
+	require.NoError(t, err)
+	require.NotEmpty(t, started.GetJobId())
+	<-manifestRequested
+
+	server.mu.Lock()
+	job := server.job
+	server.mu.Unlock()
+	select {
+	case <-job.done:
+		t.Fatal("StartDownloadBackup did not leave the transfer asynchronous")
+	default:
+	}
+
+	close(releaseManifest)
+	select {
+	case <-job.done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("successful download did not terminate")
+	}
+
+	server.mu.Lock()
+	state := job.state
+	store := server.stagingStore
+	downloaded := server.downloaded
+	server.mu.Unlock()
+	require.Equal(t, restorepb.DownloadState_DOWNLOAD_STATE_SUCCEEDED, state)
+	require.True(t, downloaded)
+	require.NotNil(t, store)
+
+	handle, err := store.NewDirectReadHandle()
+	require.NoError(t, err)
+	require.NoError(t, handle.Close())
+
+	server.Shutdown()
+	_, err = store.NewDirectReadHandle()
+	require.Error(t, err)
+}
+
+func TestCancelDownloadAndShutdownCanCompete(t *testing.T) {
+	t.Parallel()
+
+	server, job, reader := startBlockedRestoreDownload(t)
+	cancelDone := make(chan error, 1)
+	go func() {
+		_, err := server.CancelDownload(context.Background(), &restorepb.CancelDownloadRequest{JobId: job.id})
+		cancelDone <- err
+	}()
+	<-reader.canceled
+
+	server.BeginShutdown()
+	shutdownDone := make(chan struct{})
+	go func() {
+		server.Shutdown()
+		close(shutdownDone)
+	}()
+
+	select {
+	case err := <-cancelDone:
+		require.NoError(t, err)
+		t.Fatal("CancelDownload returned before the job unwound")
+	default:
+	}
+	select {
+	case <-shutdownDone:
+		t.Fatal("shutdown returned before competing cancellation unwound")
+	default:
+	}
+
+	reader.allowUnwind()
+	select {
+	case err := <-cancelDone:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("CancelDownload did not return")
+	}
+	select {
+	case <-shutdownDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("shutdown did not return")
+	}
+
+	server.BeginShutdown()
+	server.Shutdown()
+}
+
+func restoreCheckpointFixture(t *testing.T) (*backup.Manifest, map[string][]byte) {
+	t.Helper()
+
+	sourceDir := filepath.Join(t.TempDir(), "source")
+	store, err := dal.OpenDirect(sourceDir, noopLogger{})
+	require.NoError(t, err)
+	require.NoError(t, store.Close())
+
+	files := map[string]backup.CheckpointFile{}
+	objects := map[string][]byte{}
+	err = filepath.WalkDir(sourceDir, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if !entry.Type().IsRegular() {
+			return nil
+		}
+
+		rel, relErr := filepath.Rel(sourceDir, path)
+		if relErr != nil {
+			return relErr
+		}
+		name := filepath.ToSlash(rel)
+		key := "fixture/" + name
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+
+		files[name] = backup.CheckpointFile{Size: int64(len(data)), Key: key}
+		objects[key] = data
+
+		return nil
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, files)
+
+	return &backup.Manifest{Checkpoint: &backup.CheckpointManifest{Files: files}}, objects
+}

--- a/internal/adapter/grpc/server_restore_lifecycle_test.go
+++ b/internal/adapter/grpc/server_restore_lifecycle_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -100,105 +102,115 @@ func startBlockedRestoreDownload(t *testing.T) (*RestoreServiceServerImpl, *down
 
 func TestRestoreShutdownCancelsAndJoinsActiveDownload(t *testing.T) {
 	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		server, job, reader := startBlockedRestoreDownload(t)
+		server.BeginShutdown()
+		<-reader.canceled
 
-	server, job, reader := startBlockedRestoreDownload(t)
-	server.BeginShutdown()
-	<-reader.canceled
+		shutdownDone := make(chan struct{})
+		go func() {
+			server.Shutdown()
+			close(shutdownDone)
+		}()
+		// Wait until shutdown has either joined the blocked job or returned early.
+		synctest.Wait()
 
-	shutdownDone := make(chan struct{})
-	go func() {
-		server.Shutdown()
-		close(shutdownDone)
-	}()
+		select {
+		case <-shutdownDone:
+			t.Fatal("shutdown returned before the canceled download unwound")
+		default:
+		}
+		select {
+		case <-reader.closed:
+			t.Fatal("the download resource closed before its owner unwound")
+		default:
+		}
 
-	select {
-	case <-shutdownDone:
-		t.Fatal("shutdown returned before the canceled download unwound")
-	default:
-	}
-	select {
-	case <-reader.closed:
-		t.Fatal("the download resource closed before its owner unwound")
-	default:
-	}
+		_, err := server.StartDownloadBackup(context.Background(), &restorepb.StartDownloadBackupRequest{})
+		require.Equal(t, codes.Unavailable, status.Code(err))
 
-	_, err := server.StartDownloadBackup(context.Background(), &restorepb.StartDownloadBackupRequest{})
-	require.Equal(t, codes.Unavailable, status.Code(err))
+		reader.allowUnwind()
+		select {
+		case <-shutdownDone:
+		case <-time.After(10 * time.Second):
+			t.Fatal("shutdown did not join the canceled download")
+		}
 
-	reader.allowUnwind()
-	select {
-	case <-shutdownDone:
-	case <-time.After(10 * time.Second):
-		t.Fatal("shutdown did not join the canceled download")
-	}
+		select {
+		case <-reader.closed:
+		default:
+			t.Fatal("download resource was not closed during unwind")
+		}
+		select {
+		case <-job.done:
+		default:
+			t.Fatal("shutdown returned before the download job terminated")
+		}
 
-	select {
-	case <-reader.closed:
-	default:
-		t.Fatal("download resource was not closed during unwind")
-	}
-	select {
-	case <-job.done:
-	default:
-		t.Fatal("shutdown returned before the download job terminated")
-	}
-
-	server.mu.Lock()
-	state := job.state
-	server.mu.Unlock()
-	require.Equal(t, restorepb.DownloadState_DOWNLOAD_STATE_CANCELED, state)
+		server.mu.Lock()
+		state := job.state
+		server.mu.Unlock()
+		require.Equal(t, restorepb.DownloadState_DOWNLOAD_STATE_CANCELED, state)
+	})
 }
 
 func TestRestoreDownloadOutlivesInitiatingRPC(t *testing.T) {
 	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		storage := NewMockStorage(ctrl)
+		readerReady := make(chan *cancellationBlockingReader, 1)
+		storage.EXPECT().
+			GetFile(gomock.Any(), gomock.Any()).
+			DoAndReturn(func(ctx context.Context, _ string) (io.ReadCloser, error) {
+				reader := newCancellationBlockingReader(ctx)
+				readerReady <- reader
 
-	ctrl := gomock.NewController(t)
-	storage := NewMockStorage(ctrl)
-	readerReady := make(chan *cancellationBlockingReader, 1)
-	storage.EXPECT().
-		GetFile(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(ctx context.Context, _ string) (io.ReadCloser, error) {
-			reader := newCancellationBlockingReader(ctx)
-			readerReady <- reader
+				return reader, nil
+			})
 
-			return reader, nil
+		server := newServerForTest(t, staticFactory(storage))
+		rpcCtx, cancelRPC := context.WithCancel(context.Background())
+		started, err := server.StartDownloadBackup(rpcCtx, &restorepb.StartDownloadBackupRequest{})
+		require.NoError(t, err)
+
+		reader := <-readerReady
+		<-reader.started
+		t.Cleanup(func() {
+			reader.allowUnwind()
+			server.Shutdown()
 		})
+		cancelRPC()
 
-	server := newServerForTest(t, staticFactory(storage))
-	rpcCtx, cancelRPC := context.WithCancel(context.Background())
-	started, err := server.StartDownloadBackup(rpcCtx, &restorepb.StartDownloadBackupRequest{})
-	require.NoError(t, err)
+		// Drain runnable cancellation work before asserting that the job remains live.
+		synctest.Wait()
+		select {
+		case <-reader.canceled:
+			t.Fatal("initiating RPC cancellation reached the detached download")
+		default:
+		}
+		downloadStatus, err := server.GetDownloadStatus(context.Background(), &restorepb.GetDownloadStatusRequest{JobId: started.GetJobId()})
+		require.NoError(t, err)
+		// The job is still waiting for its manifest, before the RUNNING transition.
+		require.Equal(t, restorepb.DownloadState_DOWNLOAD_STATE_PENDING, downloadStatus.GetState())
 
-	reader := <-readerReady
-	<-reader.started
-	t.Cleanup(func() {
+		cancelDone := make(chan error, 1)
+		go func() {
+			_, err := server.CancelDownload(context.Background(), &restorepb.CancelDownloadRequest{JobId: started.GetJobId()})
+			cancelDone <- err
+		}()
+		<-reader.canceled
 		reader.allowUnwind()
+
+		select {
+		case err := <-cancelDone:
+			require.NoError(t, err)
+		case <-time.After(10 * time.Second):
+			t.Fatal("explicit cancellation did not join the download")
+		}
+
 		server.Shutdown()
 	})
-	cancelRPC()
-
-	select {
-	case <-reader.canceled:
-		t.Fatal("initiating RPC cancellation reached the detached download")
-	default:
-	}
-
-	cancelDone := make(chan error, 1)
-	go func() {
-		_, err := server.CancelDownload(context.Background(), &restorepb.CancelDownloadRequest{JobId: started.GetJobId()})
-		cancelDone <- err
-	}()
-	<-reader.canceled
-	reader.allowUnwind()
-
-	select {
-	case err := <-cancelDone:
-		require.NoError(t, err)
-	case <-time.After(10 * time.Second):
-		t.Fatal("explicit cancellation did not join the download")
-	}
-
-	server.Shutdown()
 }
 
 func TestRestoreShutdownWaitsForAdmittedRequestBeforeClosingStagingStore(t *testing.T) {
@@ -283,16 +295,18 @@ func TestRestoreDownloadRemainsAsynchronousAndSucceeds(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	storage := NewMockStorage(ctrl)
-	manifestRequested := make(chan struct{})
+	manifestRequested := make(chan context.Context, 1)
 	releaseManifest := make(chan struct{})
 	var requested sync.Once
 
 	storage.EXPECT().
 		GetFile(gomock.Any(), gomock.Any()).
 		AnyTimes().
-		DoAndReturn(func(_ context.Context, key string) (io.ReadCloser, error) {
+		DoAndReturn(func(ctx context.Context, key string) (io.ReadCloser, error) {
 			if strings.HasSuffix(key, "/backups/manifest.json") {
-				requested.Do(func() { close(manifestRequested) })
+				requested.Do(func() {
+					manifestRequested <- ctx
+				})
 				<-releaseManifest
 
 				return io.NopCloser(bytes.NewReader(manifestData)), nil
@@ -311,7 +325,7 @@ func TestRestoreDownloadRemainsAsynchronousAndSucceeds(t *testing.T) {
 	started, err := server.StartDownloadBackup(context.Background(), &restorepb.StartDownloadBackupRequest{})
 	require.NoError(t, err)
 	require.NotEmpty(t, started.GetJobId())
-	<-manifestRequested
+	downloadCtx := <-manifestRequested
 
 	server.mu.Lock()
 	job := server.job
@@ -328,6 +342,7 @@ func TestRestoreDownloadRemainsAsynchronousAndSucceeds(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("successful download did not terminate")
 	}
+	require.ErrorIs(t, downloadCtx.Err(), context.Canceled, "a completed job must release its lifetime child context")
 
 	server.mu.Lock()
 	state := job.state
@@ -345,6 +360,34 @@ func TestRestoreDownloadRemainsAsynchronousAndSucceeds(t *testing.T) {
 	server.Shutdown()
 	_, err = store.NewDirectReadHandle()
 	require.Error(t, err)
+}
+
+func TestRestoreFailedDownloadReleasesContext(t *testing.T) {
+	t.Parallel()
+
+	storage := NewMockStorage(gomock.NewController(t))
+	contextReady := make(chan context.Context, 1)
+	storage.EXPECT().GetFile(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, _ string) (io.ReadCloser, error) {
+		contextReady <- ctx
+
+		return nil, errors.New("manifest request failed")
+	})
+	server := newServerForTest(t, staticFactory(storage))
+	t.Cleanup(server.Shutdown)
+	_, err := server.StartDownloadBackup(context.Background(), &restorepb.StartDownloadBackupRequest{})
+	require.NoError(t, err)
+
+	server.mu.Lock()
+	job := server.job
+	server.mu.Unlock()
+	select {
+	case <-job.done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("failed download did not terminate")
+	}
+	require.Equal(t, restorepb.DownloadState_DOWNLOAD_STATE_FAILED, job.state)
+	downloadCtx := <-contextReady
+	require.ErrorIs(t, downloadCtx.Err(), context.Canceled, "a failed job must release its lifetime child context")
 }
 
 func TestCancelDownloadAndShutdownCanCompete(t *testing.T) {

--- a/internal/bootstrap/module_restore.go
+++ b/internal/bootstrap/module_restore.go
@@ -1,6 +1,7 @@
 package bootstrap
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -62,6 +63,19 @@ func RestoreModule() fx.Option {
 			func(lc fx.Lifecycle, bindings network.Bindings) {
 				lc.Append(releaseBindingsHook(bindings))
 			},
+			// Registered before the gRPC hook so it runs after that hook on stop.
+			// BeginShutdown (registered below) has already closed admission and
+			// canceled the download by then; this phase joins admitted RPCs and the
+			// detached job before closing the retained staging Pebble handle.
+			func(lc fx.Lifecycle, restoreServer *grpcadp.RestoreServiceServerImpl) {
+				lc.Append(fx.Hook{
+					OnStop: func(_ context.Context) error {
+						restoreServer.Shutdown()
+
+						return nil
+					},
+				})
+			},
 			// Validate that the data directory is fresh: no checkpoints, no
 			// live/ database (normal startup prefers it over the restored
 			// checkpoint, silently booting the stale store under the
@@ -114,6 +128,19 @@ func RestoreModule() fx.Option {
 				lc.Append(transportfx.FXHook(httpserver.NewHook(mux,
 					httpListenerOption(bindings.HTTP, fmt.Sprintf("%s:%d", cfg.EffectiveRestoreListen(), cfg.HTTPPort)),
 				)))
+			},
+			// Registered last so it is the first OnStop hook: close restore
+			// admission and cancel its application-owned job at the Fx shutdown
+			// boundary, before either network server stops. The earlier shutdown
+			// hook performs the joins and resource close after the gRPC server stop.
+			func(lc fx.Lifecycle, restoreServer *grpcadp.RestoreServiceServerImpl) {
+				lc.Append(fx.Hook{
+					OnStop: func(_ context.Context) error {
+						restoreServer.BeginShutdown()
+
+						return nil
+					},
+				})
 			},
 		),
 	)

--- a/internal/bootstrap/module_restore.go
+++ b/internal/bootstrap/module_restore.go
@@ -1,7 +1,6 @@
 package bootstrap
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
@@ -68,13 +67,7 @@ func RestoreModule() fx.Option {
 			// canceled the download by then; this phase joins admitted RPCs and the
 			// detached job before closing the retained staging Pebble handle.
 			func(lc fx.Lifecycle, restoreServer *grpcadp.RestoreServiceServerImpl) {
-				lc.Append(fx.Hook{
-					OnStop: func(_ context.Context) error {
-						restoreServer.Shutdown()
-
-						return nil
-					},
-				})
+				lc.Append(fx.StopHook(restoreServer.Shutdown))
 			},
 			// Validate that the data directory is fresh: no checkpoints, no
 			// live/ database (normal startup prefers it over the restored
@@ -129,18 +122,12 @@ func RestoreModule() fx.Option {
 					httpListenerOption(bindings.HTTP, fmt.Sprintf("%s:%d", cfg.EffectiveRestoreListen(), cfg.HTTPPort)),
 				)))
 			},
-			// Registered last so it is the first OnStop hook: close restore
+			// Registered last so it is this module's first OnStop hook: close restore
 			// admission and cancel its application-owned job at the Fx shutdown
 			// boundary, before either network server stops. The earlier shutdown
 			// hook performs the joins and resource close after the gRPC server stop.
 			func(lc fx.Lifecycle, restoreServer *grpcadp.RestoreServiceServerImpl) {
-				lc.Append(fx.Hook{
-					OnStop: func(_ context.Context) error {
-						restoreServer.BeginShutdown()
-
-						return nil
-					},
-				})
+				lc.Append(fx.StopHook(restoreServer.BeginShutdown))
 			},
 		),
 	)

--- a/internal/bootstrap/restore_download_lifecycle_test.go
+++ b/internal/bootstrap/restore_download_lifecycle_test.go
@@ -1,0 +1,118 @@
+//go:build s3
+
+package bootstrap
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	grpcadp "github.com/formancehq/ledger/v3/internal/adapter/grpc"
+	"github.com/formancehq/ledger/v3/internal/pkg/network"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/restorepb"
+)
+
+func TestRestoreDownloadStopsWithFxApplication(t *testing.T) {
+	requestStarted := make(chan struct{})
+	requestCanceled := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	var startedOnce sync.Once
+	var canceledOnce sync.Once
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		startedOnce.Do(func() { close(requestStarted) })
+		select {
+		case <-r.Context().Done():
+			canceledOnce.Do(func() { close(requestCanceled) })
+		case <-releaseRequest:
+			http.Error(w, "released", http.StatusInternalServerError)
+		}
+	}))
+	t.Cleanup(func() {
+		select {
+		case <-releaseRequest:
+		default:
+			close(releaseRequest)
+		}
+		backend.Close()
+	})
+
+	httpListener := mustListenLoopback(t, 0)
+	serviceListener := mustListenLoopback(t, 0)
+	cfg := Config{
+		ClusterID:     "restore-lifecycle-before-fix",
+		DataDir:       t.TempDir(),
+		Restore:       true,
+		RestoreListen: "127.0.0.1",
+		HTTPPort:      httpListener.Addr().(*net.TCPAddr).Port,
+		GRPCPort:      serviceListener.Addr().(*net.TCPAddr).Port,
+		TLSConfig:     TLSConfig{Mode: TLSModeDisabled},
+	}
+
+	var restoreServer *grpcadp.RestoreServiceServerImpl
+	app := fx.New(
+		fx.NopLogger,
+		fx.Supply(cfg),
+		fx.Supply(network.Bindings{HTTP: httpListener, Service: serviceListener}),
+		fx.Provide(func() logging.Logger { return logging.Testing() }),
+		RestoreModule(),
+		fx.Populate(&restoreServer),
+	)
+	require.NoError(t, app.Err())
+	t.Cleanup(func() {
+		select {
+		case <-releaseRequest:
+		default:
+			close(releaseRequest)
+		}
+		_ = app.Stop(context.Background())
+	})
+
+	startCtx, cancelStart := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancelStart()
+	require.NoError(t, app.Start(startCtx))
+
+	start, err := restoreServer.StartDownloadBackup(context.Background(), &restorepb.StartDownloadBackupRequest{
+		Storage: &commonpb.BackupStorage{Provider: &commonpb.BackupStorage_S3{S3: &commonpb.S3StorageConfig{
+			Bucket:          "backups",
+			Region:          "us-east-1",
+			Endpoint:        backend.URL,
+			AccessKeyId:     "test-access-key",
+			SecretAccessKey: "test-secret-key",
+		}}},
+	})
+	require.NoError(t, err)
+	<-requestStarted
+
+	stopDone := make(chan error, 1)
+	go func() { stopDone <- app.Stop(context.Background()) }()
+
+	select {
+	case <-requestCanceled:
+	case <-time.After(10 * time.Second):
+		t.Fatal("Fx shutdown did not cancel the restore job")
+	}
+
+	select {
+	case err := <-stopDone:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Fx shutdown did not join the canceled restore job")
+	}
+
+	_, err = restoreServer.StartDownloadBackup(context.Background(), &restorepb.StartDownloadBackupRequest{})
+	require.Equal(t, codes.Unavailable, status.Code(err))
+	require.NotEmpty(t, start.GetJobId())
+}

--- a/internal/bootstrap/restore_download_lifecycle_test.go
+++ b/internal/bootstrap/restore_download_lifecycle_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestRestoreDownloadStopsWithFxApplication(t *testing.T) {
+	t.Parallel()
+
 	requestStarted := make(chan struct{})
 	requestCanceled := make(chan struct{})
 	releaseRequest := make(chan struct{})
@@ -77,7 +79,7 @@ func TestRestoreDownloadStopsWithFxApplication(t *testing.T) {
 		default:
 			close(releaseRequest)
 		}
-		_ = app.Stop(context.Background())
+		require.NoError(t, app.Stop(context.Background()))
 	})
 
 	startCtx, cancelStart := context.WithTimeout(context.Background(), 30*time.Second)
@@ -94,7 +96,11 @@ func TestRestoreDownloadStopsWithFxApplication(t *testing.T) {
 		}}},
 	})
 	require.NoError(t, err)
-	<-requestStarted
+	select {
+	case <-requestStarted:
+	case <-time.After(10 * time.Second):
+		t.Fatal("restore job did not reach the S3 backend")
+	}
 
 	stopDone := make(chan error, 1)
 	go func() { stopDone <- app.Stop(context.Background()) }()

--- a/internal/bootstrap/restore_download_lifecycle_test.go
+++ b/internal/bootstrap/restore_download_lifecycle_test.go
@@ -7,12 +7,14 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
+	"go.uber.org/fx/fxevent"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -23,6 +25,43 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/restorepb"
 )
+
+// restoreLifecycleEvents observes the hooks Fx actually executes. Method names
+// identify the two restore phases without depending on anonymous closure numbers.
+type restoreLifecycleEvents struct {
+	mu        sync.Mutex
+	functions []string
+}
+
+func (l *restoreLifecycleEvents) LogEvent(event fxevent.Event) {
+	if event, ok := event.(*fxevent.OnStopExecuting); ok {
+		l.mu.Lock()
+		defer l.mu.Unlock()
+
+		l.functions = append(l.functions, event.FunctionName)
+	}
+}
+
+func (l *restoreLifecycleEvents) stopPhases() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	var phases []string
+	for _, name := range l.functions {
+		switch {
+		case strings.Contains(name, "RestoreServiceServerImpl).BeginShutdown"):
+			phases = append(phases, "close admission and cancel download")
+		case strings.Contains(name, "httpserver.NewHook."):
+			phases = append(phases, "stop HTTP")
+		case strings.Contains(name, ".grpcServerHook."):
+			phases = append(phases, "stop gRPC")
+		case strings.Contains(name, "RestoreServiceServerImpl).Shutdown"):
+			phases = append(phases, "join restore requests and job")
+		}
+	}
+
+	return phases
+}
 
 func TestRestoreDownloadStopsWithFxApplication(t *testing.T) {
 	t.Parallel()
@@ -64,8 +103,9 @@ func TestRestoreDownloadStopsWithFxApplication(t *testing.T) {
 	}
 
 	var restoreServer *grpcadp.RestoreServiceServerImpl
+	lifecycleEvents := &restoreLifecycleEvents{}
 	app := fx.New(
-		fx.NopLogger,
+		fx.WithLogger(func() fxevent.Logger { return lifecycleEvents }),
 		fx.Supply(cfg),
 		fx.Supply(network.Bindings{HTTP: httpListener, Service: serviceListener}),
 		fx.Provide(func() logging.Logger { return logging.Testing() }),
@@ -117,6 +157,16 @@ func TestRestoreDownloadStopsWithFxApplication(t *testing.T) {
 	case <-time.After(10 * time.Second):
 		t.Fatal("Fx shutdown did not join the canceled restore job")
 	}
+
+	// Event order comes from Fx's synchronous hook execution, not goroutine
+	// scheduling. Cancellation alone could pass with either restore hook missing
+	// or with their positions swapped, because Shutdown also calls BeginShutdown.
+	require.Equal(t, []string{
+		"close admission and cancel download",
+		"stop HTTP",
+		"stop gRPC",
+		"join restore requests and job",
+	}, lifecycleEvents.stopPhases(), "restore shutdown phases must surround network teardown")
 
 	_, err = restoreServer.StartDownloadBackup(context.Background(), &restorepb.StartDownloadBackupRequest{})
 	require.Equal(t, codes.Unavailable, status.Code(err))


### PR DESCRIPTION
## What changed

Restore-mode services now own asynchronous download jobs for the full Fx application lifetime. Shutdown rejects new restore RPC work, cancels and joins an active download, waits for admitted restore RPCs, then closes retained staging Pebble state.

Terminal jobs release their child context before signaling completion, so successful or failed attempts do not remain retained by the service lifetime context.

RPC detachment remains intentional: cancelling the initiating StartDownload RPC does not cancel the background job; explicit CancelDownload remains the job-level cancellation API.

## Why

The current service creates downloads from a background context and has no Fx stop hook. A deterministic production-module regression showed Fx shutdown returning while an S3 manifest request and restore job remained alive, leaving service-owned staging state without teardown ownership.

## Product / operational motivation

Need: restore work may outlive its initiating RPC, but must never outlive the restore-mode application that owns it.
Current limitation: Fx shutdown neither cancels nor joins active download work and never closes retained staging Pebble state.
Requirement / constraint: once shutdown begins, no new job starts; active work receives cancellation and is joined; admitted RPCs finish; service-owned staging state closes last.
Evidence: internal/bootstrap/restore_download_lifecycle_test.go and internal/adapter/grpc/server_restore_lifecycle_test.go.
Durable repository evidence: docs/ops/backup-restore.md and docs/technical/architecture/subsystems/api/grpc-api.md.

## Technical decision

Decision: add a restore-service lifetime context, an admission/stopping gate, active-request and active-job joins, and phased Fx stop hooks that order admission closure before transports and resource closure after gRPC draining.
Why now / why proportionate: this is the smallest ownership boundary matching the existing single-job service and Fx lifecycle.
Alternatives considered: tying work to the initiating RPC would break intentional asynchronous behavior; closing staging state directly from Fx would race active restore operations; a broader restore subsystem redesign is unnecessary.

## Risk

**MEDIUM**: shutdown ordering and concurrency change in restore mode; deterministic synchronization tests and focused race validation cover the affected paths.

## Validation

- [x] `bash scripts/agent-check` (standalone, then repeated by the final PR gate)
- [x] `AI_REVIEW_BASE_SHA=afdd58395fd4689c624286893c2c618e38db8148 bash scripts/agent-check-pr` with shared caches and reduced local build concurrency (`GOMAXPROCS=4 GOFLAGS=-p=2`)
- [x] Focused race suites: `./internal/adapter/grpc` and `./internal/bootstrap`
- [x] Production Fx regression: `go test -race -tags s3 ./internal/bootstrap -run '^TestRestoreDownloadStopsWithFxApplication$' -count=1 -timeout 2m`
- [x] CI `Tests` explicitly runs the tagged Fx regression against the in-process S3 endpoint; no MinIO or Docker is required for this case
- [x] Regression sensitivity: restoring the background parent made the production Fx regression fail deterministically because shutdown did not cancel the job
- [x] Final diff and fresh review: no blocking findings or generated drift
- [x] Mutation checks: removing either Fx phase, reversing phase order, forwarding RPC cancellation, removing the job join, or omitting terminal child cancellation each fails its intended regression assertion
- [x] GitHub CI on `3ef3bec1280754c19e8475201901c87326de5c08` (15 successful checks; 2 expected release/image skips)

## Architecture / behavior impact

No wire, storage-format, FSM, Raft, or compatibility change. Restore-mode shutdown now owns asynchronous work and retained staging-store teardown. Explicit cancellation still leaves the application available for another download.

## Review focus

Please check lock/join ordering, the double admission check at job registration, and the phased Fx hook order around HTTP/gRPC shutdown and staging-store closure.

## Known concerns

The current service runner supplies no deadline to Fx Stop. Synchronous storage-client initialization, local staging cleanup, or a backend that ignores cancellation can delay shutdown. The existing staging-close policy logs close failures without returning them from the stop hook. The runbook states these limits and the residual state after forced termination.


