### PR TITLE
fix(EN-1959): fence leadership worker generations

### DIFF
--- a/docs/technical/architecture/subsystems/events-mirror/events.md
+++ b/docs/technical/architecture/subsystems/events-mirror/events.md
@@ -197,8 +197,8 @@ If no notification arrives (e.g., after restart), the emitter polls at a configu
 
 The event system is gated by both the node's leader status and the presence of sink configs:
 
-- **On becoming leader**: The `Manager.OnLeadershipChange(true)` is called. If any sinks are configured, the Manager starts one Emitter per sink.
-- **On losing leadership**: The `Manager.OnLeadershipChange(false)` is called. The Manager tears down all Emitters and Sinks.
+- **On becoming leader**: The Raft observer records `Manager.OnLeadershipChange(true)` synchronously. The Manager's lifecycle-owned loop reconciles the latest recorded generation and starts one Emitter per configured sink.
+- **On losing leadership**: The Raft observer records `Manager.OnLeadershipChange(false)` synchronously. The same loop tears down all Emitters and Sinks; reconciliation from a superseded generation is discarded.
 - **On config change (while leader)**: The FSM signals the Manager via a `Signal` notification. The Manager reconciles by diffing the desired sink configs against the currently running emitters — only sinks that were added, removed, or changed are affected; unchanged sinks keep running.
 - **Followers**: Never emit events, regardless of config.
 
@@ -235,6 +235,16 @@ sequenceDiagram
 ```
 
 The Manager reconciles emitter lifecycles on leadership changes and config updates. Each emitter independently tails the log, publishes to its sink, and advances its cursor via Raft. Failed publishes are recorded as sink errors in Pebble (visible via `GetEventsSinks`), and the emitter retries with exponential backoff.
+
+Leadership callbacks do not own reconciliation goroutines. Bootstrap records
+each transition inline, preserving Raft observer order, while the Manager's
+existing loop owns the slow Pebble scan and worker mutations. A monotonically
+increasing generation fences a scan or startup that was superseded before it
+could retain a sink. The Manager records which generation owns the active
+emitter set, so a complete leadership loss and regain recycles it even when the
+buffered notification coalesces both transitions. `Stop` closes the leadership
+gate before draining the loop so a late transition cannot recreate emitters
+during Fx teardown.
 
 ## Sink Interface
 

--- a/docs/technical/architecture/subsystems/events-mirror/mirror.md
+++ b/docs/technical/architecture/subsystems/events-mirror/mirror.md
@@ -10,12 +10,21 @@ Source: `internal/application/mirror/` (worker + manager) and `internal/adapter/
 
 ## Worker model
 
-One mirror worker runs per mirror ledger, **on the leader only**. The Manager (`internal/application/mirror/manager.go:30-47`) reconciles workers against the current set of mirror ledgers (`ReadMirrorLedgers`) on every leadership change and on relevant Raft commits:
+One mirror worker runs per mirror ledger, **on the leader only**. The Manager (`internal/application/mirror/manager.go`) reconciles workers against the current set of mirror ledgers (`ReadMirrorLedgers`) on every leadership change and on relevant Raft commits:
 
 - Ledger created in mirror mode → spin up a worker.
 - Ledger promoted, deleted, or mirror config changed → stop the corresponding worker.
 
-Reconciliation is in `Manager.reconcile()` (`manager.go:112-179`).
+The Raft observer records leadership transitions synchronously, in observer
+order. The Manager's lifecycle-owned loop performs the potentially slow Pebble
+scan and worker reconciliation against the latest generation. Superseded
+generations cannot retain newly started workers. The Manager records which
+generation owns the active worker set, so a complete leadership loss and regain
+recycles it even when the buffered notification coalesces both transitions.
+`Stop` closes the leadership gate before draining the loop so a late callback
+cannot recreate a mirror worker during Fx teardown.
+
+Reconciliation is in `Manager.reconcileGeneration()`.
 
 The Worker (`worker.go:27-175`) is a polling loop:
 

--- a/internal/application/events/manager.go
+++ b/internal/application/events/manager.go
@@ -37,10 +37,15 @@ type Manager struct {
 	logger         logging.Logger
 	notifications  *signal.Notifications
 
-	mu       sync.Mutex
-	isLeader bool
-	emitters map[string]*managedSink
-	retries  map[string]struct{}
+	mu                  sync.Mutex
+	emitters            map[string]*managedSink
+	retries             map[string]struct{}
+	resourcesGeneration uint64
+
+	leadershipMu         sync.Mutex
+	leadershipGeneration uint64
+	isLeader             bool
+	stopped              bool
 
 	w worker.Worker
 }
@@ -68,6 +73,18 @@ func (m *Manager) Start() {
 
 // Stop gracefully stops the Manager and tears down any active emitters/sinks.
 func (m *Manager) Stop() {
+	m.leadershipMu.Lock()
+	if m.stopped {
+		m.leadershipMu.Unlock()
+
+		return
+	}
+
+	m.leadershipGeneration++
+	m.isLeader = false
+	m.stopped = true
+	m.leadershipMu.Unlock()
+
 	m.w.Stop()
 
 	m.mu.Lock()
@@ -76,13 +93,24 @@ func (m *Manager) Stop() {
 	m.teardown()
 }
 
-// OnLeadershipChange is called when the node's leadership status changes.
+// OnLeadershipChange records the latest leadership generation and wakes the
+// lifecycle-owned reconciliation loop. It deliberately does not reconcile on
+// the caller: bootstrap invokes it synchronously from the Raft observer so
+// transitions are recorded in order without blocking the Raft processing loop
+// on Pebble reads or worker startup.
 func (m *Manager) OnLeadershipChange(isLeader bool) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.leadershipMu.Lock()
+	if m.stopped {
+		m.leadershipMu.Unlock()
 
+		return
+	}
+
+	m.leadershipGeneration++
 	m.isLeader = isLeader
-	m.reconcile()
+	m.leadershipMu.Unlock()
+
+	m.notifications.NotifyConfigChanged()
 }
 
 func (m *Manager) loop(stop <-chan struct{}) {
@@ -99,11 +127,30 @@ func (m *Manager) loop(stop <-chan struct{}) {
 			m.mu.Lock()
 			defer m.mu.Unlock()
 
-			if m.isLeader {
-				m.reconcile()
-			}
+			m.reconcile()
 		},
 	)
+}
+
+func (m *Manager) leadershipSnapshot() (uint64, bool, bool) {
+	m.leadershipMu.Lock()
+	defer m.leadershipMu.Unlock()
+
+	return m.leadershipGeneration, m.isLeader, m.stopped
+}
+
+func (m *Manager) isCurrentLeader(generation uint64) bool {
+	m.leadershipMu.Lock()
+	defer m.leadershipMu.Unlock()
+
+	return !m.stopped && m.isLeader && m.leadershipGeneration == generation
+}
+
+func (m *Manager) isCurrentGeneration(generation uint64) bool {
+	m.leadershipMu.Lock()
+	defer m.leadershipMu.Unlock()
+
+	return m.leadershipGeneration == generation
 }
 
 // reconcile reads the current per-sink configurations from the store and
@@ -111,7 +158,24 @@ func (m *Manager) loop(stop <-chan struct{}) {
 // were added, removed, or changed are affected — unchanged sinks keep running.
 // Must be called under lock.
 func (m *Manager) reconcile() {
-	if !m.isLeader {
+	generation, isLeader, stopped := m.leadershipSnapshot()
+	m.reconcileGeneration(generation, isLeader, stopped)
+}
+
+// reconcileGeneration applies one captured leadership generation. A transition
+// can arrive after the loop wakes but before it acquires m.mu, so reject a
+// superseded generation before either teardown or startup mutates ownership.
+// Must be called under lock.
+func (m *Manager) reconcileGeneration(generation uint64, isLeader, stopped bool) {
+	if !m.isCurrentGeneration(generation) {
+		return
+	}
+	if m.resourcesGeneration != generation {
+		m.teardown()
+		m.resourcesGeneration = generation
+	}
+
+	if stopped || !isLeader {
 		m.teardown()
 
 		return
@@ -133,6 +197,10 @@ func (m *Manager) reconcile() {
 		return
 	}
 
+	if !m.isCurrentLeader(generation) {
+		return
+	}
+
 	// Build desired state as a map keyed by sink name
 	desired := make(map[string]*commonpb.SinkConfig, len(sinkCfgs))
 	for _, sc := range sinkCfgs {
@@ -147,6 +215,10 @@ func (m *Manager) reconcile() {
 
 	// Remove sinks that no longer exist or whose config changed
 	for name, ms := range m.emitters {
+		if !m.isCurrentLeader(generation) {
+			return
+		}
+
 		sc, stillDesired := desired[name]
 		if !stillDesired || !sc.EqualVT(ms.config) {
 			m.stopSink(name, ms)
@@ -156,11 +228,21 @@ func (m *Manager) reconcile() {
 
 	// Start sinks that are new or were just removed due to config change
 	for name, sc := range desired {
+		if !m.isCurrentLeader(generation) {
+			return
+		}
+
 		if _, exists := m.emitters[name]; exists {
 			continue // already running with same config
 		}
 
 		if ms := m.startSink(sc); ms != nil {
+			if !m.isCurrentLeader(generation) {
+				m.stopSink(name, ms)
+
+				return
+			}
+
 			m.emitters[name] = ms
 			delete(m.retries, name)
 		}
@@ -245,10 +327,10 @@ func (m *Manager) scheduleStartupRetry(name string) {
 		}
 
 		delete(m.retries, name)
-		isLeader := m.isLeader
+		_, isLeader, stopped := m.leadershipSnapshot()
 		m.mu.Unlock()
 
-		if isLeader {
+		if isLeader && !stopped {
 			m.notifications.NotifyConfigChanged()
 		}
 	}()

--- a/internal/application/events/manager_leadership_test.go
+++ b/internal/application/events/manager_leadership_test.go
@@ -1,0 +1,124 @@
+package events
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/pkg/signal"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+func managedSinkByName(m *Manager, name string) *managedSink {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.emitters[name]
+}
+
+func saveManagedSinkConfig(t *testing.T, attrs *attributes.Attributes, store *dal.Store, config *commonpb.SinkConfig) {
+	t.Helper()
+
+	batch := store.OpenWriteSession()
+	_, err := attrs.SinkConfig.Set(batch, domain.SinkConfigKey{Name: config.GetName()}.Bytes(), config)
+	require.NoError(t, err)
+	require.NoError(t, batch.Commit())
+}
+
+func TestManager_StopFencesLaterLeadershipGain(t *testing.T) {
+	t.Parallel()
+
+	m := &Manager{
+		notifications: signal.NewNotifications(),
+		emitters:      make(map[string]*managedSink),
+		retries:       make(map[string]struct{}),
+	}
+	m.Start()
+	m.Stop()
+
+	m.OnLeadershipChange(true)
+
+	_, isLeader, stopped := m.leadershipSnapshot()
+	require.True(t, stopped)
+	require.False(t, isLeader)
+	require.Empty(t, m.emitters, "a leadership callback after Stop must not recreate event emitters")
+}
+
+func TestManager_SupersededLossCannotTearDownCurrentGeneration(t *testing.T) {
+	t.Parallel()
+
+	m := &Manager{
+		notifications: signal.NewNotifications(),
+		emitters:      map[string]*managedSink{"current": nil},
+		retries:       make(map[string]struct{}),
+	}
+
+	m.OnLeadershipChange(false)
+	staleGeneration, staleIsLeader, staleStopped := m.leadershipSnapshot()
+	m.OnLeadershipChange(true)
+
+	m.mu.Lock()
+	m.reconcileGeneration(staleGeneration, staleIsLeader, staleStopped)
+	m.mu.Unlock()
+
+	require.Contains(t, m.emitters, "current", "a superseded leadership loss must not tear down current-generation event emitters")
+}
+
+func TestManager_CoalescedLeadershipFlapReplacesPriorGenerationEmitter(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(server.Close)
+
+	builder, store := newTestBuilder(t)
+	attrs := attributes.New()
+	notifications := signal.NewNotifications()
+	saveManagedSinkConfig(t, attrs, store, &commonpb.SinkConfig{
+		Name: "http-sink",
+		Type: &commonpb.SinkConfig_Http{
+			Http: &commonpb.HttpSinkConfig{Endpoint: server.URL},
+		},
+	})
+
+	m := NewManager(store, attrs, nil, builder, logging.Testing(), notifications)
+	m.Start()
+	t.Cleanup(m.Stop)
+	m.OnLeadershipChange(true)
+
+	require.Eventually(t, func() bool {
+		return managedSinkByName(m, "http-sink") != nil
+	}, time.Second, 10*time.Millisecond)
+	previous := managedSinkByName(m, "http-sink")
+
+	func() {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+
+		// Occupy the lifecycle loop on the manager lock, then enqueue a complete
+		// leadership flap. Only one config notification can remain buffered.
+		notifications.NotifyLogsCommitted(1)
+		require.Eventually(t, func() bool {
+			return len(notifications.LogCommitted.C()) == 0
+		}, time.Second, 10*time.Millisecond, "the lifecycle loop must consume the log notification before the flap")
+
+		m.OnLeadershipChange(false)
+		m.OnLeadershipChange(true)
+		require.Len(t, notifications.ConfigChanged.C(), 1, "the loss and regain notifications must coalesce")
+	}()
+
+	require.Eventually(t, func() bool {
+		current := managedSinkByName(m, "http-sink")
+
+		return current != nil && current != previous
+	}, time.Second, 10*time.Millisecond, "an emitter from before the loss must not be retained by the new leader generation")
+}

--- a/internal/application/mirror/manager.go
+++ b/internal/application/mirror/manager.go
@@ -40,9 +40,14 @@ type Manager struct {
 	meterProvider metric.MeterProvider
 	maxBatchSize  int
 
-	mu       sync.Mutex
-	isLeader bool
-	workers  map[string]*Worker
+	mu                  sync.Mutex
+	workers             map[string]*Worker
+	resourcesGeneration uint64
+
+	leadershipMu         sync.Mutex
+	leadershipGeneration uint64
+	isLeader             bool
+	stopped              bool
 
 	w worker.Worker
 }
@@ -70,6 +75,18 @@ func (m *Manager) Start() {
 
 // Stop gracefully stops the Manager and tears down any active workers.
 func (m *Manager) Stop() {
+	m.leadershipMu.Lock()
+	if m.stopped {
+		m.leadershipMu.Unlock()
+
+		return
+	}
+
+	m.leadershipGeneration++
+	m.isLeader = false
+	m.stopped = true
+	m.leadershipMu.Unlock()
+
 	m.w.Stop()
 
 	m.mu.Lock()
@@ -78,13 +95,24 @@ func (m *Manager) Stop() {
 	m.teardown()
 }
 
-// OnLeadershipChange is called when the node's leadership status changes.
+// OnLeadershipChange records the latest leadership generation and wakes the
+// lifecycle-owned reconciliation loop. It deliberately does not reconcile on
+// the caller: bootstrap invokes it synchronously from the Raft observer so
+// transitions are recorded in order without blocking the Raft processing loop
+// on Pebble reads or worker startup.
 func (m *Manager) OnLeadershipChange(isLeader bool) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
+	m.leadershipMu.Lock()
+	if m.stopped {
+		m.leadershipMu.Unlock()
 
+		return
+	}
+
+	m.leadershipGeneration++
 	m.isLeader = isLeader
-	m.reconcile()
+	m.leadershipMu.Unlock()
+
+	m.notifications.NotifyConfigChanged()
 }
 
 func (m *Manager) loop(stop <-chan struct{}) {
@@ -101,17 +129,53 @@ func (m *Manager) loop(stop <-chan struct{}) {
 			m.mu.Lock()
 			defer m.mu.Unlock()
 
-			if m.isLeader {
-				m.reconcile()
-			}
+			m.reconcile()
 		},
 	)
+}
+
+func (m *Manager) leadershipSnapshot() (uint64, bool, bool) {
+	m.leadershipMu.Lock()
+	defer m.leadershipMu.Unlock()
+
+	return m.leadershipGeneration, m.isLeader, m.stopped
+}
+
+func (m *Manager) isCurrentLeader(generation uint64) bool {
+	m.leadershipMu.Lock()
+	defer m.leadershipMu.Unlock()
+
+	return !m.stopped && m.isLeader && m.leadershipGeneration == generation
+}
+
+func (m *Manager) isCurrentGeneration(generation uint64) bool {
+	m.leadershipMu.Lock()
+	defer m.leadershipMu.Unlock()
+
+	return m.leadershipGeneration == generation
 }
 
 // reconcile reads the current mirror ledger configurations from the store and
 // starts or stops workers as needed. Must be called under lock.
 func (m *Manager) reconcile() {
-	if !m.isLeader {
+	generation, isLeader, stopped := m.leadershipSnapshot()
+	m.reconcileGeneration(generation, isLeader, stopped)
+}
+
+// reconcileGeneration applies one captured leadership generation. A transition
+// can arrive after the loop wakes but before it acquires m.mu, so reject a
+// superseded generation before either teardown or startup mutates ownership.
+// Must be called under lock.
+func (m *Manager) reconcileGeneration(generation uint64, isLeader, stopped bool) {
+	if !m.isCurrentGeneration(generation) {
+		return
+	}
+	if m.resourcesGeneration != generation {
+		m.teardown()
+		m.resourcesGeneration = generation
+	}
+
+	if stopped || !isLeader {
 		m.teardown()
 
 		return
@@ -133,6 +197,10 @@ func (m *Manager) reconcile() {
 		return
 	}
 
+	if !m.isCurrentLeader(generation) {
+		return
+	}
+
 	// Build desired state as a set of ledger names
 	desired := make(map[string]*commonpb.LedgerInfo, len(mirrorLedgers))
 	for _, info := range mirrorLedgers {
@@ -141,6 +209,10 @@ func (m *Manager) reconcile() {
 
 	// Remove workers for ledgers that are no longer mirrors
 	for name, w := range m.workers {
+		if !m.isCurrentLeader(generation) {
+			return
+		}
+
 		if _, stillDesired := desired[name]; !stillDesired {
 			w.Stop()
 			delete(m.workers, name)
@@ -149,6 +221,10 @@ func (m *Manager) reconcile() {
 
 	// Start workers for new mirror ledgers
 	for name, info := range desired {
+		if !m.isCurrentLeader(generation) {
+			return
+		}
+
 		if _, exists := m.workers[name]; exists {
 			continue // already running
 		}
@@ -182,6 +258,12 @@ func (m *Manager) reconcile() {
 
 		w := NewWorker(name, batchSize, source, rewriter, m.store, m.proposer, m.builder, m.logger, m.meterProvider)
 		w.Start()
+		if !m.isCurrentLeader(generation) {
+			w.Stop()
+
+			return
+		}
+
 		m.workers[name] = w
 	}
 

--- a/internal/application/mirror/manager_test.go
+++ b/internal/application/mirror/manager_test.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/metric/noop"
@@ -88,13 +90,30 @@ func newTestManager(t *testing.T, store *dal.Store, builder *plan.Builder) *Mana
 		noop.NewMeterProvider(),
 		0,
 	)
-	t.Cleanup(func() {
-		m.mu.Lock()
-		defer m.mu.Unlock()
-		m.teardown()
-	})
+	m.Start()
+	t.Cleanup(m.Stop)
 
 	return m
+}
+
+func requireWorkerNames(t *testing.T, m *Manager, expected ...string) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		actual := workerNames(m)
+		if len(actual) != len(expected) {
+			return false
+		}
+
+		for _, expectedName := range expected {
+			found := slices.Contains(actual, expectedName)
+			if !found {
+				return false
+			}
+		}
+
+		return true
+	}, time.Second, 10*time.Millisecond)
 }
 
 // workerNames snapshots the live worker set under the manager's lock.
@@ -121,7 +140,7 @@ func TestManager_ReconcileStartsWorkerForMirrorLedger(t *testing.T) {
 	m := newTestManager(t, store, builder)
 	m.OnLeadershipChange(true)
 
-	require.Equal(t, []string{"mirrored"}, workerNames(m))
+	requireWorkerNames(t, m, "mirrored")
 }
 
 // Promotion flips the ledger out of MIRROR mode, so ReadMirrorLedgers stops
@@ -137,7 +156,7 @@ func TestManager_ReconcileStopsWorkerOnPromotion(t *testing.T) {
 
 	m := newTestManager(t, store, builder)
 	m.OnLeadershipChange(true)
-	require.Equal(t, []string{"promoted"}, workerNames(m))
+	requireWorkerNames(t, m, "promoted")
 
 	// Promote: mode back to NORMAL and the source config cleared, matching
 	// processPromoteLedger.
@@ -147,7 +166,7 @@ func TestManager_ReconcileStopsWorkerOnPromotion(t *testing.T) {
 	})
 
 	m.OnLeadershipChange(true)
-	require.Empty(t, workerNames(m), "a promoted ledger is no longer a mirror; its worker must be stopped and dropped")
+	requireWorkerNames(t, m)
 }
 
 // Deletion soft-deletes the ledger, which also drops it from ReadMirrorLedgers
@@ -166,14 +185,14 @@ func TestManager_ReconcileStopsWorkerOnDeletion(t *testing.T) {
 
 	m := newTestManager(t, store, builder)
 	m.OnLeadershipChange(true)
-	require.Equal(t, []string{"deleted"}, workerNames(m))
+	requireWorkerNames(t, m, "deleted")
 
 	info := mirrorLedgerInfo("deleted", sourceURL)
 	info.DeletedAt = &commonpb.Timestamp{Data: 1}
 	saveLedgerInfo(t, store, info)
 
 	m.OnLeadershipChange(true)
-	require.Empty(t, workerNames(m), "a deleted ledger must not keep a worker, even though it is still in MIRROR mode")
+	requireWorkerNames(t, m)
 }
 
 // Losing leadership tears every worker down, whatever the config says: workers
@@ -186,12 +205,89 @@ func TestManager_ReconcileTearsDownOnLeadershipLoss(t *testing.T) {
 
 	m := newTestManager(t, store, builder)
 	m.OnLeadershipChange(true)
-	require.Equal(t, []string{"mirrored"}, workerNames(m))
+	requireWorkerNames(t, m, "mirrored")
 
 	m.OnLeadershipChange(false)
-	require.Empty(t, workerNames(m))
+	requireWorkerNames(t, m)
 
 	// And regaining leadership rebuilds the set from the store.
 	m.OnLeadershipChange(true)
-	require.Equal(t, []string{"mirrored"}, workerNames(m))
+	requireWorkerNames(t, m, "mirrored")
+}
+
+func TestManager_StopFencesLaterLeadershipGain(t *testing.T) {
+	t.Parallel()
+
+	m := &Manager{
+		notifications: signal.NewNotifications(),
+		workers:       make(map[string]*Worker),
+	}
+	m.Start()
+	m.Stop()
+
+	m.OnLeadershipChange(true)
+
+	_, isLeader, stopped := m.leadershipSnapshot()
+	require.True(t, stopped)
+	require.False(t, isLeader)
+	require.Empty(t, workerNames(m), "a leadership callback after Stop must not recreate mirror workers")
+}
+
+func TestManager_SupersededLossCannotTearDownCurrentGeneration(t *testing.T) {
+	t.Parallel()
+
+	m := &Manager{
+		notifications: signal.NewNotifications(),
+		workers:       map[string]*Worker{"current": nil},
+	}
+
+	m.OnLeadershipChange(false)
+	staleGeneration, staleIsLeader, staleStopped := m.leadershipSnapshot()
+	m.OnLeadershipChange(true)
+
+	m.mu.Lock()
+	m.reconcileGeneration(staleGeneration, staleIsLeader, staleStopped)
+	m.mu.Unlock()
+
+	require.Contains(t, m.workers, "current", "a superseded leadership loss must not tear down current-generation mirror workers")
+}
+
+func TestManager_CoalescedLeadershipFlapReplacesPriorGenerationWorker(t *testing.T) {
+	t.Parallel()
+
+	builder, store := newTestBuilder(t)
+	saveLedgerInfo(t, store, mirrorLedgerInfo("mirrored", quietV2Source(t)))
+
+	m := newTestManager(t, store, builder)
+	m.OnLeadershipChange(true)
+	requireWorkerNames(t, m, "mirrored")
+
+	m.mu.Lock()
+	previous := m.workers["mirrored"]
+	m.mu.Unlock()
+
+	func() {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+
+		// Occupy the lifecycle loop on the manager lock, then enqueue a complete
+		// leadership flap. Only one config notification can remain buffered.
+		m.notifications.NotifyLogsCommitted(1)
+		require.Eventually(t, func() bool {
+			return len(m.notifications.LogCommitted.C()) == 0
+		}, time.Second, 10*time.Millisecond, "the lifecycle loop must consume the log notification before the flap")
+
+		m.OnLeadershipChange(false)
+		m.OnLeadershipChange(true)
+		require.Len(t, m.notifications.ConfigChanged.C(), 1, "the loss and regain notifications must coalesce")
+	}()
+
+	require.Eventually(t, func() bool {
+		m.mu.Lock()
+		defer m.mu.Unlock()
+
+		current := m.workers["mirrored"]
+
+		return current != nil && current != previous
+	}, time.Second, 10*time.Millisecond, "a worker from before the loss must not be retained by the new leader generation")
 }

--- a/internal/bootstrap/module.go
+++ b/internal/bootstrap/module.go
@@ -935,12 +935,12 @@ func Module() fx.Option {
 						// cancellation. Apply it inline.
 						backupOrchestrator.OnLeadershipChange(e.IsLeader)
 
-						// The events / mirror reconcile is dispatched off the
-						// observer thread because it does a full Pebble
-						// attribute scan that can take minutes; running it
-						// synchronously would stall processReady and the
-						// readiness probe.
-						go handleLeadershipChangeEvent(e, eventsManager, mirrorManager, logger)
+						// Record the events / mirror transition inline so it
+						// cannot be reordered behind a later transition. The
+						// managers only update their desired generation here;
+						// their lifecycle-owned loops perform the potentially
+						// slow Pebble reconciliation asynchronously.
+						handleLeadershipChangeEvent(e, eventsManager, mirrorManager, logger)
 					case node.LeaderReadyEvent:
 						proposeClusterConfigIfNeeded(n, builder, store, cfg, logger)
 					default:
@@ -1788,20 +1788,21 @@ func applyAnonymousScopes(mapping internalauth.ScopeMapping, raw string, logger 
 	return nil
 }
 
-// handleLeadershipChangeEvent reconciles event emitter and mirror
-// workers on leadership transitions. Runs in a goroutine — see the
-// observer callback above for the dispatch and the reason
-// (event/mirror reconcile can take minutes).
+// handleLeadershipChangeEvent records the desired leadership generation for
+// the event and mirror managers. Each manager's lifecycle-owned loop performs
+// the potentially slow reconciliation and fences it against later generations.
 //
 // The backup orchestrator's OnLeadershipChange is intentionally NOT
-// called here: it must observe transitions in order and inline, so
-// a leadership flap cannot interleave an old-(false) update behind
-// a newer-(true) update. See the observer's LeadershipChangeEvent
-// branch.
+// called here: it has no asynchronous reconciliation and is updated directly
+// by the observer. See the observer's LeadershipChangeEvent branch.
+type leadershipChangeManager interface {
+	OnLeadershipChange(bool)
+}
+
 func handleLeadershipChangeEvent(
 	e node.LeadershipChangeEvent,
-	eventsManager *events.Manager,
-	mirrorManager *mirror.Manager,
+	eventsManager leadershipChangeManager,
+	mirrorManager leadershipChangeManager,
 	logger logging.Logger,
 ) {
 	if e.IsLeader {


### PR DESCRIPTION
## What changed

Leadership transitions for the events and mirror managers are now recorded synchronously and reconciled by their lifecycle-owned loops. Monotonic generations fence stale scans, startups, teardowns, and callbacks after Fx shutdown. Deterministic regression tests cover superseded leadership loss and post-Stop callbacks.

## Why

Fixes [EN-1959](https://formance-team.atlassian.net/browse/EN-1959).

Out-of-order asynchronous leadership callbacks could stop current-generation workers or recreate leader-only workers after leadership loss or Fx teardown.

## Product / operational motivation

Need: leader-only event and mirror workers must match the current Raft leadership generation.
Current limitation: callback serialization did not preserve transition order or establish generation ownership.
Requirement / constraint: work from generation N must never mutate generation N+1 lifecycle state or survive shutdown.
Evidence: EN-1959, deterministic stale-callback regression tests, and the lifecycle contracts in docs/technical/architecture/subsystems/events-mirror/.
Durable repository evidence: docs/technical/architecture/subsystems/events-mirror/events.md and mirror.md.

## Technical decision

Decision: record leadership transitions inline, reconcile slow work in the existing manager loops, and fence each reconciliation with a monotonically increasing generation. Stop closes the leadership gate before draining the loop.
Why now / why proportionate: this directly fixes the confirmed stale-callback execution path without redesigning the worker lifecycle.
Alternatives considered: mutex-only callback serialization was rejected because it cannot preserve transition order; callback-owned reconciliation goroutines were rejected because they lack lifecycle generation ownership.

## Risk

**MEDIUM** — concurrency and leader-only worker lifecycle change, bounded to events, mirror, and bootstrap wiring; no persisted format, API, or FSM semantics change.

## Validation

- [x] AI_REVIEW_BASE_SHA=ce72d6df10142a48fa3193ed369831d5f0252854 bash scripts/agent-check-pr
- [x] Race tests: ./internal/application/events, ./internal/application/mirror, ./internal/bootstrap
- [x] Deterministic stale-callback regression and regression sensitivity evidence
- [ ] Full suite / broader validation: GitHub CI

## Architecture / behavior impact

Leader-only events and mirror workers now use explicit leadership-generation ownership. No persisted state, wire format, API, or deterministic FSM behavior changes.

## Review focus

Please focus on generation checks around slow reconciliation, worker retention, superseded leadership loss, and the Stop gate/drain ordering.

## Known concerns

None.

[EN-1959]: https://formance-team.atlassian.net/browse/EN-1959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ