### PR TITLE
test: make synchronized timeout fixture deterministic

### DIFF
--- a/scripts/internal/testenv/synchronize.go
+++ b/scripts/internal/testenv/synchronize.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -32,7 +33,7 @@ type SynchronizedResult struct {
 type synchronizedProcess struct {
 	name          string
 	command       *exec.Cmd
-	output        bytes.Buffer
+	output        synchronizedOutput
 	readyReader   *os.File
 	readyWriter   *os.File
 	releaseReader *os.File
@@ -46,12 +47,47 @@ type processEvent struct {
 	err   error
 }
 
+// synchronizationHooks let tests observe the prerequisites for a timeout and
+// trigger it without assuming how quickly the operating system schedules peers.
+// Hook functions must not block.
+type synchronizationHooks struct {
+	deadline      <-chan time.Time
+	outputWritten func(string)
+	peerReady     func(string)
+}
+
+type synchronizedOutput struct {
+	buffer bytes.Buffer
+	once   sync.Once
+	notify func()
+}
+
+// Write is intentionally the only io.Copy fast path exposed by this type.
+// Embedding bytes.Buffer would promote ReadFrom and bypass the notification.
+func (output *synchronizedOutput) Write(data []byte) (int, error) {
+	written, err := output.buffer.Write(data)
+	if written > 0 && output.notify != nil {
+		output.once.Do(output.notify)
+	}
+
+	return written, err
+}
+
+func (output *synchronizedOutput) String() string {
+	return output.buffer.String()
+}
+
 // RunSynchronized supervises a bounded fixture barrier. A process that exits
 // before ready aborts its siblings, and every error reports both subprocesses'
 // output. Each command runs in its own process group so aborting it also stops
 // reviewer or validator children.
 func RunSynchronized(t testing.TB, timeout time.Duration, commands ...SynchronizedCommand) (SynchronizedResult, error) {
 	t.Helper()
+
+	return runSynchronized(timeout, synchronizationHooks{}, commands...)
+}
+
+func runSynchronized(timeout time.Duration, hooks synchronizationHooks, commands ...SynchronizedCommand) (SynchronizedResult, error) {
 	startedAt := time.Now()
 	result := SynchronizedResult{
 		Output: make(map[string]string, len(commands)),
@@ -90,6 +126,10 @@ func RunSynchronized(t testing.TB, timeout time.Duration, commands ...Synchroniz
 			releaseReader: releaseReader,
 			releaseWriter: releaseWriter,
 		}
+		if hooks.outputWritten != nil {
+			name := item.Name
+			processes[index].output.notify = func() { hooks.outputWritten(name) }
+		}
 		processes[index].command.ExtraFiles = []*os.File{readyWriter, releaseReader}
 		processes[index].command.Stdout = &processes[index].output
 		processes[index].command.Stderr = &processes[index].output
@@ -98,8 +138,12 @@ func RunSynchronized(t testing.TB, timeout time.Duration, commands ...Synchroniz
 
 	readyEvents := make(chan processEvent, len(processes))
 	exitEvents := make(chan processEvent, len(processes))
-	deadline := time.NewTimer(timeout)
-	defer deadline.Stop()
+	deadline := hooks.deadline
+	if deadline == nil {
+		deadlineTimer := time.NewTimer(timeout)
+		defer deadlineTimer.Stop()
+		deadline = deadlineTimer.C
+	}
 
 	failure := error(nil)
 	for index := range processes {
@@ -136,6 +180,9 @@ func RunSynchronized(t testing.TB, timeout time.Duration, commands ...Synchroniz
 			default:
 				ready[event.index] = true
 				readyCount++
+				if hooks.peerReady != nil {
+					hooks.peerReady(process.name)
+				}
 			}
 		case event := <-exitEvents:
 			process := &processes[event.index]
@@ -146,7 +193,7 @@ func RunSynchronized(t testing.TB, timeout time.Duration, commands ...Synchroniz
 			} else {
 				failure = fmt.Errorf("%s failed before all peers were ready: process exit: %w", process.name, event.err)
 			}
-		case <-deadline.C:
+		case <-deadline:
 			failure = fmt.Errorf("fixture synchronization exceeded %s", timeout)
 		}
 	}
@@ -185,7 +232,7 @@ func RunSynchronized(t testing.TB, timeout time.Duration, commands ...Synchroniz
 				result.Exit[processes[event.index].name] = event.err
 				remaining--
 			}
-		case <-deadline.C:
+		case <-deadline:
 			if failure == nil {
 				failure = fmt.Errorf("fixture processes exceeded %s", timeout)
 			}

--- a/scripts/internal/testenv/synchronize_test.go
+++ b/scripts/internal/testenv/synchronize_test.go
@@ -1,7 +1,9 @@
 package testenv
 
 import (
+	"context"
 	"os/exec"
+	"sync"
 	"testing"
 	"time"
 
@@ -10,12 +12,56 @@ import (
 
 func TestRunSynchronizedTimeoutTerminatesAndReportsEveryPeer(t *testing.T) {
 	first := exec.Command("/bin/sh", "-c", "echo first-peer-output >&2; printf 'ready\\n' >&3; IFS= read -r _ <&4")
-	second := exec.Command("/bin/sh", "-c", "echo second-peer-output >&2; sleep 60")
+	// Stop inside the peer after its diagnostic so reaping cannot race a forked sleep child.
+	second := exec.Command("/bin/sh", "-c", "echo second-peer-output >&2; kill -STOP $$")
+	deadline := make(chan time.Time, 1)
+	var triggerDeadlineOnce sync.Once
+	triggerDeadline := func() {
+		triggerDeadlineOnce.Do(func() { deadline <- time.Now() })
+	}
+	outputWritten := make(chan string, 2)
+	peerReady := make(chan string, 1)
+	type runResult struct {
+		result SynchronizedResult
+		err    error
+	}
+	completed := make(chan runResult, 1)
+	exited := make(chan struct{})
+	t.Cleanup(func() {
+		triggerDeadline()
+		cleanupDeadline := time.NewTimer(2 * time.Second)
+		defer cleanupDeadline.Stop()
+		select {
+		case <-exited:
+		case <-cleanupDeadline.C:
+			t.Error("timed out cleaning up synchronized fixture peers")
+		}
+	})
+	go func() {
+		defer close(exited)
+		result, err := runSynchronized(200*time.Millisecond, synchronizationHooks{
+			deadline:      deadline,
+			outputWritten: func(name string) { outputWritten <- name },
+			peerReady:     func(name string) { peerReady <- name },
+		},
+			SynchronizedCommand{Name: "first peer", Command: first},
+			SynchronizedCommand{Name: "second peer", Command: second},
+		)
+		completed <- runResult{result: result, err: err}
+	}()
 
-	result, err := RunSynchronized(t, 200*time.Millisecond,
-		SynchronizedCommand{Name: "first peer", Command: first},
-		SynchronizedCommand{Name: "second peer", Command: second},
-	)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+	outputs := map[string]bool{}
+	for len(outputs) < 2 {
+		outputs[receiveSynchronizedEvent(t, ctx, outputWritten)] = true
+	}
+	require.Equal(t, map[string]bool{"first peer": true, "second peer": true}, outputs)
+	require.Equal(t, "first peer", receiveSynchronizedEvent(t, ctx, peerReady))
+	triggerDeadline()
+
+	run := receiveSynchronizedEvent(t, ctx, completed)
+	result, err := run.result, run.err
 	require.Error(t, err)
 	require.Less(t, result.Duration, 2*time.Second, err.Error())
 	require.Contains(t, err.Error(), "fixture synchronization exceeded 200ms")
@@ -25,4 +71,19 @@ func TestRunSynchronizedTimeoutTerminatesAndReportsEveryPeer(t *testing.T) {
 	_, secondReaped := result.Exit["second peer"]
 	require.True(t, firstReaped, "first peer was not reaped: %v", err)
 	require.True(t, secondReaped, "second peer was not reaped: %v", err)
+}
+
+func receiveSynchronizedEvent[T any](t *testing.T, ctx context.Context, events <-chan T) T {
+	t.Helper()
+
+	select {
+	case event := <-events:
+		return event
+	case <-ctx.Done():
+		t.Fatalf("timed out waiting for synchronized fixture event: %v", ctx.Err())
+
+		var zero T
+
+		return zero
+	}
 }


### PR DESCRIPTION
## What changed

- Added an internal, test-only synchronization seam for deadline delivery, peer output observation, and barrier readiness.
- Reworked `TestRunSynchronizedTimeoutTerminatesAndReportsEveryPeer` to trigger its deadline only after both peer diagnostics and the first peer ready event are observed.
- Made the non-ready peer stop itself after emitting output and added bounded cleanup so failure paths cannot leak fixture processes.

## Why

The 200 ms wall-clock deadline started before subprocess launch and scheduling. Under race instrumentation or host contention it could expire before a peer ran its first `echo`, so the assertion intended to verify timeout cleanup and diagnostic collection instead measured scheduler latency. Increasing the duration would only reduce, not remove, that race.

The new test controls the deadline while preserving the public `RunSynchronized` API and its real timer behavior.

## Product/operational motivation

N/A — this is a deterministic regression-test fix for internal contributor tooling.

## Technical decision

Use unexported hooks around the existing supervisor rather than change its public contract. The output wrapper exposes `Write` without promoting `bytes.Buffer.ReadFrom`, ensuring `os/exec` cannot bypass the observation callback through an optimized copy path.

## Risk

Low. Changes are confined to `scripts/internal/testenv`; production Ledger behavior is unchanged. The normal helper path still creates the same real timeout at the same point.

## Validation checklist

- [x] Focused regression under `-race`, 100 repetitions
- [x] Controlled contention: 8 workers x 100 focused race repetitions
- [x] `go test -race -timeout 10m ./scripts/internal/testenv ./scripts/reviewloop`
- [x] `bash scripts/agent-check`
- [x] Canonical `agent-check-pr` full gate against authoritative SHA `e3ef7708729a709e19ae119d8165143fbeeebc28`, including lint and `go test -race ./...`
- [x] Post-rebase Go 1.27 focused lint and race tests

## Architecture/behavior impact

N/A — no runtime, API, persistence, or architecture behavior changes.

## Review focus

- The hook boundary remains private and cannot alter the default timeout path.
- Timeout delivery occurs only after both output writes and the intended ready event.
- Cleanup always wakes and reaps both peers.

## Known concerns

The post-sync native `ai-pr-loop` passed its proportional `agent-check-pr` validation against base `ce72d6df10142a48fa3193ed369831d5f0252854` and collected zero unresolved GitHub findings. Its final Codex reviewer returned `NOT_READY` because the child review process did not receive the required `EXPECTED_PR_NUMBER`, `EXPECTED_HEAD`, and review-context environment bindings, despite the adapter self-check passing. This is a launcher binding failure, not a finding on this diff.