### PR TITLE
fix(EN-1960): keep snapshot checkpoints alive during FetchFile

### DIFF
--- a/docs/technical/architecture/subsystems/storage/README.md
+++ b/docs/technical/architecture/subsystems/storage/README.md
@@ -7,7 +7,7 @@ The persistence layer (`internal/storage/dal`, `internal/storage/wal`, `internal
 | Document | Description |
 |----------|-------------|
 | [storage.md](storage.md) | WAL, snapshot/compaction boundaries, runtime stores, persistence, and recovery. |
-| [follower-sync.md](follower-sync.md) | Checkpoint streaming, SHA-256 verification, retries, and WAL reclamation after snapshot install. |
+| [follower-sync.md](follower-sync.md) | Checkpoint streaming, session lifetime, SHA-256 verification, retries, and WAL reclamation after snapshot install. |
 | [storage-drivers.md](storage-drivers.md) | Pebble storage driver characteristics and configuration. |
 | [spool.md](spool.md) | Committed entry buffer between Raft and FSM synchronization. |
 

--- a/docs/technical/architecture/subsystems/storage/follower-sync.md
+++ b/docs/technical/architecture/subsystems/storage/follower-sync.md
@@ -16,8 +16,11 @@ in parallel.
 3. The follower writes chunks to a `.tmp` file while computing the same digest.
    It requires the exact manifest byte count and a valid, matching SHA-256
    digest before atomically renaming the temporary file.
-4. `CloseSession` removes the temporary checkpoint. Session expiry provides a
-   backstop when the caller disappears.
+4. `CloseSession` retires the session. Session expiry provides a backstop when
+   the caller disappears. Either event rejects new `FetchFile` calls
+   immediately, but an acquired `FetchFile` pins the temporary checkpoint until
+   that operation finishes. Service shutdown follows the same rule: it retires
+   every session immediately and the last active user removes the checkpoint.
 
 Manifest construction never reads file contents. Its cost therefore scales
 with the number of checkpoint files rather than the checkpoint size. The file

--- a/internal/adapter/grpc/server_snapshot.go
+++ b/internal/adapter/grpc/server_snapshot.go
@@ -48,7 +48,8 @@ func NewSnapshotServiceServer(logger logging.Logger, s *dal.Store, sessionTTL ti
 	}
 }
 
-// StopSnapshotService stops the session reaper and cleans up all active sessions.
+// StopSnapshotService stops the session reaper and retires all sessions.
+// Checkpoints still in use are removed when their last FetchFile completes.
 func StopSnapshotService(server snapshotpb.SnapshotServiceServer) {
 	if impl, ok := server.(*SnapshotServiceServerImpl); ok {
 		impl.sessions.stop()
@@ -131,10 +132,11 @@ func (s *SnapshotServiceServerImpl) PrepareSnapshot(ctx context.Context, req *sn
 
 // FetchFile streams a single file from a prepared snapshot session.
 func (s *SnapshotServiceServerImpl) FetchFile(req *snapshotpb.FetchFileRequest, stream ggrpc.ServerStreamingServer[snapshotpb.FetchFileResponse]) error {
-	session, ok := s.sessions.get(req.GetSessionId())
+	session, ok := s.sessions.acquire(req.GetSessionId())
 	if !ok {
 		return status.Errorf(codes.NotFound, "session %s not found or expired", req.GetSessionId())
 	}
+	defer s.sessions.release(session)
 
 	// Validate the path stays within the checkpoint directory.
 	relPath := req.GetPath()
@@ -149,7 +151,8 @@ func (s *SnapshotServiceServerImpl) FetchFile(req *snapshotpb.FetchFileRequest, 
 	})
 }
 
-// CloseSession releases the snapshot session and its temporary checkpoint.
+// CloseSession retires the snapshot session. Its temporary checkpoint is
+// removed immediately unless an acquired FetchFile is still using it.
 func (s *SnapshotServiceServerImpl) CloseSession(_ context.Context, req *snapshotpb.CloseSessionRequest) (*snapshotpb.CloseSessionResponse, error) {
 	s.sessions.remove(req.GetSessionId())
 

--- a/internal/adapter/grpc/server_snapshot.go
+++ b/internal/adapter/grpc/server_snapshot.go
@@ -151,8 +151,10 @@ func (s *SnapshotServiceServerImpl) FetchFile(req *snapshotpb.FetchFileRequest, 
 	})
 }
 
-// CloseSession retires the snapshot session. Its temporary checkpoint is
-// removed immediately unless an acquired FetchFile is still using it.
+// CloseSession atomically retires the snapshot session, preventing new
+// FetchFile acquisitions. Already-acquired FetchFile calls may finish; the
+// final release removes the temporary checkpoint. The operation is idempotent
+// and does not wait for active calls to finish.
 func (s *SnapshotServiceServerImpl) CloseSession(_ context.Context, req *snapshotpb.CloseSessionRequest) (*snapshotpb.CloseSessionResponse, error) {
 	s.sessions.remove(req.GetSessionId())
 

--- a/internal/adapter/grpc/server_snapshot_test.go
+++ b/internal/adapter/grpc/server_snapshot_test.go
@@ -78,10 +78,11 @@ func (s *testSnapshotServer) PrepareSnapshot(ctx context.Context, _ *snapshotpb.
 }
 
 func (s *testSnapshotServer) FetchFile(req *snapshotpb.FetchFileRequest, stream ggrpc.ServerStreamingServer[snapshotpb.FetchFileResponse]) error {
-	session, ok := s.sessions.get(req.GetSessionId())
+	session, ok := s.sessions.acquire(req.GetSessionId())
 	if !ok {
 		return status.Errorf(codes.NotFound, "session not found")
 	}
+	defer s.sessions.release(session)
 
 	buf := make([]byte, defaultChunkSize)
 

--- a/internal/adapter/grpc/snapshot_session.go
+++ b/internal/adapter/grpc/snapshot_session.go
@@ -3,7 +3,7 @@ package grpc
 import (
 	"crypto/rand"
 	"encoding/hex"
-	"maps"
+	"errors"
 	"sync"
 	"time"
 
@@ -22,6 +22,8 @@ type snapshotSession struct {
 	syncName       string
 	checkpointPath string
 	lastAccess     time.Time
+	activeUsers    int
+	retired        bool
 }
 
 // snapshotSessionStore manages snapshot sessions with TTL-based expiry.
@@ -33,6 +35,8 @@ type snapshotSessionStore struct {
 	logger   logging.Logger
 	ttl      time.Duration
 	stopCh   chan struct{}
+	stopOnce sync.Once
+	stopped  bool
 }
 
 func newSnapshotSessionStore(store *dal.Store, logger logging.Logger, ttl time.Duration) *snapshotSessionStore {
@@ -56,26 +60,50 @@ func (ss *snapshotSessionStore) create(syncName, checkpointPath string) (string,
 	}
 
 	ss.mu.Lock()
+	defer ss.mu.Unlock()
+
+	if ss.stopped {
+		return "", errors.New("snapshot session store stopped")
+	}
+
 	ss.sessions[id] = &snapshotSession{
 		syncName:       syncName,
 		checkpointPath: checkpointPath,
 		lastAccess:     time.Now(),
 	}
-	ss.mu.Unlock()
 
 	return id, nil
 }
 
-func (ss *snapshotSessionStore) get(sessionID string) (*snapshotSession, bool) {
+// acquire pins a session's checkpoint until release is called. A retired
+// session cannot be acquired again, but its active users may finish.
+func (ss *snapshotSessionStore) acquire(sessionID string) (*snapshotSession, bool) {
 	ss.mu.Lock()
 	defer ss.mu.Unlock()
 
 	s, ok := ss.sessions[sessionID]
 	if ok {
+		s.activeUsers++
 		s.lastAccess = time.Now()
 	}
 
 	return s, ok
+}
+
+func (ss *snapshotSessionStore) release(s *snapshotSession) {
+	ss.mu.Lock()
+	if s.activeUsers == 0 {
+		ss.mu.Unlock()
+		panic("releasing snapshot session without an active user")
+	}
+
+	s.activeUsers--
+	cleanup := s.retired && s.activeUsers == 0
+	ss.mu.Unlock()
+
+	if cleanup {
+		ss.cleanupCheckpoint(s.syncName)
+	}
 }
 
 func (ss *snapshotSessionStore) remove(sessionID string) {
@@ -83,10 +111,12 @@ func (ss *snapshotSessionStore) remove(sessionID string) {
 	s, ok := ss.sessions[sessionID]
 	if ok {
 		delete(ss.sessions, sessionID)
+		s.retired = true
 	}
+	cleanup := ok && s.activeUsers == 0
 	ss.mu.Unlock()
 
-	if ok {
+	if cleanup {
 		ss.cleanupCheckpoint(s.syncName)
 	}
 }
@@ -120,8 +150,13 @@ func (ss *snapshotSessionStore) reapExpired() {
 	expiredSessions := make([]*snapshotSession, 0, len(expired))
 
 	for _, id := range expired {
-		expiredSessions = append(expiredSessions, ss.sessions[id])
+		s := ss.sessions[id]
 		delete(ss.sessions, id)
+		s.retired = true
+
+		if s.activeUsers == 0 {
+			expiredSessions = append(expiredSessions, s)
+		}
 	}
 
 	ss.mu.Unlock()
@@ -143,23 +178,35 @@ func (ss *snapshotSessionStore) cleanupCheckpoint(syncName string) {
 		ss.logger.WithFields(map[string]any{
 			"error":    err,
 			"syncName": syncName,
-		}).Errorf("Failed to remove temporary checkpoint for expired session")
+		}).Errorf("Failed to remove temporary checkpoint for snapshot session")
 	}
 }
 
 func (ss *snapshotSessionStore) stop() {
-	close(ss.stopCh)
+	ss.stopOnce.Do(func() {
+		close(ss.stopCh)
 
-	// Clean up all remaining sessions.
-	ss.mu.Lock()
-	remaining := make(map[string]*snapshotSession, len(ss.sessions))
-	maps.Copy(remaining, ss.sessions)
-	ss.sessions = make(map[string]*snapshotSession)
-	ss.mu.Unlock()
+		// Retire all remaining sessions. Checkpoints with active users are
+		// cleaned up by the last release.
+		ss.mu.Lock()
+		ss.stopped = true
+		remaining := make([]*snapshotSession, 0, len(ss.sessions))
 
-	for _, s := range remaining {
-		ss.cleanupCheckpoint(s.syncName)
-	}
+		for id, s := range ss.sessions {
+			delete(ss.sessions, id)
+			s.retired = true
+
+			if s.activeUsers == 0 {
+				remaining = append(remaining, s)
+			}
+		}
+
+		ss.mu.Unlock()
+
+		for _, s := range remaining {
+			ss.cleanupCheckpoint(s.syncName)
+		}
+	})
 }
 
 func generateSessionID() (string, error) {

--- a/internal/adapter/grpc/snapshot_session_test.go
+++ b/internal/adapter/grpc/snapshot_session_test.go
@@ -1,0 +1,219 @@
+package grpc
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+	"go.uber.org/mock/gomock"
+
+	"github.com/formancehq/ledger/v3/internal/proto/snapshotpb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+func newSnapshotSessionFixture(t *testing.T, syncName string) (*dal.Store, *snapshotSessionStore, string, string) {
+	t.Helper()
+
+	store, err := dal.NewStore(
+		t.TempDir(),
+		noopLogger{},
+		noop.NewMeterProvider().Meter("test"),
+		dal.DefaultConfig(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+
+	checkpointPath, err := store.CreateTemporaryCheckpoint(syncName)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(checkpointPath, "data.bin"), []byte("checkpoint data"), 0600))
+
+	sessions := newSnapshotSessionStore(store, noopLogger{}, defaultSessionTTL)
+	t.Cleanup(sessions.stop)
+
+	sessionID, err := sessions.create(syncName, checkpointPath)
+	require.NoError(t, err)
+
+	return store, sessions, sessionID, checkpointPath
+}
+
+func TestSnapshotSessionStore_CloseDefersCleanupUntilActiveFetchReleases(t *testing.T) {
+	t.Parallel()
+
+	const syncName = "active-fetch"
+	store, sessions, sessionID, _ := newSnapshotSessionFixture(t, syncName)
+
+	session, ok := sessions.acquire(sessionID)
+	require.True(t, ok)
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { sessions.release(session) })
+	}
+	t.Cleanup(release)
+
+	// Reproduce the failing interleaving: FetchFile has acquired the session,
+	// then CloseSession removes it before FetchFile opens the rooted file.
+	sessions.remove(sessionID)
+
+	var received []byte
+	err := streamOneFile(session.checkpointPath, "data.bin", make([]byte, defaultChunkSize), func(resp *snapshotpb.FetchFileResponse) error {
+		received = append(received, resp.GetData()...)
+
+		return nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, []byte("checkpoint data"), received)
+
+	_, exists := store.TemporaryCheckpointPath(syncName)
+	require.True(t, exists)
+
+	release()
+
+	_, exists = store.TemporaryCheckpointPath(syncName)
+	require.False(t, exists)
+}
+
+func TestSnapshotService_FetchFileReleasesSessionUseOnCompletion(t *testing.T) {
+	t.Parallel()
+
+	const syncName = "completed-fetch"
+	store, sessions, sessionID, _ := newSnapshotSessionFixture(t, syncName)
+	server := &SnapshotServiceServerImpl{logger: noopLogger{}, sessions: sessions}
+	stream := newFakeServerStream[snapshotpb.FetchFileResponse](t)
+
+	require.NoError(t, server.FetchFile(&snapshotpb.FetchFileRequest{
+		SessionId: sessionID,
+		Path:      "data.bin",
+	}, stream))
+	require.NotEmpty(t, stream.sent)
+
+	_, err := server.CloseSession(context.Background(), &snapshotpb.CloseSessionRequest{SessionId: sessionID})
+	require.NoError(t, err)
+
+	_, exists := store.TemporaryCheckpointPath(syncName)
+	require.False(t, exists)
+}
+
+func TestSnapshotService_CloseRacingActiveFetchDefersCleanup(t *testing.T) {
+	t.Parallel()
+
+	const syncName = "close-race"
+	store, sessions, sessionID, _ := newSnapshotSessionFixture(t, syncName)
+	server := &SnapshotServiceServerImpl{logger: noopLogger{}, sessions: sessions}
+
+	firstSend := make(chan struct{})
+	continueSend := make(chan struct{})
+	var continueOnce sync.Once
+	unblockSend := func() {
+		continueOnce.Do(func() { close(continueSend) })
+	}
+	t.Cleanup(unblockSend)
+
+	stream := NewMockServerStreamingServer[snapshotpb.FetchFileResponse](gomock.NewController(t))
+	var sendCount atomic.Int32
+	stream.EXPECT().Send(gomock.Any()).DoAndReturn(func(*snapshotpb.FetchFileResponse) error {
+		if sendCount.Add(1) == 1 {
+			close(firstSend)
+			<-continueSend
+		}
+
+		return nil
+	}).AnyTimes()
+
+	fetchDone := make(chan error, 1)
+	go func() {
+		fetchDone <- server.FetchFile(&snapshotpb.FetchFileRequest{
+			SessionId: sessionID,
+			Path:      "data.bin",
+		}, stream)
+	}()
+
+	<-firstSend
+
+	_, err := server.CloseSession(context.Background(), &snapshotpb.CloseSessionRequest{SessionId: sessionID})
+	require.NoError(t, err)
+	_, exists := store.TemporaryCheckpointPath(syncName)
+	require.True(t, exists)
+	_, ok := sessions.acquire(sessionID)
+	require.False(t, ok)
+
+	unblockSend()
+	require.NoError(t, <-fetchDone)
+
+	_, exists = store.TemporaryCheckpointPath(syncName)
+	require.False(t, exists)
+}
+
+func TestSnapshotSessionStore_ExpiryDefersCleanupUntilActiveFetchReleases(t *testing.T) {
+	t.Parallel()
+
+	const syncName = "expired-fetch"
+	store, sessions, sessionID, _ := newSnapshotSessionFixture(t, syncName)
+	session, ok := sessions.acquire(sessionID)
+	require.True(t, ok)
+
+	sessions.mu.Lock()
+	session.lastAccess = time.Now().Add(-sessions.ttl - time.Second)
+	sessions.mu.Unlock()
+	sessions.reapExpired()
+
+	_, ok = sessions.acquire(sessionID)
+	require.False(t, ok)
+	_, exists := store.TemporaryCheckpointPath(syncName)
+	require.True(t, exists)
+
+	sessions.release(session)
+
+	_, exists = store.TemporaryCheckpointPath(syncName)
+	require.False(t, exists)
+}
+
+func TestSnapshotSessionStore_CleanupWaitsForLastActiveFetch(t *testing.T) {
+	t.Parallel()
+
+	const syncName = "parallel-fetches"
+	store, sessions, sessionID, _ := newSnapshotSessionFixture(t, syncName)
+	first, ok := sessions.acquire(sessionID)
+	require.True(t, ok)
+	second, ok := sessions.acquire(sessionID)
+	require.True(t, ok)
+
+	sessions.remove(sessionID)
+	sessions.release(first)
+
+	_, exists := store.TemporaryCheckpointPath(syncName)
+	require.True(t, exists)
+
+	sessions.release(second)
+
+	_, exists = store.TemporaryCheckpointPath(syncName)
+	require.False(t, exists)
+}
+
+func TestSnapshotSessionStore_StopDefersCleanupUntilActiveFetchReleases(t *testing.T) {
+	t.Parallel()
+
+	const syncName = "shutdown-fetch"
+	store, sessions, sessionID, checkpointPath := newSnapshotSessionFixture(t, syncName)
+	session, ok := sessions.acquire(sessionID)
+	require.True(t, ok)
+
+	sessions.stop()
+
+	_, ok = sessions.acquire(sessionID)
+	require.False(t, ok)
+	_, exists := store.TemporaryCheckpointPath(syncName)
+	require.True(t, exists)
+	_, err := sessions.create("after-stop", checkpointPath)
+	require.ErrorContains(t, err, "stopped")
+
+	sessions.release(session)
+
+	_, exists = store.TemporaryCheckpointPath(syncName)
+	require.False(t, exists)
+}


### PR DESCRIPTION
## What changed

Snapshot `FetchFile` now acquires explicit ownership of its session for the duration of the request. Session close, expiry, and service shutdown retire lookup authority immediately while deferring physical checkpoint cleanup until admitted users have released it.

The storage lifecycle documentation and deterministic concurrency regression coverage are updated with the same contract.

## Why

[EN-1960](https://formancehq.atlassian.net/browse/EN-1960) tracks a race where cleanup could delete a snapshot checkpoint after `FetchFile` found its session but before it opened or finished reading the requested file.

## Product / operational motivation

Need: admitted snapshot downloads must remain readable through completion.
Current limitation: session lookup returned an unowned pointer, allowing concurrent close, expiry, or shutdown to delete its backing checkpoint.
Requirement / constraint: retirement rejects new acquisitions and physical cleanup occurs exactly once after the final active user releases ownership.
Evidence: deterministic pre-fix reproduction and post-fix regression in `internal/adapter/grpc/snapshot_session_test.go`.
Durable repository evidence: `docs/technical/architecture/subsystems/storage/follower-sync.md` and `docs/technical/architecture/subsystems/storage/README.md`.

## Technical decision

Decision: add explicit active-use accounting and retired state to snapshot sessions; `FetchFile` acquires/releases ownership, while all cleanup paths retire first and wait for active users to drain.
Why now / why proportionate: the checkpoint filesystem lifetime must cover the complete RPC, not only registry lookup. Centralizing ownership in the session gives close, expiry, shutdown, and multiple readers one lifecycle contract.
Alternatives considered: retaining the unowned lookup leaves the race intact; holding the registry lock across file streaming would serialize unrelated operations and couple network duration to global registry progress.

## Risk

**MEDIUM** — localized gRPC snapshot lifecycle synchronization, with concurrency-sensitive cleanup semantics and deterministic race coverage.

## Validation

- [x] `env -u GOROOT -u GOTOOLDIR nix develop --command bash -c 'AI_REVIEW_BASE_SHA=ce72d6df10142a48fa3193ed369831d5f0252854 bash scripts/agent-check-pr'`
- [x] Targeted race: `go test -race ./internal/adapter/grpc` selected by the canonical validation
- [ ] Full suite / broader validation: GitHub CI

Additional existing evidence: `BEFORE_FIX=BUG_REPRODUCED`; `AFTER_FIX=PASS`; multi-user/boundaries PASS; regression sensitivity PASS; exact final review APPROVE.

## Architecture / behavior impact

Snapshot session lifecycle only. No wire-format, API-shape, FSM, Raft, or persisted-format change.

## Review focus

Please focus on acquisition/release ordering, retirement under close/expiry/shutdown, and exactly-once cleanup after the final concurrent reader.

## Known concerns

Broad CI and human review remain required before merge. No known product-code concern from the focused validation.


[EN-1960]: https://formance-team.atlassian.net/browse/EN-1960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ