### PR TITLE
test(EN-1965): specify and cover the AddressTxIterator union

### DIFF
--- a/docs/technical/architecture/subsystems/read-path/README.md
+++ b/docs/technical/architecture/subsystems/read-path/README.md
@@ -16,7 +16,7 @@ and the pipeline pages.
 | Document | Description |
 |----------|-------------|
 | [query-pipeline.md](query-pipeline.md) | End-to-end read flow: ReadIndex barrier, min_log_sequence, Pebble snapshot, iterator algebra, pagination, streaming. |
-| [iterator-seek-contract.md](iterator-seek-contract.md) | Absolute SeekGE/SeekLE semantics across the iterator algebra, and the seekFloor/seekCeil exhaustion-proof cache. |
+| [iterator-seek-contract.md](iterator-seek-contract.md) | Absolute SeekGE/SeekLE semantics across the iterator algebra, the AddressTxIterator materialized union, and the seekFloor/seekCeil exhaustion-proof cache. |
 | [read-snapshot-consistency.md](read-snapshot-consistency.md) | Single-snapshot rule for controller reads that stitch LedgerInfo with attribute data. |
 | [readstore-event-keys.md](readstore-event-keys.md) | Append-only metadata/existence event resolution, lease-bounded reclamation, and edge-triggered GC cycles. |
 | [prepared-queries.md](prepared-queries.md) | Named pre-validated query templates: lifecycle, filter DSL, execution, bloom acceleration. |

--- a/docs/technical/architecture/subsystems/read-path/iterator-seek-contract.md
+++ b/docs/technical/architecture/subsystems/read-path/iterator-seek-contract.md
@@ -44,18 +44,43 @@ The contract is enforced by unit tests per leaf (`iterator_floor_test.go`,
 contradiction specs in
 `tests/e2e/business/filter_nested_not_reposition_test.go`.
 
-## AddressTxIterator materialization
+## The materialized union (`AddressTxIterator`)
 
-`AddressTxIterator` materializes the union of transaction IDs lazily on first
-positioning call and keeps it as a stable sorted slice for the iterator's
-lifetime. Materialization deduplicates via a seen-set, appends each unseen ID
-as an owned copy (never a Pebble iterator key buffer), and **sorts the slice
-once** when the scan completes. The observable requirement is O(U log U)
-sorting work for U unique IDs rather than the O(U²) shifts of the former
-per-insert `insertSorted`, which an interleaved account history (evens in one
-account, odds in another) triggers. This is a pure cost change: the emitted
-IDs remain identical, sorted and unique, so the absolute-seek contract above is
-unchanged.
+`iterator_address.go`. An address match on the `TRANSACTIONS` target has no
+entity-ordered index to scan: it walks the matching account addresses and, per
+account, scans that account's `account→tx` bucket. Each per-account scan is
+ascending, but the accounts are visited in address order, so the transaction
+IDs arrive out of order across accounts.
+
+The iterator satisfies the absolute-seek contract by materializing the whole
+union once, on first use, and keeping it for the iterator's lifetime; `Next`
+and `SeekGE` are then cursor moves over a stable sorted slice. `SeekGE`
+binary-searches that slice, which makes it computed from `target` alone,
+idempotent, and well-defined after exhaustion for free.
+
+The observable requirement is on the *exposed* slice, not on how it is built:
+
+- Before any positioning call returns, the slice is **sorted and unique**.
+  `ensureMaterialized` is the single gate in front of both `Next` and
+  `SeekGE`, and it returns only after the sort.
+- The order **during** materialization is unspecified. IDs are appended as
+  they are scanned, deduplicated through a `uint64` set, and the completed
+  slice is sorted once (`slices.SortFunc` with `bytes.Compare`, which is the
+  numeric order of the 8-byte big-endian IDs — see `ReadStoreComparer`).
+  Nothing outside `materialize` may observe the intermediate order.
+
+Sorting per insertion instead — a binary search plus a tail shift, the
+pre-EN-1965 `insertSorted` — is the same output at O(U²) element movement for
+U unique IDs, because interleaved account histories make almost every new ID
+land near the front. Appending and sorting once is O(U log U). Both variants
+materialize in full, so neither claims O(pageSize) memory, and IDs stay
+immutable 8-byte copies rather than retained Pebble key buffers.
+
+`iterator_address_bench_test.go` holds the workloads that keep this honest:
+interleaved multi-account histories, an already-ascending single account (a
+one-shot sort can only lose there, so any small-history regression is visible
+rather than implicit), and duplicate-heavy unions that report scanned rows
+alongside unique IDs.
 
 ## The exhaustion-proof cache (`seekFloor`/`seekCeil`)
 

--- a/internal/storage/readstore/audit_index_test.go
+++ b/internal/storage/readstore/audit_index_test.go
@@ -10,11 +10,13 @@ import (
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
 
-func newTestStore(t *testing.T) *Store {
-	t.Helper()
-	s, err := New(t.TempDir(), logging.NopZap(), DefaultConfig())
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = s.Close() })
+// newTestStore opens a throwaway read store. It takes testing.TB so that
+// benchmarks in this package can share the fixture with the tests.
+func newTestStore(tb testing.TB) *Store {
+	tb.Helper()
+	s, err := New(tb.TempDir(), logging.NopZap(), DefaultConfig())
+	require.NoError(tb, err)
+	tb.Cleanup(func() { _ = s.Close() })
 
 	return s
 }

--- a/internal/storage/readstore/iterator_address.go
+++ b/internal/storage/readstore/iterator_address.go
@@ -42,7 +42,7 @@ type AddressTxIterator struct {
 
 // NewAddressTxIterator creates an iterator that, for each address matching
 // addrIter, looks up all associated transaction IDs in the specified
-// account→tx prefix and produces them in sorted order (merge-union).
+// account→tx prefix and produces them in sorted order.
 func NewAddressTxIterator(
 	reader dal.PebbleReader,
 	kb *dal.KeyBuilder,

--- a/internal/storage/readstore/iterator_address.go
+++ b/internal/storage/readstore/iterator_address.go
@@ -3,6 +3,7 @@ package readstore
 import (
 	"bytes"
 	"encoding/binary"
+	"slices"
 	"sort"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -14,7 +15,12 @@ import (
 // a sorted iterator of transaction IDs. It works by:
 //  1. Scanning the existence index for matching account addresses
 //  2. For each matching account, scanning the account→tx mapping
-//  3. Merge-unioning all transaction ID sets into a single sorted output
+//  3. Unioning all transaction ID sets into a single sorted output
+//
+// The union is built by appending each unseen ID and sorting the completed
+// slice once, so the order during materialization is unspecified; nothing
+// outside materialize may observe it. Every positioning call goes through
+// ensureMaterialized, which returns only after the slice is sorted.
 //
 // The union is materialized in full on first use and kept for the iterator's
 // lifetime; Next and SeekGE are cursor moves over the stable sorted slice, so
@@ -126,13 +132,13 @@ func (it *AddressTxIterator) ensureMaterialized() bool {
 }
 
 // materialize collects all transaction IDs from all matching accounts,
-// deduplicating via a seen-set and appending each unseen ID copy, then sorts
-// the completed slice once. The sort is O(U log U) in the number of unique
-// IDs; the previous per-ID insertSorted moved an ever-growing sorted slice on
-// every insert, which is O(U²) for interleaved account histories. Output IDs
-// are immutable copies, so no Pebble iterator key buffer is retained. Surfaces
-// I/O errors from the underlying Pebble iterators and from the addrIter
-// through addrIter.Err() (checked by the caller via it.Err()).
+// deduplicates them through txSeen, appends each unseen ID as an owned copy
+// (never a retained Pebble iterator key buffer), and sorts the completed slice
+// once. Sorting on each insertion instead (a binary search plus a tail shift)
+// moves O(U^2) elements for U unique IDs when account histories interleave,
+// because most new IDs land near the front. Surfaces I/O errors from the
+// underlying Pebble iterators and from the addrIter through addrIter.Err()
+// (checked by the caller via it.Err()).
 func (it *AddressTxIterator) materialize() error {
 	txSeen := make(map[uint64]struct{})
 
@@ -178,9 +184,11 @@ func (it *AddressTxIterator) materialize() error {
 		}
 	}
 
-	sort.Slice(it.txns, func(i, j int) bool {
-		return bytes.Compare(it.txns[i], it.txns[j]) < 0
-	})
+	// Sort once, on every non-error path, before any consumer can reach the
+	// slice. IDs are unique after txSeen, so no tie can be reordered and an
+	// unstable sort is safe. bytes.Compare on the 8-byte big-endian IDs is the
+	// numeric ID order (see ReadStoreComparer).
+	slices.SortFunc(it.txns, bytes.Compare)
 
 	return it.addrIter.Err()
 }

--- a/internal/storage/readstore/iterator_address_bench_test.go
+++ b/internal/storage/readstore/iterator_address_bench_test.go
@@ -1,129 +1,148 @@
 package readstore
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/pebble/v2"
-
-	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	"github.com/stretchr/testify/require"
 
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
 
-// addressBenchPage mirrors the diagnostic read: a single page of results over
-// a fully materialized union. Materialization dominates the cost; how many
-// entries are consumed afterwards does not change the sort-once fix's effect.
-const addressBenchPage = 100
+// addressTxPageSize is the page a paginated address query reads. The union is
+// materialized in full regardless, so this is the shape the diagnostic
+// measurement in EN-1965 used (a page of 100 over a large union).
+const addressTxPageSize = 100
 
-// runAddressTxBenchmark writes the account→tx rows, then repeatedly
-// re-materializes the union from scratch (a fresh AddressTxIterator per
-// iteration) and consumes the first addressBenchPage entries. scanned-rows and
-// unique-ids are reported so duplicate-heavy workloads record the dedup
-// pressure alongside the materialized output size.
-func runAddressTxBenchmark(b *testing.B, txsByAccount map[string][]uint64, addrs ...string) {
+// addressTxUnionBench describes an account→tx layout for
+// benchmarkAddressTxUnion.
+type addressTxUnionBench struct {
+	// uniqueIDs is the number of distinct transaction IDs in the union.
+	uniqueIDs int
+	// accounts is the number of matched account addresses.
+	accounts int
+	// duplicated writes every unique ID under every account, so the scan
+	// reads accounts*uniqueIDs rows for uniqueIDs union entries.
+	duplicated bool
+	// prefix is the account→tx bucket, as picked by addressRolePrefix.
+	prefix byte
+}
+
+// benchmarkAddressTxUnion measures materializing the union and reading one
+// page. The store is written once; each iteration builds a fresh iterator so
+// the one-time materialization is what gets measured.
+func benchmarkAddressTxUnion(b *testing.B, cfg addressTxUnionBench) {
 	b.Helper()
 
-	s, err := New(b.TempDir(), logging.NopZap(), DefaultConfig())
-	if err != nil {
-		b.Fatal(err)
-	}
-	b.Cleanup(func() { _ = s.Close() })
-
+	s := newTestStore(b)
 	kb := dal.NewKeyBuilder()
-	scanned := 0
-	unique := make(map[uint64]struct{})
-	for account, txs := range txsByAccount {
-		scanned += len(txs)
-		for _, id := range txs {
-			unique[id] = struct{}{}
-			if err := s.DB().Set(AccountTxKey(kb, PrefixAccountTx, "l", account, id), nil, pebble.NoSync); err != nil {
-				b.Fatal(err)
-			}
+
+	addrs := make([]string, 0, cfg.accounts)
+	for a := range cfg.accounts {
+		addrs = append(addrs, "acc:"+string(rune('a'+a%26))+string(rune('0'+a/26)))
+	}
+
+	batch := s.DB().NewBatch()
+	scannedRows := 0
+
+	for id := range cfg.uniqueIDs {
+		// Interleaved: consecutive IDs belong to different accounts, so every
+		// account contributes IDs that sort before IDs another account already
+		// appended. A single account degenerates to an ascending scan.
+		owners := addrs[id%len(addrs) : id%len(addrs)+1]
+		if cfg.duplicated {
+			owners = addrs
+		}
+
+		for _, account := range owners {
+			require.NoError(b, batch.Set(AccountTxKey(kb, cfg.prefix, "l", account, uint64(id+1)), nil, nil))
+			scannedRows++
 		}
 	}
 
-	b.ResetTimer()
+	require.NoError(b, batch.Commit(pebble.NoSync))
+	require.NoError(b, batch.Close())
 
-	// Report after ResetTimer: ResetTimer deletes user-reported metrics, so
-	// reporting the setup-derived cardinalities beforehand would drop them
-	// from the benchmark output.
-	b.ReportMetric(float64(scanned), "scanned-rows")
-	b.ReportMetric(float64(len(unique)), "unique-ids")
+	b.ReportAllocs()
 
-	for range b.N {
-		it := NewAddressTxIterator(s.DB(), dal.NewKeyBuilder(), "l", newAliasingIter(addrs...), PrefixAccountTx)
-		for n := 0; n < addressBenchPage && it.Next(); n++ {
-			_ = it.Current()
+	for b.Loop() {
+		it := NewAddressTxIterator(s.DB(), kb, "l", newAliasingIter(addrs...), cfg.prefix)
+
+		read := 0
+		for read < addressTxPageSize && it.Next() {
+			read++
 		}
+
 		if err := it.Err(); err != nil {
-			it.Close()
 			b.Fatal(err)
 		}
+
 		it.Close()
 	}
+
+	// Reported after the loop: b.Loop resets the timer on its first call,
+	// which also clears metrics reported before it.
+	b.ReportMetric(float64(cfg.uniqueIDs), "uniqueIDs")
+	b.ReportMetric(float64(scannedRows), "scannedRows")
 }
 
-// BenchmarkAddressTxIterator_InterleavedLargeHistory is the diagnostic case
-// from the ticket: two account histories whose IDs interleave (evens/odds), so
-// the pre-fix per-ID insertSorted shifted an ever-growing sorted slice for
-// every unseen ID — O(U²) movement. Append-then-sort-once removes that.
-func BenchmarkAddressTxIterator_InterleavedLargeHistory(b *testing.B) {
-	const total = 50_000
-
-	txs := map[string][]uint64{
-		"acc:even": make([]uint64, 0, total/2),
-		"acc:odd":  make([]uint64, 0, total/2),
-	}
-	for id := range uint64(total) {
-		if id%2 == 0 {
-			txs["acc:even"] = append(txs["acc:even"], id)
-		} else {
-			txs["acc:odd"] = append(txs["acc:odd"], id)
-		}
-	}
-
-	runAddressTxBenchmark(b, txs, "acc:even", "acc:odd")
+// Interleaved histories: the layout whose per-insertion tail shifts were
+// quadratic in the size of the union.
+func BenchmarkAddressTxUnion_Interleaved_1k(b *testing.B) {
+	benchmarkAddressTxUnion(b, addressTxUnionBench{uniqueIDs: 1_000, accounts: 4, prefix: PrefixAccountTx})
 }
 
-// BenchmarkAddressTxIterator_SortedSingleAccount is the already-sorted
-// control: IDs arrive in ascending order, so insertSorted never shifted and
-// the pre-fix code was already near-linear. This workload reports any
-// regression from the unconditional final sort.
-func BenchmarkAddressTxIterator_SortedSingleAccount(b *testing.B) {
-	const total = 50_000
-
-	txs := map[string][]uint64{"acc:0": make([]uint64, 0, total)}
-	for id := range uint64(total) {
-		txs["acc:0"] = append(txs["acc:0"], id)
-	}
-
-	runAddressTxBenchmark(b, txs, "acc:0")
+func BenchmarkAddressTxUnion_Interleaved_10k(b *testing.B) {
+	benchmarkAddressTxUnion(b, addressTxUnionBench{uniqueIDs: 10_000, accounts: 4, prefix: PrefixAccountTx})
 }
 
-// BenchmarkAddressTxIterator_DuplicateHeavy stresses the dedup path: many
-// matching accounts reference the same small set of transaction IDs (the same
-// shape a transaction touching several matching accounts, or an account in
-// multiple address roles, produces against the any-role index). scanned-rows
-// (accounts × IDs) and unique-ids are reported via metrics.
-func BenchmarkAddressTxIterator_DuplicateHeavy(b *testing.B) {
-	const (
-		accounts      = 200
-		idsPerAccount = 250
-	)
+func BenchmarkAddressTxUnion_Interleaved_50k(b *testing.B) {
+	benchmarkAddressTxUnion(b, addressTxUnionBench{uniqueIDs: 50_000, accounts: 4, prefix: PrefixAccountTx})
+}
 
-	txs := make(map[string][]uint64, accounts)
-	addrs := make([]string, 0, accounts)
-	for a := range accounts {
-		addr := fmt.Sprintf("acc:%d", a)
-		addrs = append(addrs, addr)
+// Sorted single account: the append order is already ascending, so this is
+// where sorting the completed slice can only lose. It exists to make any
+// small-history regression visible rather than implicit.
+func BenchmarkAddressTxUnion_SortedSingleAccount_1k(b *testing.B) {
+	benchmarkAddressTxUnion(b, addressTxUnionBench{uniqueIDs: 1_000, accounts: 1, prefix: PrefixAccountTx})
+}
 
-		ids := make([]uint64, 0, idsPerAccount)
-		for id := range uint64(idsPerAccount) {
-			ids = append(ids, id)
-		}
-		txs[addr] = ids
-	}
+func BenchmarkAddressTxUnion_SortedSingleAccount_10k(b *testing.B) {
+	benchmarkAddressTxUnion(b, addressTxUnionBench{uniqueIDs: 10_000, accounts: 1, prefix: PrefixAccountTx})
+}
 
-	runAddressTxBenchmark(b, txs, addrs...)
+func BenchmarkAddressTxUnion_SortedSingleAccount_50k(b *testing.B) {
+	benchmarkAddressTxUnion(b, addressTxUnionBench{uniqueIDs: 50_000, accounts: 1, prefix: PrefixAccountTx})
+}
+
+// Duplicate heavy: every account holds every ID, so scannedRows is four times
+// uniqueIDs and the dedup map absorbs the difference before the sort.
+func BenchmarkAddressTxUnion_DuplicateHeavy_1k(b *testing.B) {
+	benchmarkAddressTxUnion(b, addressTxUnionBench{
+		uniqueIDs: 1_000, accounts: 4, duplicated: true, prefix: PrefixAccountTx,
+	})
+}
+
+func BenchmarkAddressTxUnion_DuplicateHeavy_10k(b *testing.B) {
+	benchmarkAddressTxUnion(b, addressTxUnionBench{
+		uniqueIDs: 10_000, accounts: 4, duplicated: true, prefix: PrefixAccountTx,
+	})
+}
+
+func BenchmarkAddressTxUnion_DuplicateHeavy_50k(b *testing.B) {
+	benchmarkAddressTxUnion(b, addressTxUnionBench{
+		uniqueIDs: 50_000, accounts: 4, duplicated: true, prefix: PrefixAccountTx,
+	})
+}
+
+// The source and destination buckets carry the same layout, so a regression
+// confined to one address role stays visible.
+func BenchmarkAddressTxUnion_Interleaved_10k_Source(b *testing.B) {
+	benchmarkAddressTxUnion(b, addressTxUnionBench{uniqueIDs: 10_000, accounts: 4, prefix: PrefixSourceAccountTx})
+}
+
+func BenchmarkAddressTxUnion_Interleaved_10k_Destination(b *testing.B) {
+	benchmarkAddressTxUnion(b, addressTxUnionBench{
+		uniqueIDs: 10_000, accounts: 4, prefix: PrefixDestinationAccountTx,
+	})
 }

--- a/internal/storage/readstore/iterator_address_test.go
+++ b/internal/storage/readstore/iterator_address_test.go
@@ -17,21 +17,49 @@ func txIDBytes(id uint64) []byte {
 	return b
 }
 
-// newAddressTxFixture writes account→tx rows and returns an AddressTxIterator
-// over the given addresses.
+// newAddressTxFixture writes account→tx rows in the any-role bucket and
+// returns an AddressTxIterator over the given addresses.
 func newAddressTxFixture(t *testing.T, txsByAccount map[string][]uint64, addrs ...string) *AddressTxIterator {
 	t.Helper()
 
-	s := newTestStore(t)
+	return newAddressTxFixtureForPrefix(t, PrefixAccountTx, txsByAccount, addrs...)
+}
+
+// newAddressTxFixtureForPrefix is newAddressTxFixture over an explicit
+// account→tx bucket, so tests can cover every address role reached from
+// addressRolePrefix (source, destination, any).
+func newAddressTxFixtureForPrefix(
+	tb testing.TB,
+	prefix byte,
+	txsByAccount map[string][]uint64,
+	addrs ...string,
+) *AddressTxIterator {
+	tb.Helper()
+
+	s := newTestStore(tb)
 	kb := dal.NewKeyBuilder()
 
 	for account, txs := range txsByAccount {
 		for _, id := range txs {
-			require.NoError(t, s.DB().Set(AccountTxKey(kb, PrefixAccountTx, "l", account, id), nil, pebble.NoSync))
+			require.NoError(tb, s.DB().Set(AccountTxKey(kb, prefix, "l", account, id), nil, pebble.NoSync))
 		}
 	}
 
-	return NewAddressTxIterator(s.DB(), dal.NewKeyBuilder(), "l", newAliasingIter(addrs...), PrefixAccountTx)
+	return NewAddressTxIterator(s.DB(), dal.NewKeyBuilder(), "l", newAliasingIter(addrs...), prefix)
+}
+
+// drainIDs consumes the iterator and returns the decoded transaction IDs.
+func drainIDs(tb testing.TB, it *AddressTxIterator) []uint64 {
+	tb.Helper()
+
+	var got []uint64
+	for it.Next() {
+		got = append(got, binary.BigEndian.Uint64(it.Current()))
+	}
+
+	require.NoError(tb, it.Err())
+
+	return got
 }
 
 // SeekGE on AddressTxIterator must be an absolute reposition over the
@@ -154,34 +182,68 @@ func TestAddressTxIterator_EmptyUnion(t *testing.T) {
 	require.NoError(t, it.Err())
 }
 
-// Materialization must emit sorted, deduplicated IDs for single-account,
-// interleaved multi-account, and duplicate-heavy unions regardless of the
-// order IDs are appended. The append-then-sort-once implementation must
-// therefore be observably identical to the previous per-ID insertSorted.
-func TestAddressTxIterator_MaterializeSortedUniqueOutput(t *testing.T) {
+// The union is appended in whatever order the address iterator and the per-
+// account Pebble scans produce, then sorted once. Whatever that append order
+// is, the exposed slice must be sorted and unique before the first positioning
+// call — the observable requirement that replaced per-insertion insertSorted
+// (EN-1965).
+func TestAddressTxIterator_UnionIsSortedAndUnique(t *testing.T) {
 	t.Parallel()
 
-	cases := map[string]struct {
+	for _, tc := range []struct {
+		name         string
 		txsByAccount map[string][]uint64
 		addrs        []string
 		want         []uint64
 	}{
-		"single account sorted": {
-			txsByAccount: map[string][]uint64{"acc:1": {1, 2, 3, 4, 5}},
+		{
+			// One account: the Pebble scan already appends ascending.
+			name:         "single account ascending",
+			txsByAccount: map[string][]uint64{"acc:1": {1, 2, 3, 4}},
 			addrs:        []string{"acc:1"},
-			want:         []uint64{1, 2, 3, 4, 5},
+			want:         []uint64{1, 2, 3, 4},
 		},
-		"interleaved accounts": {
-			// Interleaved histories: each account's scan is ascending, but
-			// the merged append order alternates low/high IDs.
+		{
+			// Interleaved histories: every account appends IDs that belong
+			// before IDs already appended. This is the workload whose tail
+			// shifts were quadratic.
+			name: "interleaved histories",
 			txsByAccount: map[string][]uint64{
-				"acc:even": {0, 2, 4},
-				"acc:odd":  {1, 3, 5},
+				"acc:1": {1, 4, 7},
+				"acc:2": {2, 5, 8},
+				"acc:3": {3, 6, 9},
 			},
-			addrs: []string{"acc:even", "acc:odd"},
-			want:  []uint64{0, 1, 2, 3, 4, 5},
+			addrs: []string{"acc:1", "acc:2", "acc:3"},
+			want:  []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9},
 		},
-		"duplicate heavy": {
+		{
+			// Strictly descending append order: each later account holds only
+			// IDs below every ID appended so far.
+			name: "descending append order",
+			txsByAccount: map[string][]uint64{
+				"acc:1": {7, 8, 9},
+				"acc:2": {4, 5, 6},
+				"acc:3": {1, 2, 3},
+			},
+			addrs: []string{"acc:1", "acc:2", "acc:3"},
+			want:  []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9},
+		},
+		{
+			// Every ID is shared by all three accounts: the dedup map must
+			// still collapse them to one entry each.
+			name: "duplicate heavy",
+			txsByAccount: map[string][]uint64{
+				"acc:1": {1, 2, 3},
+				"acc:2": {1, 2, 3},
+				"acc:3": {1, 2, 3},
+			},
+			addrs: []string{"acc:1", "acc:2", "acc:3"},
+			want:  []uint64{1, 2, 3},
+		},
+		{
+			// Partially overlapping histories: the dedup map must collapse the
+			// shared IDs while keeping the ID only one account holds.
+			name: "partially overlapping histories",
 			txsByAccount: map[string][]uint64{
 				"acc:1": {1, 2, 3},
 				"acc:2": {1, 2, 3},
@@ -190,21 +252,102 @@ func TestAddressTxIterator_MaterializeSortedUniqueOutput(t *testing.T) {
 			addrs: []string{"acc:1", "acc:2", "acc:3"},
 			want:  []uint64{1, 2, 3, 4},
 		},
-	}
-
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
+		{
+			// A matched address with no transaction rows contributes nothing
+			// and must not disturb the other accounts.
+			name: "matched address with no rows",
+			txsByAccount: map[string][]uint64{
+				"acc:1": {2},
+				"acc:3": {1},
+			},
+			addrs: []string{"acc:1", "acc:2", "acc:3"},
+			want:  []uint64{1, 2},
+		},
+		{
+			// Only the matched addresses contribute; acc:2 is indexed but not
+			// selected.
+			name: "unmatched account excluded",
+			txsByAccount: map[string][]uint64{
+				"acc:1": {1, 3},
+				"acc:2": {2},
+			},
+			addrs: []string{"acc:1"},
+			want:  []uint64{1, 3},
+		},
+		{
+			name:         "no matched addresses",
+			txsByAccount: map[string][]uint64{"acc:1": {1, 2}},
+			addrs:        nil,
+			want:         nil,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			it := newAddressTxFixture(t, tc.txsByAccount, tc.addrs...)
 			defer it.Close()
 
-			var got []uint64
-			for it.Next() {
-				got = append(got, binary.BigEndian.Uint64(it.Current()))
+			require.Equal(t, tc.want, drainIDs(t, it))
+
+			// A seek before the first entry sees the same sorted union, so no
+			// consumer can reach an unsorted slice through either entry point.
+			if len(tc.want) == 0 {
+				require.False(t, it.SeekGE(txIDBytes(0)))
+
+				return
 			}
-			require.Equal(t, tc.want, got)
+
+			require.True(t, it.SeekGE(txIDBytes(0)))
+			require.Equal(t, tc.want[0], binary.BigEndian.Uint64(it.Current()))
 			require.NoError(t, it.Err())
 		})
 	}
+}
+
+// Sorting once must hold in every account→tx bucket, not only the any-role one
+// the other tests use: compileAddressPrefix picks the bucket from the query's
+// address role (addressRolePrefix), and the iterator must never mix buckets.
+func TestAddressTxIterator_UnionIsSortedPerAddressRole(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name   string
+		prefix byte
+	}{
+		{name: "any role", prefix: PrefixAccountTx},
+		{name: "source", prefix: PrefixSourceAccountTx},
+		{name: "destination", prefix: PrefixDestinationAccountTx},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			it := newAddressTxFixtureForPrefix(t, tc.prefix, map[string][]uint64{
+				"acc:1": {5, 6},
+				"acc:2": {3, 4},
+				"acc:3": {1, 2},
+			}, "acc:1", "acc:2", "acc:3")
+			defer it.Close()
+
+			require.Equal(t, []uint64{1, 2, 3, 4, 5, 6}, drainIDs(t, it))
+		})
+	}
+}
+
+// The rows written for one role must stay invisible to an iterator scanning
+// another role's bucket, so a per-role empty union really is empty.
+func TestAddressTxIterator_AddressRoleBucketsAreIsolated(t *testing.T) {
+	t.Parallel()
+
+	s := newTestStore(t)
+	kb := dal.NewKeyBuilder()
+	require.NoError(t, s.DB().Set(AccountTxKey(kb, PrefixSourceAccountTx, "l", "acc:1", 1), nil, pebble.NoSync))
+
+	it := NewAddressTxIterator(
+		s.DB(), dal.NewKeyBuilder(), "l", newAliasingIter("acc:1"), PrefixDestinationAccountTx,
+	)
+	defer it.Close()
+
+	require.Empty(t, drainIDs(t, it))
+	require.False(t, it.SeekGE(txIDBytes(0)))
+	require.NoError(t, it.Err())
 }


### PR DESCRIPTION
[EN-1965](https://formance-team.atlassian.net/browse/EN-1965)

## Scope after rebase

The optimization itself landed in #1919 (`perf(query): sort address transaction unions once`), which merged first. This PR is rebased on top of it and now carries only the material that #1919 did not: the read-path specification, the regression tests, and the benchmarks.

`git log release/v3.0..HEAD` is two commits; the code delta is doc comments plus one line — `sort.Slice` with an inline closure becomes `slices.SortFunc(it.txns, bytes.Compare)`. Both are unstable pdqsort and the IDs are unique after `txSeen`, so that is a same-semantics swap, not a behavior change.

## Docs

`docs/technical/architecture/subsystems/read-path/iterator-seek-contract.md` gains a "The materialized union (`AddressTxIterator`)" section stating the **observable** requirement rather than the algorithm:

- before any positioning call returns, the exposed slice is sorted and unique — `ensureMaterialized` is the single gate in front of both `Next` and `SeekGE`, and it returns only after the sort;
- the order *during* materialization is unspecified: IDs are appended as scanned, deduplicated through a `uint64` set, and the completed slice is sorted once. Nothing outside `materialize` may observe the intermediate order.

It also records why sorting per insertion was quadratic (an address match visits accounts in address order and each `account→tx` scan is ascending, so with interleaved histories almost every new ID lands near the front: O(U²) element movement for U unique IDs, against O(U log U) for one sort), and that neither variant makes an O(pageSize) memory claim — both materialize in full, with immutable 8-byte ID copies rather than retained Pebble key buffers.

The read-path README index line is extended. The doc comments on the type, on `materialize`, and on `NewAddressTxIterator` are restated against this contract; the constructor's stale "(merge-union)" wording is dropped.

## Tests

New in `iterator_address_test.go`:

- `TestAddressTxIterator_UnionIsSortedAndUnique` — 8 subtests: single ascending account, interleaved histories, strictly descending append order, duplicate-heavy, partially overlapping histories, a matched address with no rows, an unmatched account, and no matched addresses. Each asserts the drained union *and* that a seek below the first entry sees the same sorted union, covering both entry points into `ensureMaterialized`.
- `TestAddressTxIterator_UnionIsSortedPerAddressRole` — the three buckets picked by `addressRolePrefix` (any, source, destination).
- `TestAddressTxIterator_AddressRoleBucketsAreIsolated` — rows written for one role stay invisible to another role's iterator.

Additive: the existing `TestAddressTxIterator_SeekGEIsAbsolute`, `TestAndIterator_AddressTxChildKeepsIntersection`, `TestNotIterator_AddressTxChildExcludesAfterExhaustion` and `TestAddressTxIterator_EmptyUnion` triggers are untouched.

`newTestStore` was widened from `*testing.T` to `testing.TB` so the benchmarks share the existing fixture; its 37 callers are unchanged.

**Mutation proof:** replacing the sort with a no-op fails 6 of the new subtests plus the pre-existing `TestAddressTxIterator_SeekGEIsAbsolute`. The tests detect the sort's absence rather than merely passing alongside it.

## Benchmarks

`iterator_address_bench_test.go` holds the workloads that keep the sort honest: interleaved multi-account histories, an already-ascending single account (a one-shot sort can only lose there, so any small-history regression is visible rather than implicit), and duplicate-heavy unions that report `scannedRows` alongside `uniqueIDs` — plus the source and destination role buckets. Sizes 1k/10k/50k.

Figures below are pre-#1919 base vs the merged implementation, median of 3, `-benchtime=1s`, Apple M5 Pro. Base was measured by porting this benchmark file into a detached pre-#1919 worktree, so these show direction of change rather than head-only numbers. They are what the benchmarks record, not a deliverable of this PR.

| Benchmark | pre-#1919 | with #1919 | change |
|---|---|---|---|
| Interleaved 50k | 165.9 ms | 7.30 ms | **22.7x faster** |
| Interleaved 10k | 5.89 ms | 1.31 ms | 4.5x faster |
| Interleaved 1k | 154.8 µs | 113.2 µs | -27% |
| SortedSingleAccount 50k | 4.68 ms | 3.91 ms | -16% |
| SortedSingleAccount 10k | 911 µs | 781 µs | -14% |
| SortedSingleAccount 1k | 89.3 µs | 82.1 µs | -8% |
| DuplicateHeavy 50k (200k scanned) | 9.98 ms | 9.73 ms | -2.5% |
| DuplicateHeavy 10k (40k scanned) | 1.86 ms | 1.80 ms | -4% |
| DuplicateHeavy 1k (4k scanned) | 174.1 µs | 173.0 µs | ~0 |
| Interleaved 10k, source role | 6.46 ms | 1.32 ms | 4.9x faster |
| Interleaved 10k, destination role | 5.95 ms | 1.32 ms | 4.5x faster |

No small-history regression: the 1k and already-ascending cases improve too, because `insertSorted` paid a binary search plus a bounds-checked append per element while pdqsort short-circuits an already-sorted run. Allocation counts and bytes/op are unchanged (~9.09 MB at 50k).

Direction and magnitude match the diagnostic recorded on the ticket (288.4 ms → 23.4 ms at 50k); the absolute numbers differ because that probe ran on different hardware and a different harness.

## Validation

- `bash scripts/agent-check` — PASS
- `go test -race -count=1 ./internal/storage/readstore/...` — ok; 16 `TestAddressTxIterator*` cases pass, including the 8 subtests above

No storage or wire migration, no new cache, no weakened invariant.

## Note for review

The ticket's plan listed a "reverse write order" test. That case is unreachable: Pebble scans each account bucket in key order, so write order never reaches `it.txns`. The unsorted append order comes from the address iterator visiting accounts whose ID ranges overlap, which the `descending append order` subtest encodes instead (acc:1={7,8,9}, acc:2={4,5,6}, acc:3={1,2,3}).

`SeekGE`'s `sort.Search` was left as-is. Migrating it to `slices.BinarySearchFunc` would be a clean swap and would drop the `sort` import, but it touches the seek path that EN-1597 fixed; out of scope here.


[EN-1965]: https://formance-team.atlassian.net/browse/EN-1965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
