### PR TITLE
fix(tooling): accept newer Nix Go toolchains

### DIFF
--- a/docs/technical/contributing/ai-bugfix-workflow.md
+++ b/docs/technical/contributing/ai-bugfix-workflow.md
@@ -18,11 +18,12 @@ When a validation failure occurs, classify it as
 attributing it to the candidate. An unclassified important failure is not
 ready for publication. Non-bugfix changes may omit bug reproduction evidence.
 
-Before Go validation, `scripts/ai-bugfix-gate environment` compares the
-effective `go version` with the repository `go.mod` directive, reports the
-selected binary and `GOROOT`, and rejects a host toolchain selected outside
-the repository environment. Being inside `nix develop` alone is not evidence
-of the effective toolchain.
+Before Go validation, `scripts/ai-bugfix-gate environment` verifies that the
+effective Nix-provided `go version` is at least the minimum language version
+declared by the repository `go.mod`, then reports the selected binary and
+`GOROOT`. It rejects an older compiler or a host toolchain selected outside the
+repository environment. Being inside `nix develop` alone is not evidence of
+the effective toolchain.
 
 Before exact review, the loop runs applicable base-pinned normalization to a
 one-replay fixpoint. Exact-state targeted validation after review must leave the

--- a/scripts/ai-bugfix-gate
+++ b/scripts/ai-bugfix-gate
@@ -24,27 +24,31 @@ environment_gate() {
     unset GOROOT || true
 
     local go_bin go_version expected_raw expected actual actual_root
-    local expected_major expected_minor actual_major actual_minor
+    local expected_major expected_minor expected_patch actual_major actual_minor actual_patch
     go_bin=$(command -v go) || die "ENVIRONMENT_GATE=FAIL (go not found)"
     go_version=$(go version) || die "ENVIRONMENT_GATE=FAIL (go unusable)"
     expected_raw=$(awk '$1 == "go" {print $2; exit}' "$mod_file")
     [[ -n "$expected_raw" ]] || die "ENVIRONMENT_GATE=FAIL (go directive missing)"
-    [[ "$expected_raw" =~ ^([0-9]+)\.([0-9]+)(\.[0-9]+)?$ ]] || \
+    [[ "$expected_raw" =~ ^([0-9]+)\.([0-9]+)(\.([0-9]+))?$ ]] || \
         die "ENVIRONMENT_GATE=FAIL (invalid go directive: $expected_raw)"
     expected_major=${BASH_REMATCH[1]}
     expected_minor=${BASH_REMATCH[2]}
-    expected="$expected_major.$expected_minor"
-    [[ "$go_version" =~ go([0-9]+)\.([0-9]+) ]] || \
+    expected_patch=${BASH_REMATCH[4]:-0}
+    expected="$expected_major.$expected_minor.$expected_patch"
+    [[ "$go_version" =~ go([0-9]+)\.([0-9]+)(\.([0-9]+))?([[:space:]]|$) ]] || \
         die "ENVIRONMENT_GATE=FAIL (unable to parse toolchain version: $go_version)"
     actual_major=${BASH_REMATCH[1]}
     actual_minor=${BASH_REMATCH[2]}
-    actual="$actual_major.$actual_minor"
+    actual_patch=${BASH_REMATCH[4]:-0}
+    actual="$actual_major.$actual_minor.$actual_patch"
     actual_root=$(go env GOROOT)
 
     [[ "$go_bin" == /nix/store/* && "$actual_root" == /nix/store/* ]] || \
         die "ENVIRONMENT_GATE=FAIL (Go is not from the Nix store)"
     if (( 10#$actual_major < 10#$expected_major ||
-        (10#$actual_major == 10#$expected_major && 10#$actual_minor < 10#$expected_minor) )); then
+        (10#$actual_major == 10#$expected_major && 10#$actual_minor < 10#$expected_minor) ||
+        (10#$actual_major == 10#$expected_major && 10#$actual_minor == 10#$expected_minor &&
+            10#$actual_patch < 10#$expected_patch) )); then
         die "ENVIRONMENT_GATE=FAIL (module requires Go $expected or newer, got $go_version)"
     fi
 

--- a/scripts/ai-bugfix-gate
+++ b/scripts/ai-bugfix-gate
@@ -23,20 +23,33 @@ environment_gate() {
     export PATH
     unset GOROOT || true
 
-    local go_bin go_version expected actual actual_root
+    local go_bin go_version expected_raw expected actual actual_root
+    local expected_major expected_minor actual_major actual_minor
     go_bin=$(command -v go) || die "ENVIRONMENT_GATE=FAIL (go not found)"
     go_version=$(go version) || die "ENVIRONMENT_GATE=FAIL (go unusable)"
-    expected=$(awk '$1 == "go" {print $2; exit}' "$mod_file")
-    expected=$(sed -E 's/^([0-9]+\.[0-9]+).*/\1/' <<<"$expected")
-    [[ -n "$expected" ]] || die "ENVIRONMENT_GATE=FAIL (go directive missing)"
-    actual=$(sed -E 's/.*go([0-9]+\.[0-9]+).*/\1/' <<<"$go_version")
+    expected_raw=$(awk '$1 == "go" {print $2; exit}' "$mod_file")
+    [[ -n "$expected_raw" ]] || die "ENVIRONMENT_GATE=FAIL (go directive missing)"
+    [[ "$expected_raw" =~ ^([0-9]+)\.([0-9]+)(\.[0-9]+)?$ ]] || \
+        die "ENVIRONMENT_GATE=FAIL (invalid go directive: $expected_raw)"
+    expected_major=${BASH_REMATCH[1]}
+    expected_minor=${BASH_REMATCH[2]}
+    expected="$expected_major.$expected_minor"
+    [[ "$go_version" =~ go([0-9]+)\.([0-9]+) ]] || \
+        die "ENVIRONMENT_GATE=FAIL (unable to parse toolchain version: $go_version)"
+    actual_major=${BASH_REMATCH[1]}
+    actual_minor=${BASH_REMATCH[2]}
+    actual="$actual_major.$actual_minor"
     actual_root=$(go env GOROOT)
+
+    [[ "$go_bin" == /nix/store/* && "$actual_root" == /nix/store/* ]] || \
+        die "ENVIRONMENT_GATE=FAIL (Go is not from the Nix store)"
+    if (( 10#$actual_major < 10#$expected_major ||
+        (10#$actual_major == 10#$expected_major && 10#$actual_minor < 10#$expected_minor) )); then
+        die "ENVIRONMENT_GATE=FAIL (module requires Go $expected or newer, got $go_version)"
+    fi
 
     printf 'ENVIRONMENT_GATE=PASS\nEXPECTED_GO=%s\nACTUAL_GO=%s\nGO_BINARY=%s\nGOROOT=%s\nGOTOOLCHAIN=%s\n' \
         "$expected" "$actual" "$go_bin" "$actual_root" "$(go env GOTOOLCHAIN)"
-    [[ "$actual" == "$expected"* ]] || die "ENVIRONMENT_GATE=FAIL (expected Go $expected, got $go_version)"
-    [[ "$go_bin" == /nix/store/* && "$actual_root" == /nix/store/* ]] || \
-        die "ENVIRONMENT_GATE=FAIL (Go is not from the Nix store)"
 }
 
 evidence_gate() {

--- a/scripts/ai-bugfix-gate-test
+++ b/scripts/ai-bugfix-gate-test
@@ -6,6 +6,55 @@ gate="$root/scripts/ai-bugfix-gate"
 tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 
+go_version=$(go version)
+if [[ ! "$go_version" =~ go([0-9]+)\.([0-9]+) ]]; then
+    echo "unable to parse test toolchain version: $go_version" >&2
+    exit 1
+fi
+actual_major=${BASH_REMATCH[1]}
+actual_minor=${BASH_REMATCH[2]}
+if (( actual_minor == 0 )); then
+    echo "test requires a Go toolchain with a non-zero minor version" >&2
+    exit 1
+fi
+
+write_module() {
+    local path=$1 major=$2 minor=$3
+    printf 'module example.com/test\n\ngo %s.%s.0\n' "$major" "$minor" >"$path"
+}
+
+write_module "$tmp/older-language.mod" "$actual_major" "$((actual_minor - 1))"
+"$gate" environment "$tmp/older-language.mod"
+
+write_module "$tmp/equal-language.mod" "$actual_major" "$actual_minor"
+"$gate" environment "$tmp/equal-language.mod"
+
+write_module "$tmp/newer-language.mod" "$actual_major" "$((actual_minor + 1))"
+if "$gate" environment "$tmp/newer-language.mod" >"$tmp/newer-language.out" 2>&1; then
+    echo 'expected a toolchain older than the go directive to fail' >&2
+    exit 1
+fi
+grep -Fq "requires Go $actual_major.$((actual_minor + 1)) or newer" "$tmp/newer-language.out" || {
+    cat "$tmp/newer-language.out" >&2
+    echo 'expected the version failure to describe the minimum toolchain' >&2
+    exit 1
+}
+if grep -Fxq 'ENVIRONMENT_GATE=PASS' "$tmp/newer-language.out"; then
+    echo 'failed environment gate reported a false pass marker' >&2
+    exit 1
+fi
+
+printf 'module example.com/test\n\ngo invalid\n' >"$tmp/invalid-language.mod"
+if "$gate" environment "$tmp/invalid-language.mod" >"$tmp/invalid-language.out" 2>&1; then
+    echo 'expected an invalid go directive to fail' >&2
+    exit 1
+fi
+grep -Fq 'invalid go directive' "$tmp/invalid-language.out" || {
+    cat "$tmp/invalid-language.out" >&2
+    echo 'expected the malformed directive to be identified' >&2
+    exit 1
+}
+
 cat >"$tmp/bugfix.ok" <<'EOF'
 DISCOVERY: NO_EXISTING_WORK
 BEFORE_FIX: BUG_REPRODUCED
@@ -31,7 +80,7 @@ fi
 mkdir -p "$tmp/fake-bin"
 cat >"$tmp/fake-bin/go" <<'EOF'
 #!/usr/bin/env bash
-case "$1 $2" in
+case "$*" in
   "version") echo 'go version go1.26.5 darwin/arm64' ;;
   "env GOROOT") echo '/tmp/fake-go-root' ;;
   "env GOTOOLCHAIN") echo 'auto' ;;
@@ -39,8 +88,17 @@ case "$1 $2" in
 esac
 EOF
 chmod +x "$tmp/fake-bin/go"
-if PATH="$tmp/fake-bin:$PATH" "$gate" environment "$root/go.mod" >/dev/null 2>&1; then
+if PATH="$tmp/fake-bin:$PATH" "$gate" environment "$root/go.mod" >"$tmp/non-nix.out" 2>&1; then
     echo 'expected non-Nix matching Go to fail' >&2
+    exit 1
+fi
+grep -Fq 'Go is not from the Nix store' "$tmp/non-nix.out" || {
+    cat "$tmp/non-nix.out" >&2
+    echo 'expected the non-Nix toolchain to be identified' >&2
+    exit 1
+}
+if grep -Fxq 'ENVIRONMENT_GATE=PASS' "$tmp/non-nix.out"; then
+    echo 'non-Nix environment gate reported a false pass marker' >&2
     exit 1
 fi
 

--- a/scripts/ai-bugfix-gate-test
+++ b/scripts/ai-bugfix-gate-test
@@ -7,34 +7,50 @@ tmp=$(mktemp -d)
 trap 'rm -rf "$tmp"' EXIT
 
 go_version=$(go version)
-if [[ ! "$go_version" =~ go([0-9]+)\.([0-9]+) ]]; then
+if [[ ! "$go_version" =~ go([0-9]+)\.([0-9]+)\.([0-9]+)([[:space:]]|$) ]]; then
     echo "unable to parse test toolchain version: $go_version" >&2
     exit 1
 fi
 actual_major=${BASH_REMATCH[1]}
 actual_minor=${BASH_REMATCH[2]}
+actual_patch=${BASH_REMATCH[3]}
 if (( actual_minor == 0 )); then
     echo "test requires a Go toolchain with a non-zero minor version" >&2
     exit 1
 fi
 
 write_module() {
-    local path=$1 major=$2 minor=$3
-    printf 'module example.com/test\n\ngo %s.%s.0\n' "$major" "$minor" >"$path"
+    local path=$1 major=$2 minor=$3 patch=$4
+    printf 'module example.com/test\n\ngo %s.%s.%s\n' "$major" "$minor" "$patch" >"$path"
 }
 
-write_module "$tmp/older-language.mod" "$actual_major" "$((actual_minor - 1))"
+write_module "$tmp/older-language.mod" "$actual_major" "$((actual_minor - 1))" 0
 "$gate" environment "$tmp/older-language.mod"
 
-write_module "$tmp/equal-language.mod" "$actual_major" "$actual_minor"
+write_module "$tmp/equal-language.mod" "$actual_major" "$actual_minor" "$actual_patch"
 "$gate" environment "$tmp/equal-language.mod"
 
-write_module "$tmp/newer-language.mod" "$actual_major" "$((actual_minor + 1))"
+write_module "$tmp/newer-language.mod" "$actual_major" "$((actual_minor + 1))" 0
 if "$gate" environment "$tmp/newer-language.mod" >"$tmp/newer-language.out" 2>&1; then
     echo 'expected a toolchain older than the go directive to fail' >&2
     exit 1
 fi
-grep -Fq "requires Go $actual_major.$((actual_minor + 1)) or newer" "$tmp/newer-language.out" || {
+
+write_module "$tmp/newer-patch-language.mod" "$actual_major" "$actual_minor" "$((actual_patch + 1))"
+if "$gate" environment "$tmp/newer-patch-language.mod" >"$tmp/newer-patch-language.out" 2>&1; then
+    echo 'expected a toolchain below the go directive patch version to fail' >&2
+    exit 1
+fi
+grep -Fq "requires Go $actual_major.$actual_minor.$((actual_patch + 1)) or newer" "$tmp/newer-patch-language.out" || {
+    cat "$tmp/newer-patch-language.out" >&2
+    echo 'expected the patch failure to describe the minimum toolchain' >&2
+    exit 1
+}
+if grep -Fxq 'ENVIRONMENT_GATE=PASS' "$tmp/newer-patch-language.out"; then
+    echo 'failed patch environment gate reported a false pass marker' >&2
+    exit 1
+fi
+grep -Fq "requires Go $actual_major.$((actual_minor + 1)).0 or newer" "$tmp/newer-language.out" || {
     cat "$tmp/newer-language.out" >&2
     echo 'expected the version failure to describe the minimum toolchain' >&2
     exit 1


### PR DESCRIPTION
DISCOVERY: DIRECT_FIX
BEFORE_FIX: BUG_REPRODUCED
AFTER_FIX: PASS
BASELINE_CLASSIFICATION: BASELINE_FAILURE

## What changed

The AI bugfix environment gate now treats the complete `go.mod` language version as a minimum and accepts a newer repository-pinned Nix toolchain. It validates major, minor, and patch components, retains the Nix binary/GOROOT provenance check, and emits `ENVIRONMENT_GATE=PASS` only after all checks succeed.

The shell regression suite now covers compatible-newer, exact, insufficient-minor, insufficient-patch, malformed, and non-Nix cases. It also fixes the existing fake `go` dispatcher so the non-Nix test reaches the intended provenance branch.

## Why

PR #1911 deliberately kept `go.mod` at 1.26 while upgrading the Nix devshell to Go 1.27.1. The gate encoded exact equality, so every `agent-check-pr` and `ai-pr-loop` invocation stopped before validation even though a newer Go compiler is compatible with the declared minimum.

## Product / operational motivation

N/A — narrow contributor-tooling correctness fix.

## Technical decision

N/A

## Risk

**LOW** — the gate still fails closed for non-Nix and too-old toolchains. The accepted set only expands to newer Nix-provided Go versions compatible with the complete module minimum.

## Validation

- [x] `bash scripts/agent-check`
- [x] Targeted test: `nix develop --command bash scripts/ai-bugfix-gate-test`
- [x] Real Go 1.27.1 / `go 1.26.0` environment gate, repeated 5 times
- [x] `bash -n scripts/ai-bugfix-gate scripts/ai-bugfix-gate-test`
- [x] Canonical `agent-check-pr`: environment gate, normalization, root/operator lint, and baseline validation
- [ ] Full `go test -race ./...`: reached the pre-existing `TestRunSynchronizedTimeoutTerminatesAndReportsEveryPeer` 200 ms baseline flake fixed by #1914; every other reported package passed

## Architecture / behavior impact

N/A — contributor tooling only; no Ledger runtime, API, storage, or persisted-state behavior changes.

## Review focus

- Numeric major/minor/patch comparison correctly implements `actual >= minimum`.
- Failed version and provenance checks cannot emit a false PASS marker.
- The non-Nix fixture now exercises the actual Nix-store check.

## Known concerns

The broad race suite can still hit the synchronized-fixture baseline flake tracked and fixed independently in #1914. This PR neither changes nor masks that test.

The native `ai-pr-loop` cannot bootstrap this gate change because it executes the immutable base version of `agent-check-pr` and `ai-bugfix-gate`; the old exact-version gate rejects Go 1.27 before reviewing its replacement. After this PR merges, the loop can run normally on #1914.