### PR TITLE
fix(EN-1860): prevent authoritative sequence counter wraparound

### DIFF
--- a/docs/technical/architecture/subsystems/checker/README.md
+++ b/docs/technical/architecture/subsystems/checker/README.md
@@ -42,7 +42,10 @@ position** (`LedgerBoundaries.last_mirror_v2_log_id`) is now verified by
 unverified cursor advanced beyond the source head fetching no source logs and
 reporting FOLLOWING, silently under-ingesting v2→v3) is **closed**: EN-1513
 removed that duplicate durable position, leaving the checker-verified boundary
-as the only ingestion position. The
+as the only ingestion position. Boundary reconstruction also uses the FSM's
+checked sequence transition: a transaction, ledger-log, or global-log value
+that would require `MaxUint64 + 1` makes the check fail explicitly instead of
+wrapping the expected boundary to zero (EN-1860). The
 **readstore inverted-index contents** are a peer secondary store, out of
 main-store checker scope as a rule — but that is not a claim they are
 integrity-safe: their contents are a current open integrity gap until per-replica

--- a/docs/technical/architecture/subsystems/fsm/README.md
+++ b/docs/technical/architecture/subsystems/fsm/README.md
@@ -6,7 +6,7 @@ The deterministic state machine (`internal/infra/state`, `internal/infra/plan`, 
 
 | Document | Description |
 |----------|-------------|
-| [deterministic-fsm.md](deterministic-fsm.md) | Deterministic FSM with generation-based caching and preloading. |
+| [deterministic-fsm.md](deterministic-fsm.md) | Deterministic FSM with generation-based caching, preloading, and authoritative sequence-exhaustion rules. |
 | [cache-layers.md](cache-layers.md) | FSM-side read/write layering: gatedScope → WriteSet → DerivedKeyStore → KeyStore → AttributeCache. |
 | [preload.md](preload.md) | Preload contract: `plan.Coverage` declaration, `MirrorPreload`, `PredictedIndex` stale-detection, and the producer-owns-its-declaration rule. |
 | [coverage-gate.md](coverage-gate.md) | The per-order coverage bits the FSM uses to gate every cache read against admission's declared `plan.Coverage`. |

--- a/docs/technical/architecture/subsystems/fsm/deterministic-fsm.md
+++ b/docs/technical/architecture/subsystems/fsm/deterministic-fsm.md
@@ -125,7 +125,33 @@ Before allowing configuration to influence a write path, answer:
 
 If question 3 is not unconditionally true, the configuration is on the wrong side of the admission/FSM boundary.
 
-### 3.5 Raft-replicated cluster policy
+### 3.5 Sequence exhaustion
+
+The authoritative transaction ID, per-ledger log ID, global log sequence, and
+audit sequence are `uint64` next-value counters. They share one terminal
+contract: a counter never wraps. `MaxUint64 - 1` is the last allocatable value;
+the successful allocation advances the stored next value to `MaxUint64`, and a
+later allocation fails deterministically with `SEQUENCE_EXHAUSTED` before the
+affected business, cache, or durable mutation is staged. When the failure is
+still auditable, the failure audit entry is the only committed effect and
+consumes its own audit sequence. Exhausting the audit sequence itself stops a
+proposal before preload, HLC advancement, technical updates, or audit-hash and
+durable mutation. Saturating or wrapping to zero would permit an existing
+transaction or sequence-derived Pebble key to be reused.
+
+Externally supplied v2 mirror log and transaction IDs obey the same boundary
+while translation needs to return a next cursor. Mirror apply also validates
+the supplied transaction ID and the local per-ledger log allocation before
+changing boundaries. A terminal `last_mirror_v2_log_id == MaxUint64` remains a
+valid applied high-water mark: every representable replay is at or below it and
+is therefore a no-op; contiguity checks never compute `last + 1` in that state.
+
+Recovery, incremental-restore rebuilding, and checker replay use the same
+checked transition. A persisted terminal key is detected and rejected instead
+of being hidden by an exclusive iterator bound or reconstructed as zero. This
+keeps retry, replay, and restart behavior deterministic (EN-1860).
+
+### 3.6 Raft-replicated cluster policy
 
 When a setting must influence FSM apply identically on every node — not merely gate admission — it cannot stay node-local. The **cluster policy** (`ClusterPolicy`) is the Raft-replicated home for such settings: the idempotency TTL and the query-checkpoint limit. It is a single global row (`ZoneGlobal` / `SubGlobClusterPolicy`) carried in `FSMState`, so it rides inside snapshots and cold backups and is checker-verified (`clusterPolicyVerifier`) against the audited `SetClusterPolicy` orders.
 

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -858,6 +858,7 @@ Each error response includes a `google.rpc.ErrorInfo` detail with:
 | Raft node already absent during removal | `NOT_FOUND` | `RAFT_NODE_NOT_IN_CLUSTER` | *(none)* |
 | Raft node removal committed; durable FSM apply still pending | `UNAVAILABLE` | `RAFT_NODE_REMOVAL_COMMITTED` | `nodeId`, `committedIndex` |
 | Writes blocked — disk full | `RESOURCE_EXHAUSTED` | `WRITES_BLOCKED_DISK_FULL` | *(none)* |
+| Authoritative sequence exhausted | `RESOURCE_EXHAUSTED` | `SEQUENCE_EXHAUSTED` | `counter` (`transactionId`, `ledgerLogId`, `logSequence`, `auditSequence`, or `mirrorV2LogId`) |
 | Writes blocked — clock skew | `UNAVAILABLE` | `WRITES_BLOCKED_CLOCK_SKEW` | *(none)* |
 | Metadata not found | `NOT_FOUND` | `METADATA_NOT_FOUND` | `target`, `key` |
 | Metadata field not in schema | `FAILED_PRECONDITION` | `METADATA_FIELD_NOT_IN_SCHEMA` | `target`, `key` |

--- a/internal/adapter/grpc/errors_test.go
+++ b/internal/adapter/grpc/errors_test.go
@@ -66,6 +66,20 @@ func TestBusinessErrorToGRPCStatus_LedgerAlreadyExists(t *testing.T) {
 	require.Equal(t, "my-ledger", info.GetMetadata()["name"])
 }
 
+func TestBusinessErrorToGRPCStatus_SequenceExhausted(t *testing.T) {
+	t.Parallel()
+
+	bizErr := &domain.BusinessError{Err: &domain.ErrSequenceExhausted{
+		Counter: domain.SequenceCounterTransactionID,
+	}}
+	st := businessErrorToGRPCStatus(bizErr)
+
+	require.Equal(t, codes.ResourceExhausted, st.Code())
+	info := extractErrorInfo(t, st)
+	require.Equal(t, domain.ErrReasonSequenceExhausted, info.GetReason())
+	require.Equal(t, "transactionId", info.GetMetadata()["counter"])
+}
+
 func TestBusinessErrorToGRPCStatus_LedgerNotFound(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapter/http/error_handler_test.go
+++ b/internal/adapter/http/error_handler_test.go
@@ -115,6 +115,12 @@ func TestHandleError(t *testing.T) {
 			expectedCode:   "INSUFFICIENT_FUNDS",
 		},
 		{
+			name:           "sequence exhausted",
+			err:            &domain.ErrSequenceExhausted{Counter: domain.SequenceCounterLog},
+			expectedStatus: http.StatusTooManyRequests,
+			expectedCode:   domain.ErrReasonSequenceExhausted,
+		},
+		{
 			name:           "numscript parse error",
 			err:            &domain.ErrNumscriptParse{Details: "syntax error"},
 			expectedStatus: http.StatusBadRequest,

--- a/internal/adapter/http/handlers_coverage_test.go
+++ b/internal/adapter/http/handlers_coverage_test.go
@@ -985,6 +985,8 @@ func TestWriteBulkResponse_KindDispatch(t *testing.T) {
 	}{
 		// Business kinds → suppressed to 200 under continueOnFailure=true.
 		{"validation", domain.NewValidationSentinel("bad"), http.StatusOK, false},
+		// Resource exhaustion remains visible even when business failures are suppressed.
+		{"sequence-exhausted", &domain.ErrSequenceExhausted{Counter: domain.SequenceCounterLog}, http.StatusTooManyRequests, false},
 		// Retryable infra → 503 with Retry-After, unmasked by continueOnFailure.
 		{"leader-loss", commonpb.ErrNoLeader, http.StatusServiceUnavailable, true},
 		// Plain infrastructure error (non-Describable) → 500.

--- a/internal/adapter/v2/translator.go
+++ b/internal/adapter/v2/translator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/formancehq/ledger/v3/internal/adapter/v2/celrewrite"
+	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 )
@@ -49,7 +50,11 @@ func TranslateBatch(ledger string, v2Logs []V2Log, expectedNextLogID, expectedNe
 					FillGap: &raftcmdpb.MirrorFillGap{},
 				},
 			}))
-			expectedNextLogID++
+			nextLogID, exhausted := domain.CheckedNextSequence(expectedNextLogID, domain.SequenceCounterMirrorV2LogID)
+			if exhausted != nil {
+				return nil, 0, 0, fmt.Errorf("filling v2 log gap before %d: %w", v2Log.ID, exhausted)
+			}
+			expectedNextLogID = nextLogID
 		}
 
 		entry, newNextTxID, err := translateV2Log(v2Log, expectedNextTxID)
@@ -78,7 +83,11 @@ func TranslateBatch(ledger string, v2Logs []V2Log, expectedNextLogID, expectedNe
 			orders = append(orders, makeMirrorOrder(ledger, entry))
 		}
 
-		expectedNextLogID = v2Log.ID + 1
+		nextLogID, exhausted := domain.CheckedNextSequence(v2Log.ID, domain.SequenceCounterMirrorV2LogID)
+		if exhausted != nil {
+			return nil, 0, 0, fmt.Errorf("advancing after v2 log %d: %w", v2Log.ID, exhausted)
+		}
+		expectedNextLogID = nextLogID
 	}
 
 	return orders, expectedNextLogID, expectedNextTxID, nil
@@ -159,6 +168,13 @@ func translateNewTransaction(v2Log V2Log, _ uint64) (*raftcmdpb.MirrorLogEntry, 
 	}
 
 	txID := data.Transaction.ID
+	nextTxID, exhausted := domain.CheckedNextSequence(txID, domain.SequenceCounterTransactionID)
+	if exhausted != nil {
+		resetV2NewTxData(data)
+		v2NewTxPool.Put(data)
+
+		return nil, 0, exhausted
+	}
 
 	postings, err := translatePostings(data.Transaction.Postings)
 	if err != nil {
@@ -198,7 +214,7 @@ func translateNewTransaction(v2Log V2Log, _ uint64) (*raftcmdpb.MirrorLogEntry, 
 	resetV2NewTxData(data)
 	v2NewTxPool.Put(data)
 
-	return entry, txID + 1, nil
+	return entry, nextTxID, nil
 }
 
 // resetV2NewTxData zeroes the struct while preserving the Postings backing array.
@@ -241,6 +257,17 @@ func translateRevertedTransaction(v2Log V2Log, expectedNextTxID uint64) (*raftcm
 	}
 
 	revertTxID := data.RevertTransaction.ID
+	newNextTxID := expectedNextTxID
+	if revertTxID >= newNextTxID {
+		next, exhausted := domain.CheckedNextSequence(revertTxID, domain.SequenceCounterTransactionID)
+		if exhausted != nil {
+			resetV2RevertData(data)
+			v2RevertPool.Put(data)
+
+			return nil, 0, exhausted
+		}
+		newNextTxID = next
+	}
 
 	postings, err := translatePostings(data.RevertTransaction.Postings)
 	if err != nil {
@@ -270,11 +297,6 @@ func translateRevertedTransaction(v2Log V2Log, expectedNextTxID uint64) (*raftcm
 				Timestamp:             timestamp,
 			},
 		},
-	}
-
-	newNextTxID := expectedNextTxID
-	if revertTxID >= newNextTxID {
-		newNextTxID = revertTxID + 1
 	}
 
 	resetV2RevertData(data)

--- a/internal/adapter/v2/translator_test.go
+++ b/internal/adapter/v2/translator_test.go
@@ -2,12 +2,84 @@ package v2
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 )
+
+func TestTranslateBatchRejectsExhaustedSourceCounters(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		log     V2Log
+		nextLog uint64
+		nextTx  uint64
+		counter domain.SequenceCounter
+	}{
+		{
+			name:    "v2 log id",
+			log:     V2Log{ID: math.MaxUint64, Type: "UNKNOWN"},
+			nextLog: math.MaxUint64,
+			counter: domain.SequenceCounterMirrorV2LogID,
+		},
+		{
+			name: "created transaction id",
+			log: V2Log{ID: 1, Type: "NEW_TRANSACTION", Data: mustMarshal(t, V2NewTransactionData{
+				Transaction: V2Transaction{ID: math.MaxUint64},
+			})},
+			nextLog: 1,
+			counter: domain.SequenceCounterTransactionID,
+		},
+		{
+			name: "revert transaction id",
+			log: V2Log{ID: 1, Type: "REVERTED_TRANSACTION", Data: mustMarshal(t, V2RevertedTransactionData{
+				RevertTransaction: V2Transaction{ID: math.MaxUint64},
+			})},
+			nextLog: 1,
+			nextTx:  1,
+			counter: domain.SequenceCounterTransactionID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			orders, nextLog, nextTx, err := TranslateBatch("default", []V2Log{tt.log}, tt.nextLog, tt.nextTx, nil)
+			require.Error(t, err)
+			require.Nil(t, orders)
+			require.Zero(t, nextLog)
+			require.Zero(t, nextTx)
+
+			var exhausted *domain.ErrSequenceExhausted
+			require.ErrorAs(t, err, &exhausted)
+			require.Equal(t, tt.counter, exhausted.Counter)
+		})
+	}
+}
+
+func TestTranslateBatchAllowsLastRepresentableNextValues(t *testing.T) {
+	t.Parallel()
+
+	log := V2Log{
+		ID:   math.MaxUint64 - 1,
+		Type: "NEW_TRANSACTION",
+		Data: mustMarshal(t, V2NewTransactionData{
+			Transaction: V2Transaction{ID: math.MaxUint64 - 1},
+		}),
+	}
+
+	orders, nextLog, nextTx, err := TranslateBatch("default", []V2Log{log}, math.MaxUint64-1, 1, nil)
+	require.NoError(t, err)
+	require.Len(t, orders, 1)
+	require.Equal(t, uint64(math.MaxUint64), nextLog)
+	require.Equal(t, uint64(math.MaxUint64), nextTx)
+}
 
 func TestTranslateBatch_NewTransaction(t *testing.T) {
 	t.Parallel()

--- a/internal/application/check/checker.go
+++ b/internal/application/check/checker.go
@@ -349,7 +349,11 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 			expectedSeq++
 		}
 
-		expectedSeq = seq + 1
+		nextExpectedSeq, exhausted := domain.CheckedNextSequence(seq, domain.SequenceCounterLog)
+		if exhausted != nil {
+			return fmt.Errorf("checking log sequence %d: %w", seq, exhausted)
+		}
+		expectedSeq = nextExpectedSeq
 
 		value, err := logIter.ValueAndErr()
 		if err != nil {
@@ -474,7 +478,9 @@ func (c *Checker) Check(ctx context.Context, callback func(*servicepb.CheckStore
 							}
 						}
 
-						advanceExpectedBoundaries(expectedBoundaries, ledgerName, payload.Apply.GetLog())
+						if err := advanceExpectedBoundaries(expectedBoundaries, ledgerName, payload.Apply.GetLog()); err != nil {
+							return fmt.Errorf("advancing expected boundaries at log %d: %w", seq, err)
+						}
 
 						// Index registry derivation: every CreateIndex /
 						// DropIndex / RemovedMetadataFieldType log entry
@@ -2164,7 +2170,10 @@ func (c *Checker) verifyAuditHashChain(
 			// The decoded orders come back so the signing fold below reuses them
 			// instead of unmarshalling the whole live audit range a second time.
 			// Parallel to `items` by index; nil where the bytes did not decode.
-			decoded := collectExpectedSkippable(items, success.GetMinLogSequence(), success.GetMaxLogSequence(), expectedSkippable, chainBound)
+			decoded, err := collectExpectedSkippable(items, success.GetMinLogSequence(), success.GetMaxLogSequence(), expectedSkippable, chainBound)
+			if err != nil {
+				return expectedSkippable, fmt.Errorf("rebuild chain-bound state: %w", err)
+			}
 
 			// Fold signing orders from this successful entry, over the SAME fresh-log
 			// window collectExpectedSkippable uses. AuditSuccess.{Min,Max}LogSequence
@@ -2427,7 +2436,7 @@ func collectExpectedSkippable(
 	minLogSeq, maxLogSeq uint64,
 	expectedSkippable map[uint64]*expectedSkippableOrder,
 	chainBound *chainBoundState,
-) []*raftcmdpb.Order {
+) ([]*raftcmdpb.Order, error) {
 	// Parallel to `items` by index, which is what lets a caller pair an order back
 	// to the item it came from — the filters below are per-item and each caller
 	// applies its own, so a compacted slice would not line up.
@@ -2541,7 +2550,9 @@ func collectExpectedSkippable(
 		// the emitting order opted into skip — a later skip on the same
 		// key/id needs the full prior history to answer "was the
 		// underlying condition true?".
-		recordChainBoundMutations(ls, ledger, logSeq, chainBound)
+		if err := recordChainBoundMutations(ls, ledger, logSeq, chainBound); err != nil {
+			return decoded, err
+		}
 
 		reasons := apply.GetSkippableReasons()
 		if len(reasons) == 0 {
@@ -2585,7 +2596,7 @@ func collectExpectedSkippable(
 		expectedSkippable[logSeq] = exp
 	}
 
-	return decoded
+	return decoded, nil
 }
 
 // recordChainBoundMutations extracts every state transition from the
@@ -2639,9 +2650,9 @@ func recordChainBoundMutations(
 	ledger string,
 	logSeq uint64,
 	chainBound *chainBoundState,
-) {
+) error {
 	if ls == nil || ledger == "" {
-		return
+		return nil
 	}
 
 	if cl := ls.GetCreateLedger(); cl != nil {
@@ -2667,7 +2678,7 @@ func recordChainBoundMutations(
 
 	apply := ls.GetApply()
 	if apply == nil {
-		return
+		return nil
 	}
 
 	if am := apply.GetAddMetadata(); am != nil {
@@ -2736,7 +2747,10 @@ func recordChainBoundMutations(
 				}
 			}
 
-			txID := allocateChainBoundTxID(ledger, chainBound)
+			txID, err := allocateChainBoundTxID(ledger, chainBound)
+			if err != nil {
+				return err
+			}
 
 			// The successful CreateTransaction owns its reference — record
 			// the (ref → txID) binding so a later conflicting order's skip
@@ -2772,7 +2786,10 @@ func recordChainBoundMutations(
 			// counter allocation.
 			rememberFirstRevert(chainBound.reverted, ledger, rt.GetTransactionId(), logSeq)
 
-			newTxID := allocateChainBoundTxID(ledger, chainBound)
+			newTxID, err := allocateChainBoundTxID(ledger, chainBound)
+			if err != nil {
+				return err
+			}
 
 			if _, anchored := chainBound.ledgerCreationSeen[ledger]; anchored {
 				// Same "tx:<id>" namespacing as the CreateTransaction path
@@ -2798,21 +2815,27 @@ func recordChainBoundMutations(
 			appendAccountTypeMutation(chainBound.accountTypes, ledger, name, logSeq, false)
 		}
 	}
+
+	return nil
 }
 
 // allocateChainBoundTxID mirrors the FSM's boundary bump: returns the
 // current nextTxID for the ledger, then increments. Auto-initialises to
 // 1 (matching CreateLedger's initial value) when the ledger's counter
 // has not been seeded yet.
-func allocateChainBoundTxID(ledger string, chainBound *chainBoundState) uint64 {
+func allocateChainBoundTxID(ledger string, chainBound *chainBoundState) (uint64, *domain.ErrSequenceExhausted) {
 	current, seen := chainBound.nextTxID[ledger]
 	if !seen {
 		current = 1
 	}
 
-	chainBound.nextTxID[ledger] = current + 1
+	next, err := domain.CheckedNextSequence(current, domain.SequenceCounterTransactionID)
+	if err != nil {
+		return 0, err
+	}
+	chainBound.nextTxID[ledger] = next
 
-	return current
+	return current, nil
 }
 
 // chainBoundCreateTxSkipped predicts whether a CreateTransactionOrder
@@ -4434,15 +4457,20 @@ func trackTxID(m map[string]*bitset.Bitset, ledgerName string, txID uint64) {
 // The per-ledger usage counters (posting / revert / numscript / volume /
 // metadata / reference) live in the usagestore peer secondary store and are
 // out of main-store checker scope, so they are not advanced here.
-func advanceExpectedBoundaries(expected map[string]*raftcmdpb.LedgerBoundaries, ledger string, log *commonpb.LedgerLog) {
+func advanceExpectedBoundaries(expected map[string]*raftcmdpb.LedgerBoundaries, ledger string, log *commonpb.LedgerLog) error {
 	b, ok := expected[ledger]
 	if !ok {
 		b = &raftcmdpb.LedgerBoundaries{NextTransactionId: 1, NextLogId: 1}
 		expected[ledger] = b
 	}
 
-	if next := log.GetId() + 1; next > b.GetNextLogId() {
-		b.NextLogId = next
+	nextLogID, exhausted := domain.CheckedNextSequence(log.GetId(), domain.SequenceCounterLedgerLogID)
+	if exhausted != nil {
+		return exhausted
+	}
+
+	if nextLogID > b.GetNextLogId() {
+		b.NextLogId = nextLogID
 	}
 
 	var txID uint64
@@ -4451,24 +4479,31 @@ func advanceExpectedBoundaries(expected map[string]*raftcmdpb.LedgerBoundaries, 
 	case *commonpb.LedgerLogPayload_CreatedTransaction:
 		tx := d.CreatedTransaction.GetTransaction()
 		if tx == nil {
-			return
+			return nil
 		}
 
 		txID = tx.GetId()
 	case *commonpb.LedgerLogPayload_RevertedTransaction:
 		revertTx := d.RevertedTransaction.GetRevertTransaction()
 		if revertTx == nil {
-			return
+			return nil
 		}
 
 		txID = revertTx.GetId()
 	default:
-		return
+		return nil
 	}
 
-	if next := txID + 1; next > b.GetNextTransactionId() {
-		b.NextTransactionId = next
+	nextTransactionID, exhausted := domain.CheckedNextSequence(txID, domain.SequenceCounterTransactionID)
+	if exhausted != nil {
+		return exhausted
 	}
+
+	if nextTransactionID > b.GetNextTransactionId() {
+		b.NextTransactionId = nextTransactionID
+	}
+
+	return nil
 }
 
 // collectAuditOrderBoundaryEffects iterates the AuditItem rows and folds the
@@ -4520,7 +4555,12 @@ func (c *Checker) collectAuditOrderBoundaryEffects(reader dal.PebbleReader, expe
 		}
 
 		for _, id := range effects.SkippedTransactionIDs {
-			if next := id + 1; next > b.GetNextTransactionId() {
+			next, exhausted := domain.CheckedNextSequence(id, domain.SequenceCounterTransactionID)
+			if exhausted != nil {
+				return fmt.Errorf("advancing mirror fill-gap transaction id for ledger %q: %w", effects.Ledger, exhausted)
+			}
+
+			if next > b.GetNextTransactionId() {
 				b.NextTransactionId = next
 			}
 		}

--- a/internal/application/check/checker_test.go
+++ b/internal/application/check/checker_test.go
@@ -2,6 +2,7 @@ package check
 
 import (
 	"context"
+	"math"
 	"strings"
 	"testing"
 
@@ -23,6 +24,48 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
+
+func TestCheckerBoundaryRebuildRejectsExhaustedCounters(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ledger log", func(t *testing.T) {
+		t.Parallel()
+
+		expected := make(map[string]*raftcmdpb.LedgerBoundaries)
+		err := advanceExpectedBoundaries(expected, "ledger", &commonpb.LedgerLog{Id: math.MaxUint64})
+		var exhausted *domain.ErrSequenceExhausted
+		require.ErrorAs(t, err, &exhausted)
+		require.Equal(t, domain.SequenceCounterLedgerLogID, exhausted.Counter)
+		require.Equal(t, uint64(1), expected["ledger"].GetNextLogId())
+	})
+
+	t.Run("transaction", func(t *testing.T) {
+		t.Parallel()
+
+		expected := make(map[string]*raftcmdpb.LedgerBoundaries)
+		log := &commonpb.LedgerLog{Id: 1, Data: &commonpb.LedgerLogPayload{
+			Payload: &commonpb.LedgerLogPayload_CreatedTransaction{CreatedTransaction: &commonpb.CreatedTransaction{
+				Transaction: &commonpb.Transaction{Id: math.MaxUint64},
+			}},
+		}}
+		err := advanceExpectedBoundaries(expected, "ledger", log)
+		var exhausted *domain.ErrSequenceExhausted
+		require.ErrorAs(t, err, &exhausted)
+		require.Equal(t, domain.SequenceCounterTransactionID, exhausted.Counter)
+		require.Equal(t, uint64(1), expected["ledger"].GetNextTransactionId())
+	})
+
+	t.Run("audit-derived transaction allocation", func(t *testing.T) {
+		t.Parallel()
+
+		chainBound := newChainBoundState()
+		chainBound.nextTxID["ledger"] = math.MaxUint64
+		id, err := allocateChainBoundTxID("ledger", chainBound)
+		require.Zero(t, id)
+		require.Equal(t, domain.SequenceCounterTransactionID, err.Counter)
+		require.Equal(t, uint64(math.MaxUint64), chainBound.nextTxID["ledger"])
+	})
+}
 
 func createTestStore(t *testing.T) *dal.Store {
 	t.Helper()
@@ -664,11 +707,16 @@ func (s *scopeImpl) GetNextSequenceID() uint64 {
 	return s.engine.nextSequenceID
 }
 
-func (s *scopeImpl) IncrementNextSequenceID() uint64 {
+func (s *scopeImpl) IncrementNextSequenceID() (uint64, domain.Describable) {
 	id := s.engine.nextSequenceID
-	s.engine.nextSequenceID++
+	next, exhausted := domain.CheckedNextSequence(id, domain.SequenceCounterLog)
+	if exhausted != nil {
+		return 0, exhausted
+	}
 
-	return id
+	s.engine.nextSequenceID = next
+
+	return id, nil
 }
 
 func (s *scopeImpl) GetNextLedgerID() uint32 {

--- a/internal/application/check/verify_skipped_order_test.go
+++ b/internal/application/check/verify_skipped_order_test.go
@@ -11,6 +11,21 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
 
+func requireCollectExpectedSkippable(
+	t *testing.T,
+	items []*auditpb.AuditItem,
+	minLogSeq, maxLogSeq uint64,
+	expectedSkippable map[uint64]*expectedSkippableOrder,
+	chainBound *chainBoundState,
+) []*raftcmdpb.Order {
+	t.Helper()
+
+	decoded, err := collectExpectedSkippable(items, minLogSeq, maxLogSeq, expectedSkippable, chainBound)
+	require.NoError(t, err)
+
+	return decoded
+}
+
 // TestVerifySkippedOrder_AllowedReasonEmitsNothing exercises the happy path:
 // reason in the whitelist, prior reference claim present, AND the persisted
 // context fields match the chain-bound expectations.
@@ -805,7 +820,8 @@ func TestCollectExpectedSkippable_RecordsReferencesFromChain(t *testing.T) {
 	expectedSkip := make(map[uint64]*expectedSkippableOrder)
 	refs := make(map[string]map[string]uint64)
 
-	collectExpectedSkippable(items, 1, ^uint64(0), expectedSkip, chainBoundStateFromRefs(refs))
+	_, err := collectExpectedSkippable(items, 1, ^uint64(0), expectedSkip, chainBoundStateFromRefs(refs))
+	require.NoError(t, err)
 
 	require.Equal(t, uint64(100), refs["L"]["ref-A"], "first claim must win for re-claimed reference")
 	require.Equal(t, uint64(101), refs["L"]["ref-B"])
@@ -868,7 +884,8 @@ func TestCollectExpectedSkippable_ReturnsOrdersParallelToItems(t *testing.T) {
 		item(order("duplicate-sequence"), 10),
 	}
 
-	decoded := collectExpectedSkippable(items, 10, 20, make(map[uint64]*expectedSkippableOrder), newChainBoundState())
+	decoded, err := collectExpectedSkippable(items, 10, 20, make(map[uint64]*expectedSkippableOrder), newChainBoundState())
+	require.NoError(t, err)
 
 	require.Len(t, decoded, len(items), "one element per item, so index i pairs with items[i]")
 
@@ -927,7 +944,8 @@ func TestCollectExpectedSkippable_TracksMirrorIngestedReferences(t *testing.T) {
 	expectedSkip := make(map[uint64]*expectedSkippableOrder)
 	refs := make(map[string]map[string]uint64)
 
-	collectExpectedSkippable(items, 1, ^uint64(0), expectedSkip, chainBoundStateFromRefs(refs))
+	_, err = collectExpectedSkippable(items, 1, ^uint64(0), expectedSkip, chainBoundStateFromRefs(refs))
+	require.NoError(t, err)
 
 	require.Equal(t, uint64(50), refs["L"]["mirror-ref"],
 		"mirror-ingested reference must be recorded at its log sequence so later skip verifiers see the prior claim")
@@ -965,7 +983,8 @@ func TestCollectExpectedSkippable_RemoveAccountTypeEmptyNameFlagsKind(t *testing
 	items := []*auditpb.AuditItem{{SerializedOrder: body, LogSequence: 7}}
 	chainBound := newChainBoundState()
 	expectedSkip := make(map[uint64]*expectedSkippableOrder)
-	collectExpectedSkippable(items, 1, ^uint64(0), expectedSkip, chainBound)
+	_, err = collectExpectedSkippable(items, 1, ^uint64(0), expectedSkip, chainBound)
+	require.NoError(t, err)
 
 	exp := expectedSkip[7]
 	require.NotNil(t, exp)
@@ -1041,7 +1060,7 @@ func TestRecordChainBoundMutations_UncertainConflictDoesNotSeedAccountMetadata(t
 
 	chainBound := newChainBoundState()
 	expectedSkip := make(map[uint64]*expectedSkippableOrder)
-	collectExpectedSkippable(items, 1, ^uint64(0), expectedSkip, chainBound)
+	requireCollectExpectedSkippable(t, items, 1, ^uint64(0), expectedSkip, chainBound)
 
 	// The account metadata timeline for (alice, role) must be empty: the
 	// create's application could not be proven.
@@ -1090,7 +1109,7 @@ func TestRecordChainBoundMutations_AnchoredCreateSeedsAccountMetadata(t *testing
 
 	chainBound := newChainBoundState()
 	expectedSkip := make(map[uint64]*expectedSkippableOrder)
-	collectExpectedSkippable(items, 1, ^uint64(0), expectedSkip, chainBound)
+	requireCollectExpectedSkippable(t, items, 1, ^uint64(0), expectedSkip, chainBound)
 
 	require.NotEmpty(t, chainBound.metadata["L"][metadataTimelineTarget(false, "alice")]["role"],
 		"anchored create with an unclaimed reference provably applied → account metadata seeded")
@@ -1181,7 +1200,7 @@ func TestVerifySkippedOrder_MirrorCreatedTxMetadataSeedsTimeline(t *testing.T) {
 
 			chainBound := newChainBoundState()
 			expectedSkip := make(map[uint64]*expectedSkippableOrder)
-			collectExpectedSkippable(items, 1, ^uint64(0), expectedSkip, chainBound)
+			requireCollectExpectedSkippable(t, items, 1, ^uint64(0), expectedSkip, chainBound)
 
 			reason := commonpb.ErrorReason_ERROR_REASON_METADATA_NOT_FOUND
 			expected := map[uint64]*expectedSkippableOrder{
@@ -1223,7 +1242,7 @@ func TestVerifySkippedOrder_MirrorCreatedTxUnrelatedKeyStillSkippable(t *testing
 
 	chainBound := newChainBoundState()
 	expectedSkip := make(map[uint64]*expectedSkippableOrder)
-	collectExpectedSkippable(items, 1, ^uint64(0), expectedSkip, chainBound)
+	requireCollectExpectedSkippable(t, items, 1, ^uint64(0), expectedSkip, chainBound)
 
 	reason := commonpb.ErrorReason_ERROR_REASON_METADATA_NOT_FOUND
 	// Different key ("other") on the same account — never applied by the
@@ -1286,7 +1305,7 @@ func TestCollectExpectedSkippable_HonoursItemLogSequence(t *testing.T) {
 	expectedSkip := make(map[uint64]*expectedSkippableOrder)
 	refs := make(map[string]map[string]uint64)
 
-	collectExpectedSkippable(items, 1, ^uint64(0), expectedSkip, chainBoundStateFromRefs(refs))
+	requireCollectExpectedSkippable(t, items, 1, ^uint64(0), expectedSkip, chainBoundStateFromRefs(refs))
 
 	require.Contains(t, expectedSkip, uint64(80))
 	require.Contains(t, expectedSkip, uint64(200))
@@ -1362,7 +1381,7 @@ func TestRecordChainBoundMutations_LiveCreateTxSeedsTxMetadataNamespace(t *testi
 
 	chainBound := newChainBoundState()
 	expectedSkip := make(map[uint64]*expectedSkippableOrder)
-	collectExpectedSkippable(items, 1, ^uint64(0), expectedSkip, chainBound)
+	requireCollectExpectedSkippable(t, items, 1, ^uint64(0), expectedSkip, chainBound)
 
 	require.NotEmpty(t, chainBound.metadata["L"][metadataTimelineTarget(true, "1")]["txkey"],
 		"live create's tx-scoped metadata must be seeded under the tx:<id> namespace")
@@ -1405,7 +1424,7 @@ func TestCollectExpectedSkippable_DedupesFoldOfLegacyDupKeyReplay(t *testing.T) 
 	// [10,10]) so the counter is seeded to 1 and tx-scoped metadata is
 	// attributed. chainBound persists across per-entry folds, mirroring real
 	// replay where CreateLedger and the transaction live in distinct entries.
-	collectExpectedSkippable(
+	requireCollectExpectedSkippable(t,
 		[]*auditpb.AuditItem{buildCreateLedgerItem(t, "L", 10)},
 		10, 10, expectedSkip, chainBound,
 	)
@@ -1414,7 +1433,7 @@ func TestCollectExpectedSkippable_DedupesFoldOfLegacyDupKeyReplay(t *testing.T) 
 	// Max=50] — the fresh create + the legacy dup-key replay reference to the
 	// same log.
 	item := buildCreateTxWithTxMetadataItem(t, "L", "ref-1", "txkey", 50)
-	collectExpectedSkippable(
+	requireCollectExpectedSkippable(t,
 		[]*auditpb.AuditItem{item, item},
 		50, 50, expectedSkip, chainBound,
 	)
@@ -2013,7 +2032,7 @@ func TestCollectExpectedSkippable_TracksTransactionScopedMetadata(t *testing.T) 
 	}
 
 	cb := newChainBoundState()
-	collectExpectedSkippable(items, 1, ^uint64(0), map[uint64]*expectedSkippableOrder{}, cb)
+	requireCollectExpectedSkippable(t, items, 1, ^uint64(0), map[uint64]*expectedSkippableOrder{}, cb)
 
 	// Tx-scoped metadata from CreateTransaction @ seq=11 → target="tx:1".
 	// The "tx:" namespace MUST match metadataTimelineTarget(isTx=true, id),
@@ -2201,7 +2220,7 @@ func TestCollectExpectedSkippable_LegacyReplayReferenceFoldedOnce(t *testing.T) 
 	expectedSkip := make(map[uint64]*expectedSkippableOrder)
 	// [min,max] = [10,10]: only the fresh item is in range; the replay
 	// reference at seq 5 is below min and must be filtered.
-	collectExpectedSkippable(items, 10, 10, expectedSkip, chainBound)
+	requireCollectExpectedSkippable(t, items, 10, 10, expectedSkip, chainBound)
 
 	// nextTxID advanced by exactly ONE (the fresh create), not two.
 	require.Equal(t, uint64(2), chainBound.nextTxID["L"],
@@ -2278,7 +2297,7 @@ func TestRecordChainBoundMutations_NonConflictSkippableCreateSeedsUnconditionall
 
 	chainBound := newChainBoundState()
 	expectedSkip := make(map[uint64]*expectedSkippableOrder)
-	collectExpectedSkippable(items, 50, 50, expectedSkip, chainBound)
+	requireCollectExpectedSkippable(t, items, 50, 50, expectedSkip, chainBound)
 
 	// account_metadata IS seeded (the create provably applied).
 	require.NotEmpty(t, chainBound.metadata["L"][metadataTimelineTarget(false, "alice")]["role"],

--- a/internal/application/mirror/worker.go
+++ b/internal/application/mirror/worker.go
@@ -306,8 +306,6 @@ func (w *Worker) processBatch(ctx context.Context) (bool, error) {
 		w.boundariesLoaded = true
 	}
 
-	expectedNextLogID := w.lastAppliedV2LogID + 1
-
 	// Use prefetched result if available and valid, otherwise fetch synchronously.
 	var (
 		v2Logs   []v2.V2Log
@@ -355,6 +353,14 @@ func (w *Worker) processBatch(ctx context.Context) (bool, error) {
 		w.publishIdleStatus(ctx)
 
 		return false, nil
+	}
+
+	expectedNextLogID, exhausted := domain.CheckedNextSequence(w.lastAppliedV2LogID, domain.SequenceCounterMirrorV2LogID)
+	if exhausted != nil {
+		// A source queried strictly after MaxUint64 cannot return a fresh log.
+		// Reject an inconsistent non-empty response without wrapping the
+		// translation cursor to zero.
+		return false, fmt.Errorf("advancing mirror source position: %w", exhausted)
 	}
 
 	w.logsIngested.Add(ctx, int64(len(v2Logs)), attrs)

--- a/internal/application/mirror/worker_test.go
+++ b/internal/application/mirror/worker_test.go
@@ -2,14 +2,58 @@ package mirror
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	v2 "github.com/formancehq/ledger/v3/internal/adapter/v2"
+	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 )
+
+func TestWorkerTerminalSourcePositionNeverWraps(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		logs    []v2.V2Log
+		wantErr bool
+	}{
+		{name: "caught up source remains idle"},
+		{name: "non-empty source response is rejected", logs: []v2.V2Log{{ID: math.MaxUint64}}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			builder, store := newTestBuilder(t)
+			writeBoundaries(t, store, "mirrored", &raftcmdpb.LedgerBoundaries{
+				NextTransactionId: 1,
+				LastMirrorV2LogId: math.MaxUint64,
+			})
+			ctrl := gomock.NewController(t)
+			source := v2.NewMockSource(ctrl)
+			source.EXPECT().FetchLogs(gomock.Any(), uint64(math.MaxUint64), gomock.Any()).Return(tt.logs, false, nil)
+			w := newWorkerForTest(t, "mirrored", source, store, builder)
+
+			_, err := w.processBatch(context.Background())
+			if !tt.wantErr {
+				require.NoError(t, err)
+				require.Equal(t, uint64(math.MaxUint64), w.lastAppliedV2LogID)
+
+				return
+			}
+
+			var exhausted *domain.ErrSequenceExhausted
+			require.ErrorAs(t, err, &exhausted)
+			require.Equal(t, domain.SequenceCounterMirrorV2LogID, exhausted.Counter)
+			require.Equal(t, uint64(math.MaxUint64), w.lastAppliedV2LogID)
+		})
+	}
+}
 
 // A mirror ledger with no boundary row starts fetching from source ID 1,
 // i.e. it asks the source for logs after ID 0.

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -230,6 +230,7 @@ const (
 	ErrReasonClusterPolicyInvalid          = "CLUSTER_POLICY_INVALID"
 	ErrReasonCheckpointLimitReached        = "CHECKPOINT_LIMIT_REACHED"
 	ErrReasonCheckpointNotFound            = "CHECKPOINT_NOT_FOUND"
+	ErrReasonSequenceExhausted             = "SEQUENCE_EXHAUSTED"
 
 	// ErrReasonWritesBlockedDiskFull signals that the write gate rejected the
 	// request because disk usage is at or above the configured block threshold.
@@ -241,6 +242,21 @@ const (
 	// Maps to gRPC Unavailable / HTTP 503.
 	ErrReasonWritesBlockedClockSkew = "WRITES_BLOCKED_CLOCK_SKEW"
 )
+
+// ErrSequenceExhausted rejects an allocation that would wrap an authoritative
+// uint64 counter to zero. Exhaustion is permanent for the affected ledger or
+// cluster; retrying cannot create another unique identifier.
+type ErrSequenceExhausted struct {
+	Counter SequenceCounter
+}
+
+func (e *ErrSequenceExhausted) Error() string {
+	return fmt.Sprintf("%s exhausted: cannot allocate another identifier", e.Counter)
+}
+func (*ErrSequenceExhausted) Reason() string { return ErrReasonSequenceExhausted }
+func (e *ErrSequenceExhausted) Metadata() map[string]string {
+	return map[string]string{"counter": string(e.Counter)}
+}
 
 // BusinessError wraps a Describable so it can flow through code paths that
 // only understand the standard `error` interface (futures, admission,

--- a/internal/domain/errors_test.go
+++ b/internal/domain/errors_test.go
@@ -315,6 +315,7 @@ func TestEveryDomainErrorImplementsDescribable(t *testing.T) {
 		"ErrTransactionAlreadyReverted":    &ErrTransactionAlreadyReverted{},
 		"ErrInsufficientFunds":             &ErrInsufficientFunds{},
 		"ErrVolumeOverflow":                &ErrVolumeOverflow{},
+		"ErrSequenceExhausted":             &ErrSequenceExhausted{},
 		"ErrBalanceNotFound":               &ErrBalanceNotFound{},
 		"ErrSinkAlreadyExists":             &ErrSinkAlreadyExists{},
 		"ErrSinkBatchSizeTooLarge":         &ErrSinkBatchSizeTooLarge{},

--- a/internal/domain/processing/overlay_scope.go
+++ b/internal/domain/processing/overlay_scope.go
@@ -152,12 +152,16 @@ func (o *orderOverlayScope) GetNextSequenceID() uint64 {
 	return o.baseSeqID + o.seqIDDelta
 }
 
-func (o *orderOverlayScope) IncrementNextSequenceID() uint64 {
+func (o *orderOverlayScope) IncrementNextSequenceID() (uint64, domain.Describable) {
 	o.captureBaseCounters()
 	next := o.baseSeqID + o.seqIDDelta
+	if _, exhausted := domain.CheckedNextSequence(next, domain.SequenceCounterLog); exhausted != nil {
+		return 0, exhausted
+	}
+
 	o.seqIDDelta++
 
-	return next
+	return next, nil
 }
 
 func (o *orderOverlayScope) GetNextLedgerID() uint32 {
@@ -237,7 +241,9 @@ func (o *orderOverlayScope) Commit() error {
 	}
 
 	for range o.seqIDDelta {
-		o.Scope.IncrementNextSequenceID()
+		if _, err := o.Scope.IncrementNextSequenceID(); err != nil {
+			return err
+		}
 	}
 
 	for range o.ledgerIDDelta {

--- a/internal/domain/processing/overlay_scope_test.go
+++ b/internal/domain/processing/overlay_scope_test.go
@@ -1,6 +1,7 @@
 package processing
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -248,7 +249,8 @@ func TestOrderOverlayScope_RollbackOnNoCommit(t *testing.T) {
 	overlay := newOrderOverlayScope(s.parent)
 	overlay.Ledgers().Put(domain.LedgerKey{Name: "L"}, &commonpb.LedgerInfo{Name: "L"})
 	overlay.Boundaries().Put(domain.LedgerKey{Name: "L"}, &raftcmdpb.LedgerBoundaries{})
-	overlay.IncrementNextSequenceID()
+	_, err := overlay.IncrementNextSequenceID()
+	require.NoError(t, err)
 	overlay.IncrementNextLedgerID()
 
 	// No Commit. The catch-all parent write hook fails the test on any
@@ -269,7 +271,7 @@ func TestOrderOverlayScope_CommitFlushesEveryCategory(t *testing.T) {
 	s.parent.EXPECT().GetNextLedgerID().Return(uint32(5)).AnyTimes()
 	s.parent.EXPECT().GetNextQueryCheckpointID().Return(uint64(0)).AnyTimes()
 	s.parent.EXPECT().PutReverted(gomock.Any(), true)
-	s.parent.EXPECT().IncrementNextSequenceID().Return(uint64(101)).Times(2)
+	s.parent.EXPECT().IncrementNextSequenceID().Return(uint64(101), nil).Times(2)
 	s.parent.EXPECT().IncrementNextLedgerID().Return(uint32(6))
 	s.parent.EXPECT().IncrementNextQueryCheckpointID().Return(uint64(1))
 
@@ -304,8 +306,10 @@ func TestOrderOverlayScope_CommitFlushesEveryCategory(t *testing.T) {
 	overlay.TransactionStates().Put(tsk, &commonpb.TransactionState{})
 	overlay.PreparedQueries().Put(pqk, &commonpb.PreparedQuery{Name: "q1"})
 	overlay.Indexes().Put(ik, &commonpb.Index{})
-	overlay.IncrementNextSequenceID()
-	overlay.IncrementNextSequenceID()
+	_, err := overlay.IncrementNextSequenceID()
+	require.NoError(t, err)
+	_, err = overlay.IncrementNextSequenceID()
+	require.NoError(t, err)
 	overlay.IncrementNextLedgerID()
 	overlay.IncrementNextQueryCheckpointID()
 
@@ -328,9 +332,34 @@ func TestOrderOverlayScope_CounterDeltasMonotonicWithinOrder(t *testing.T) {
 
 	overlay := newOrderOverlayScope(s.parent)
 
-	require.Equal(t, uint64(100), overlay.IncrementNextSequenceID())
-	require.Equal(t, uint64(101), overlay.IncrementNextSequenceID())
+	sequence, err := overlay.IncrementNextSequenceID()
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), sequence)
+	sequence, err = overlay.IncrementNextSequenceID()
+	require.NoError(t, err)
+	require.Equal(t, uint64(101), sequence)
 	require.Equal(t, uint64(102), overlay.GetNextSequenceID())
+}
+
+func TestOrderOverlayScopeRejectsExhaustedLogSequenceWithoutDelta(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	s := wireOverlayParent(ctrl)
+	s.parent.EXPECT().GetNextSequenceID().Return(uint64(math.MaxUint64)).Times(1)
+	s.parent.EXPECT().GetNextLedgerID().Return(uint32(5)).Times(1)
+	s.parent.EXPECT().GetNextQueryCheckpointID().Return(uint64(0)).Times(1)
+	overlay := newOrderOverlayScope(s.parent)
+
+	sequence, err := overlay.IncrementNextSequenceID()
+	require.Zero(t, sequence)
+	var exhausted *domain.ErrSequenceExhausted
+	require.ErrorAs(t, err, &exhausted)
+	require.Equal(t, domain.SequenceCounterLog, exhausted.Counter)
+	require.Equal(t, uint64(math.MaxUint64), overlay.GetNextSequenceID())
+	require.Zero(t, overlay.seqIDDelta)
 }
 
 // TestOrderOverlayScope_DeleteOverridesPriorPut models the

--- a/internal/domain/processing/processor.go
+++ b/internal/domain/processing/processor.go
@@ -292,7 +292,10 @@ func (p *RequestProcessor) ProcessOrders(orders []*raftcmdpb.Order, scopeFactory
 					return nil, err
 				}
 
-				nextSequenceID := orderScope.IncrementNextSequenceID()
+				nextSequenceID, sequenceErr := orderScope.IncrementNextSequenceID()
+				if sequenceErr != nil {
+					return nil, sequenceErr
+				}
 				skipLog := &commonpb.Log{
 					Sequence: nextSequenceID,
 					Payload:  skippedPayload,
@@ -350,7 +353,10 @@ func (p *RequestProcessor) ProcessOrders(orders []*raftcmdpb.Order, scopeFactory
 			}
 		}
 
-		nextSequenceID := orderScope.IncrementNextSequenceID()
+		nextSequenceID, sequenceErr := orderScope.IncrementNextSequenceID()
+		if sequenceErr != nil {
+			return nil, sequenceErr
+		}
 		log := &commonpb.Log{
 			Sequence: nextSequenceID,
 			Payload:  payload,

--- a/internal/domain/processing/processor_apply.go
+++ b/internal/domain/processing/processor_apply.go
@@ -53,6 +53,15 @@ func processApply(ledger string, apply *raftcmdpb.LedgerApplyOrder, ctx *Context
 	ctx.Boundaries = boundaries
 	ctx.LedgerInfo = ledgerInfo
 
+	// Every successful ledger-scoped apply emits one per-ledger log. Check the
+	// next-ID transition before dispatch so exhaustion rejects without leaving
+	// any staged child-handler mutation behind (EN-1860).
+	nextLogID := boundaries.GetNextLogId()
+	advancedLogID, exhausted := domain.CheckedNextSequence(nextLogID, domain.SequenceCounterLedgerLogID)
+	if exhausted != nil {
+		return nil, exhausted
+	}
+
 	var (
 		logPayload *commonpb.LedgerLogPayload
 		err        domain.Describable
@@ -89,8 +98,7 @@ func processApply(ledger string, apply *raftcmdpb.LedgerApplyOrder, ctx *Context
 		return nil, err
 	}
 
-	nextLogID := boundaries.GetNextLogId()
-	boundaries.NextLogId = nextLogID + 1
+	boundaries.NextLogId = advancedLogID
 
 	s.Boundaries().Put(domain.LedgerKey{Name: ledger}, boundaries)
 

--- a/internal/domain/processing/processor_mirror.go
+++ b/internal/domain/processing/processor_mirror.go
@@ -82,11 +82,19 @@ func processMirrorIngest(ledger string, order *raftcmdpb.MirrorIngestOrder, ctx 
 	//
 	// First-ingest case: LastMirrorV2LogId defaults to 0, so expected = 1 and the
 	// first real v2LogId (>= 1) applies.
-	switch {
-	case v2LogID <= last:
+	if v2LogID <= last {
 		return nil, nil
-	case v2LogID > last+1:
-		return nil, &domain.ErrMirrorV2LogIDGap{Name: ledger, Got: v2LogID, Expected: last + 1}
+	}
+
+	expectedV2LogID, exhausted := domain.CheckedNextSequence(last, domain.SequenceCounterMirrorV2LogID)
+	if exhausted != nil {
+		// A uint64 greater than MaxUint64 cannot reach this branch; retain the
+		// explicit guard so the contiguity check itself never relies on wrap.
+		return nil, exhausted
+	}
+
+	if v2LogID > expectedV2LogID {
+		return nil, &domain.ErrMirrorV2LogIDGap{Name: ledger, Got: v2LogID, Expected: expectedV2LogID}
 	}
 
 	// Created and reverted transactions must carry the source v2 log date.
@@ -99,10 +107,13 @@ func processMirrorIngest(ledger string, order *raftcmdpb.MirrorIngestOrder, ctx 
 		}
 	}
 
-	// Re-touch ledger info so it enters the Merge buffer and gets propagated
-	// back to Gen0 on commit. Without this, ledger info is evicted after two
-	// cache rotations because mirror proposals bypass the admission preloader.
-	s.Ledgers().Put(domain.LedgerKey{Name: ledger}, info)
+	// Every fresh mirror entry emits one per-ledger log. Reject exhaustion
+	// before re-touching the ledger or dispatching a child handler.
+	nextLogID := boundaries.GetNextLogId()
+	advancedLogID, exhausted := domain.CheckedNextSequence(nextLogID, domain.SequenceCounterLedgerLogID)
+	if exhausted != nil {
+		return nil, exhausted
+	}
 
 	// Stage per-apply context fields for child handlers.
 	ctx.Boundaries = boundaries
@@ -112,7 +123,12 @@ func processMirrorIngest(ledger string, order *raftcmdpb.MirrorIngestOrder, ctx 
 
 	switch data := entry.GetData().(type) {
 	case *raftcmdpb.MirrorLogEntry_FillGap:
-		logPayload = processMirrorFillGap(data.FillGap, entry.GetV2LogId(), ctx)
+		var err domain.Describable
+
+		logPayload, err = processMirrorFillGap(data.FillGap, entry.GetV2LogId(), ctx)
+		if err != nil {
+			return nil, err
+		}
 
 	case *raftcmdpb.MirrorLogEntry_CreatedTransaction:
 		var err domain.Describable
@@ -150,9 +166,15 @@ func processMirrorIngest(ledger string, order *raftcmdpb.MirrorIngestOrder, ctx 
 		return nil, &domain.ErrLedgerNotInMirrorMode{Name: ledger}
 	}
 
+	// Re-touch ledger info so it enters the Merge buffer and gets propagated
+	// back to Gen0 on commit. Do this only after the child handler succeeds so
+	// sequence exhaustion cannot leave even a staged ledger mutation behind.
+	// Without the touch, ledger info is evicted after two cache rotations because
+	// mirror proposals bypass the admission preloader.
+	s.Ledgers().Put(domain.LedgerKey{Name: ledger}, info)
+
 	// Assign per-ledger log ID and advance boundaries
-	nextLogID := boundaries.GetNextLogId()
-	boundaries.NextLogId = nextLogID + 1
+	boundaries.NextLogId = advancedLogID
 	// Advance the idempotent-replay high-water mark. Set once here regardless of
 	// the inner ingest kind, because v2LogId lives on the wrapping MirrorLogEntry
 	// and applies to every kind (CreatedTransaction, SavedMetadata,
@@ -183,17 +205,24 @@ func processMirrorIngest(ledger string, order *raftcmdpb.MirrorIngestOrder, ctx 
 // Signature deviates from the uniform `(order, ctx)` shape because the
 // v2LogID belongs to the wrapping MirrorLogEntry, not the FillGap message
 // itself — passing it as an extra arg avoids reaching back into the entry.
-func processMirrorFillGap(gap *raftcmdpb.MirrorFillGap, v2LogID uint64, ctx *Context) *commonpb.LedgerLogPayload {
+func processMirrorFillGap(gap *raftcmdpb.MirrorFillGap, v2LogID uint64, ctx *Context) (*commonpb.LedgerLogPayload, domain.Describable) {
 	// Advance NextTransactionId past every skipped transaction id, using the id
 	// values rather than the element count. This matches the created/reverted
 	// apply paths (NextTransactionId = id + 1) and stays correct even if a
 	// dropped id is not contiguous with the current boundary — incrementing by
 	// count would leave the boundary too low.
+	advancedTransactionID := ctx.Boundaries.GetNextTransactionId()
 	for _, id := range gap.GetSkippedTransactionIds() {
-		if ctx.Boundaries.GetNextTransactionId() <= id {
-			ctx.Boundaries.NextTransactionId = id + 1
+		if advancedTransactionID <= id {
+			next, exhausted := domain.CheckedNextSequence(id, domain.SequenceCounterTransactionID)
+			if exhausted != nil {
+				return nil, exhausted
+			}
+
+			advancedTransactionID = next
 		}
 	}
+	ctx.Boundaries.NextTransactionId = advancedTransactionID
 
 	return &commonpb.LedgerLogPayload{
 		Payload: &commonpb.LedgerLogPayload_FillGap{
@@ -201,7 +230,7 @@ func processMirrorFillGap(gap *raftcmdpb.MirrorFillGap, v2LogID uint64, ctx *Con
 				OriginalId: v2LogID,
 			},
 		},
-	}
+	}, nil
 }
 
 // processMirrorCreatedTransaction creates a transaction from mirror data.
@@ -212,6 +241,16 @@ func processMirrorCreatedTransaction(ledger string, ct *raftcmdpb.MirrorCreatedT
 	boundaries := ctx.Boundaries
 	s := ctx.Scope
 
+	txID := ct.GetTransactionId()
+	var advancedTransactionID uint64
+	if boundaries.GetNextTransactionId() <= txID {
+		var exhausted *domain.ErrSequenceExhausted
+		advancedTransactionID, exhausted = domain.CheckedNextSequence(txID, domain.SequenceCounterTransactionID)
+		if exhausted != nil {
+			return nil, exhausted
+		}
+	}
+
 	// Apply each posting with force=true (skip balance checks, auto-init missing volumes)
 	for _, posting := range ct.GetPostings() {
 		if err := applyPosting(s, ledger, posting, true, ctx.AssetCache); err != nil {
@@ -221,10 +260,9 @@ func processMirrorCreatedTransaction(ledger string, ct *raftcmdpb.MirrorCreatedT
 		}
 	}
 
-	txID := ct.GetTransactionId()
 	// Ensure NextTransactionId is past this ID
 	if boundaries.GetNextTransactionId() <= txID {
-		boundaries.NextTransactionId = txID + 1
+		boundaries.NextTransactionId = advancedTransactionID
 	}
 
 	// posting_count is no longer maintained on LedgerBoundaries — the
@@ -399,6 +437,16 @@ func processMirrorRevertedTransaction(ledger string, rt *raftcmdpb.MirrorReverte
 	boundaries := ctx.Boundaries
 	s := ctx.Scope
 
+	revertTxID := rt.GetNewTransactionId()
+	var advancedTransactionID uint64
+	if boundaries.GetNextTransactionId() <= revertTxID {
+		var exhausted *domain.ErrSequenceExhausted
+		advancedTransactionID, exhausted = domain.CheckedNextSequence(revertTxID, domain.SequenceCounterTransactionID)
+		if exhausted != nil {
+			return nil, exhausted
+		}
+	}
+
 	// Apply reversed postings with force=true (auto-init missing volumes)
 	for _, posting := range rt.GetReversePostings() {
 		if err := applyPosting(s, ledger, posting, true, ctx.AssetCache); err != nil {
@@ -409,10 +457,9 @@ func processMirrorRevertedTransaction(ledger string, rt *raftcmdpb.MirrorReverte
 	// Mark original transaction as reverted
 	s.PutReverted(domain.TransactionKey{LedgerName: ledger, ID: rt.GetRevertedTransactionId()}, true)
 
-	revertTxID := rt.GetNewTransactionId()
 	// Ensure NextTransactionId is past this ID
 	if boundaries.GetNextTransactionId() <= revertTxID {
-		boundaries.NextTransactionId = revertTxID + 1
+		boundaries.NextTransactionId = advancedTransactionID
 	}
 
 	// posting_count and revert_count are no longer maintained on

--- a/internal/domain/processing/processor_mirror_test.go
+++ b/internal/domain/processing/processor_mirror_test.go
@@ -1,6 +1,7 @@
 package processing
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,6 +11,273 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 )
+
+func TestMirrorIngestRejectsExhaustedTransactionIDWithoutMutation(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	processor, err := NewRequestProcessor(nil, 0)
+	require.NoError(t, err)
+
+	boundaries := &raftcmdpb.LedgerBoundaries{
+		NextTransactionId: math.MaxUint64,
+		NextLogId:         1,
+		LastMirrorV2LogId: 41,
+	}
+	ledgerInfo := &commonpb.LedgerInfo{
+		Name: "mirror-ledger",
+		Mode: commonpb.LedgerMode_LEDGER_MODE_MIRROR,
+	}
+
+	ledgerTouched := false
+	ledgers := setupLedgersStub(mockStore)
+	ledgers.expectGet(domain.LedgerKey{Name: "mirror-ledger"}, ledgerInfo.AsReader(), nil)
+	ledgers.onPut(func(domain.LedgerKey, *commonpb.LedgerInfo) { ledgerTouched = true })
+
+	boundaryWritten := false
+	boundariesStub := setupBoundariesStub(mockStore)
+	boundariesStub.expectGet(domain.LedgerKey{Name: "mirror-ledger"}, boundaries.AsReader(), nil)
+	boundariesStub.onPut(func(domain.LedgerKey, *raftcmdpb.LedgerBoundaries) { boundaryWritten = true })
+
+	for range 2 {
+		result, processErr := processor.ProcessOrder(
+			mirrorCreatedTxOrder("mirror-ledger", 42, math.MaxUint64),
+			mockStore,
+		)
+		require.Nil(t, result)
+		var exhausted *domain.ErrSequenceExhausted
+		require.ErrorAs(t, processErr, &exhausted)
+		require.Equal(t, domain.SequenceCounterTransactionID, exhausted.Counter)
+		require.Equal(t, uint64(math.MaxUint64), boundaries.GetNextTransactionId())
+		require.Equal(t, uint64(1), boundaries.GetNextLogId())
+		require.Equal(t, uint64(41), boundaries.GetLastMirrorV2LogId())
+		require.False(t, ledgerTouched)
+		require.False(t, boundaryWritten)
+	}
+}
+
+func TestMirrorIngestRejectsExhaustedLedgerLogIDWithoutMutation(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	processor, err := NewRequestProcessor(nil, 0)
+	require.NoError(t, err)
+
+	boundaries := &raftcmdpb.LedgerBoundaries{
+		NextTransactionId: 1,
+		NextLogId:         math.MaxUint64,
+	}
+	ledgerInfo := &commonpb.LedgerInfo{
+		Name: "mirror-ledger",
+		Mode: commonpb.LedgerMode_LEDGER_MODE_MIRROR,
+	}
+
+	ledgerTouched := false
+	ledgers := setupLedgersStub(mockStore)
+	ledgers.expectGet(domain.LedgerKey{Name: "mirror-ledger"}, ledgerInfo.AsReader(), nil)
+	ledgers.onPut(func(domain.LedgerKey, *commonpb.LedgerInfo) { ledgerTouched = true })
+
+	boundaryWritten := false
+	boundariesStub := setupBoundariesStub(mockStore)
+	boundariesStub.expectGet(domain.LedgerKey{Name: "mirror-ledger"}, boundaries.AsReader(), nil)
+	boundariesStub.onPut(func(domain.LedgerKey, *raftcmdpb.LedgerBoundaries) { boundaryWritten = true })
+
+	order := &raftcmdpb.Order{
+		Type: &raftcmdpb.Order_LedgerScoped{
+			LedgerScoped: &raftcmdpb.LedgerScopedOrder{
+				Ledger: "mirror-ledger",
+				Payload: &raftcmdpb.LedgerScopedOrder_MirrorIngest{
+					MirrorIngest: &raftcmdpb.MirrorIngestOrder{Entry: &raftcmdpb.MirrorLogEntry{
+						V2LogId: 1,
+						Data: &raftcmdpb.MirrorLogEntry_FillGap{
+							FillGap: &raftcmdpb.MirrorFillGap{},
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	for range 2 {
+		result, processErr := processor.ProcessOrder(order, mockStore)
+		require.Nil(t, result)
+		var exhausted *domain.ErrSequenceExhausted
+		require.ErrorAs(t, processErr, &exhausted)
+		require.Equal(t, domain.SequenceCounterLedgerLogID, exhausted.Counter)
+		require.Equal(t, uint64(math.MaxUint64), boundaries.GetNextLogId())
+		require.Equal(t, uint64(1), boundaries.GetNextTransactionId())
+		require.Zero(t, boundaries.GetLastMirrorV2LogId())
+		require.False(t, ledgerTouched)
+		require.False(t, boundaryWritten)
+	}
+}
+
+func TestMirrorIngestAllowsLastTransactionAndLedgerLogIDs(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	processor, err := NewRequestProcessor(nil, 0)
+	require.NoError(t, err)
+
+	boundaries := &raftcmdpb.LedgerBoundaries{
+		NextTransactionId: math.MaxUint64 - 1,
+		NextLogId:         math.MaxUint64 - 1,
+		LastMirrorV2LogId: 41,
+	}
+	ledgerInfo := &commonpb.LedgerInfo{Name: "mirror-ledger", Mode: commonpb.LedgerMode_LEDGER_MODE_MIRROR}
+	expectGetLedger(mockStore, domain.LedgerKey{Name: "mirror-ledger"}, ledgerInfo.AsReader(), nil).AnyTimes()
+	expectPutLedger(t, mockStore, domain.LedgerKey{Name: "mirror-ledger"}, ledgerInfo)
+	mockStore.EXPECT().GetDate().Return((&commonpb.Timestamp{Data: 1}).AsReader()).AnyTimes()
+	mockStore.EXPECT().GetNextSequenceID().Return(uint64(100))
+
+	var persisted *raftcmdpb.LedgerBoundaries
+	boundariesStub := setupBoundariesStub(mockStore)
+	boundariesStub.expectGet(domain.LedgerKey{Name: "mirror-ledger"}, boundaries.AsReader(), nil)
+	boundariesStub.onPut(func(_ domain.LedgerKey, b *raftcmdpb.LedgerBoundaries) { persisted = b })
+
+	zeroVol := (&raftcmdpb.VolumePair{
+		Input:  commonpb.NewUint256FromUint64(0),
+		Output: commonpb.NewUint256FromUint64(0),
+	}).AsReader()
+	volumes := setupVolumesStub(mockStore)
+	volumes.expectGet(domain.NewVolumeKey("mirror-ledger", "world", "USD/2", ""), zeroVol, nil)
+	volumes.expectGet(domain.NewVolumeKey("mirror-ledger", "users:001", "USD/2", ""), zeroVol, nil)
+	expectPutTransactionState(t, mockStore, domain.TransactionKey{LedgerName: "mirror-ledger", ID: math.MaxUint64 - 1}, nil)
+
+	result, processErr := processor.ProcessOrder(
+		mirrorCreatedTxOrder("mirror-ledger", 42, math.MaxUint64-1),
+		mockStore,
+	)
+	require.NoError(t, processErr)
+	require.Equal(t, uint64(math.MaxUint64-1), result.GetApply().GetLog().GetId())
+	require.Equal(t, uint64(math.MaxUint64), persisted.GetNextTransactionId())
+	require.Equal(t, uint64(math.MaxUint64), persisted.GetNextLogId())
+	require.Equal(t, uint64(42), persisted.GetLastMirrorV2LogId())
+}
+
+func TestMirrorTransactionVariantsRejectMaxIDBeforeMutation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fill gap validates all skipped ids before advancing", func(t *testing.T) {
+		t.Parallel()
+
+		boundaries := &raftcmdpb.LedgerBoundaries{NextTransactionId: 7}
+		payload, err := processMirrorFillGap(
+			&raftcmdpb.MirrorFillGap{SkippedTransactionIds: []uint64{10, math.MaxUint64}},
+			42,
+			&Context{Boundaries: boundaries},
+		)
+		require.Nil(t, payload)
+		var exhausted *domain.ErrSequenceExhausted
+		require.ErrorAs(t, err, &exhausted)
+		require.Equal(t, domain.SequenceCounterTransactionID, exhausted.Counter)
+		require.Equal(t, uint64(7), boundaries.GetNextTransactionId())
+	})
+
+	t.Run("reverted transaction validates new id before applying postings", func(t *testing.T) {
+		t.Parallel()
+
+		boundaries := &raftcmdpb.LedgerBoundaries{NextTransactionId: 7}
+		payload, err := processMirrorRevertedTransaction(
+			"mirror-ledger",
+			&raftcmdpb.MirrorRevertedTransaction{NewTransactionId: math.MaxUint64},
+			&commonpb.Timestamp{Data: 1},
+			&Context{Boundaries: boundaries},
+		)
+		require.Nil(t, payload)
+		var exhausted *domain.ErrSequenceExhausted
+		require.ErrorAs(t, err, &exhausted)
+		require.Equal(t, domain.SequenceCounterTransactionID, exhausted.Counter)
+		require.Equal(t, uint64(7), boundaries.GetNextTransactionId())
+	})
+}
+
+func TestMirrorIngestAcceptsTerminalV2HighWaterWithoutContiguityWrap(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	processor, err := NewRequestProcessor(nil, 0)
+	require.NoError(t, err)
+
+	boundaries := &raftcmdpb.LedgerBoundaries{
+		NextTransactionId: 1,
+		NextLogId:         1,
+		LastMirrorV2LogId: math.MaxUint64 - 1,
+	}
+	ledgerInfo := &commonpb.LedgerInfo{Name: "mirror-ledger", Mode: commonpb.LedgerMode_LEDGER_MODE_MIRROR}
+	expectGetLedger(mockStore, domain.LedgerKey{Name: "mirror-ledger"}, ledgerInfo.AsReader(), nil).AnyTimes()
+	expectPutLedger(t, mockStore, domain.LedgerKey{Name: "mirror-ledger"}, ledgerInfo)
+	mockStore.EXPECT().GetDate().Return((&commonpb.Timestamp{Data: 1}).AsReader())
+
+	var persisted *raftcmdpb.LedgerBoundaries
+	boundariesStub := setupBoundariesStub(mockStore)
+	boundariesStub.expectGet(domain.LedgerKey{Name: "mirror-ledger"}, boundaries.AsReader(), nil)
+	boundariesStub.onPut(func(_ domain.LedgerKey, b *raftcmdpb.LedgerBoundaries) { persisted = b })
+
+	order := &raftcmdpb.Order{Type: &raftcmdpb.Order_LedgerScoped{LedgerScoped: &raftcmdpb.LedgerScopedOrder{
+		Ledger: "mirror-ledger",
+		Payload: &raftcmdpb.LedgerScopedOrder_MirrorIngest{MirrorIngest: &raftcmdpb.MirrorIngestOrder{
+			Entry: &raftcmdpb.MirrorLogEntry{
+				V2LogId: math.MaxUint64,
+				Data:    &raftcmdpb.MirrorLogEntry_FillGap{FillGap: &raftcmdpb.MirrorFillGap{}},
+			},
+		}},
+	}}}
+
+	result, processErr := processor.ProcessOrder(order, mockStore)
+	require.NoError(t, processErr)
+	require.Equal(t, uint64(1), result.GetApply().GetLog().GetId())
+	require.Equal(t, uint64(2), persisted.GetNextLogId())
+	require.Equal(t, uint64(math.MaxUint64), persisted.GetLastMirrorV2LogId())
+}
+
+func TestMirrorIngestTerminalV2HighWaterReplayIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	processor, err := NewRequestProcessor(nil, 0)
+	require.NoError(t, err)
+
+	boundaries := &raftcmdpb.LedgerBoundaries{
+		NextTransactionId: 43,
+		NextLogId:         5,
+		LastMirrorV2LogId: math.MaxUint64,
+	}
+	ledgerInfo := &commonpb.LedgerInfo{Name: "mirror-ledger", Mode: commonpb.LedgerMode_LEDGER_MODE_MIRROR}
+	expectGetLedger(mockStore, domain.LedgerKey{Name: "mirror-ledger"}, ledgerInfo.AsReader(), nil).AnyTimes()
+	boundariesStub := setupBoundariesStub(mockStore)
+	boundariesStub.expectGet(domain.LedgerKey{Name: "mirror-ledger"}, boundaries.AsReader(), nil)
+	boundariesStub.onPut(func(domain.LedgerKey, *raftcmdpb.LedgerBoundaries) {
+		t.Fatal("terminal mirror replay must not write boundaries")
+	})
+	ledgersStub := setupLedgersStub(mockStore)
+	ledgersStub.onPut(func(domain.LedgerKey, *commonpb.LedgerInfo) {
+		t.Fatal("terminal mirror replay must not touch the ledger")
+	})
+
+	result, processErr := processor.ProcessOrder(
+		mirrorCreatedTxOrder("mirror-ledger", math.MaxUint64, 42),
+		mockStore,
+	)
+	require.NoError(t, processErr)
+	require.Nil(t, result)
+	require.Equal(t, uint64(math.MaxUint64), boundaries.GetLastMirrorV2LogId())
+}
 
 func TestMirrorIngest_FillGap(t *testing.T) {
 	t.Parallel()

--- a/internal/domain/processing/processor_revert_transaction.go
+++ b/internal/domain/processing/processor_revert_transaction.go
@@ -81,6 +81,14 @@ func processRevertTransaction(ledger string, order *raftcmdpb.RevertTransactionO
 		}
 	}
 
+	// Reject exhaustion before applying the compensating postings or marking
+	// the original transaction reverted. See processCreateTransaction.
+	revertTxID := boundaries.GetNextTransactionId()
+	advancedTransactionID, exhausted := domain.CheckedNextSequence(revertTxID, domain.SequenceCounterTransactionID)
+	if exhausted != nil {
+		return nil, exhausted
+	}
+
 	for _, posting := range revertPostings {
 		// Apply the reversed posting (skip balance check if force is set)
 		err := applyPosting(s, ledger, posting, order.GetForce(), ctx.AssetCache)
@@ -92,9 +100,8 @@ func processRevertTransaction(ledger string, order *raftcmdpb.RevertTransactionO
 	// Mark the original transaction as reverted
 	s.PutReverted(txKey, true)
 
-	// Get new transaction ID for the revert transaction
-	revertTxID := boundaries.GetNextTransactionId()
-	boundaries.NextTransactionId = revertTxID + 1
+	// Consume the preflighted transaction ID for the compensating transaction.
+	boundaries.NextTransactionId = advancedTransactionID
 
 	// posting_count and revert_count are no longer maintained on
 	// LedgerBoundaries — the usagebuilder derives them from the audit

--- a/internal/domain/processing/processor_revert_transaction_test.go
+++ b/internal/domain/processing/processor_revert_transaction_test.go
@@ -1,6 +1,7 @@
 package processing
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -10,6 +11,32 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 )
+
+func TestProcessRevertTransactionRejectsExhaustedIDBeforeWrites(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	boundaries := &raftcmdpb.LedgerBoundaries{NextTransactionId: math.MaxUint64}
+	txKey := domain.TransactionKey{LedgerName: "test-ledger", ID: 3}
+	mockStore.EXPECT().GetReverted(txKey).Return(false, nil)
+	expectGetTransactionState(mockStore, txKey, (&commonpb.TransactionState{Postings: []*commonpb.Posting{{
+		Source: "world", Destination: "users:001", Amount: commonpb.NewUint256FromUint64(1), Asset: "USD",
+	}}}).AsReader(), nil)
+
+	payload, err := processRevertTransaction(
+		"test-ledger",
+		&raftcmdpb.RevertTransactionOrder{TransactionId: 3},
+		&Context{Scope: mockStore, Boundaries: boundaries, LedgerInfo: &commonpb.LedgerInfo{}},
+	)
+	require.Nil(t, payload)
+	var exhausted *domain.ErrSequenceExhausted
+	require.ErrorAs(t, err, &exhausted)
+	require.Equal(t, domain.SequenceCounterTransactionID, exhausted.Counter)
+	require.Equal(t, uint64(math.MaxUint64), boundaries.GetNextTransactionId())
+}
 
 func TestProcessRevertTransaction_Success(t *testing.T) {
 	t.Parallel()

--- a/internal/domain/processing/processor_skippable.go
+++ b/internal/domain/processing/processor_skippable.go
@@ -151,7 +151,12 @@ func assignSkipLogIDAndDate(parent Scope, order *raftcmdpb.Order, payload *commo
 
 	boundaries := boundariesReader.Mutate()
 	nextLogID := boundaries.GetNextLogId()
-	boundaries.NextLogId = nextLogID + 1
+	advancedLogID, exhausted := domain.CheckedNextSequence(nextLogID, domain.SequenceCounterLedgerLogID)
+	if exhausted != nil {
+		return exhausted
+	}
+
+	boundaries.NextLogId = advancedLogID
 
 	boundariesAccessor.Put(domain.LedgerKey{Name: ledger}, boundaries)
 

--- a/internal/domain/processing/processor_skippable_test.go
+++ b/internal/domain/processing/processor_skippable_test.go
@@ -1,6 +1,7 @@
 package processing
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -183,6 +184,34 @@ func TestAssignSkipLogIDAndDate_AllocatesLogIDAndDateOnParent(t *testing.T) {
 	ledgerLog := payload.GetApply().GetLog()
 	require.Equal(t, uint64(42), ledgerLog.GetId())
 	require.Equal(t, uint64(1700), ledgerLog.GetDate().GetData())
+}
+
+func TestAssignSkipLogIDAndDateRejectsExhaustedLedgerLogWithoutMutation(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	parent := NewMockScope(ctrl)
+	persisted := false
+	boundary := &raftcmdpb.LedgerBoundaries{NextLogId: math.MaxUint64}
+	boundaries := &kindStub[domain.LedgerKey, *raftcmdpb.LedgerBoundaries, raftcmdpb.LedgerBoundariesReader]{}
+	boundaries.expectGet(domain.LedgerKey{Name: "L"}, boundary.AsReader(), nil)
+	boundaries.onPut(func(domain.LedgerKey, *raftcmdpb.LedgerBoundaries) { persisted = true })
+	parent.EXPECT().Boundaries().Return(boundaries).AnyTimes()
+
+	order := &raftcmdpb.Order{Type: &raftcmdpb.Order_LedgerScoped{
+		LedgerScoped: &raftcmdpb.LedgerScopedOrder{Ledger: "L"},
+	}}
+	payload := wrapSkippedPayloadForOrder(order, &commonpb.OrderSkippedLog{})
+
+	err := assignSkipLogIDAndDate(parent, order, payload)
+	var exhausted *domain.ErrSequenceExhausted
+	require.ErrorAs(t, err, &exhausted)
+	require.Equal(t, domain.SequenceCounterLedgerLogID, exhausted.Counter)
+	require.Equal(t, uint64(math.MaxUint64), boundary.GetNextLogId())
+	require.Zero(t, payload.GetApply().GetLog().GetId())
+	require.False(t, persisted)
 }
 
 // TestAssignSkipLogIDAndDate_RefusesNonLedgerScoped surfaces a structural

--- a/internal/domain/processing/processor_test.go
+++ b/internal/domain/processing/processor_test.go
@@ -258,7 +258,7 @@ func TestProcessOrders_WithoutIdempotencyKey(t *testing.T) {
 	mockStore.EXPECT().GetDate().Return(now.AsReader())
 	expectPutLedger(t, mockStore, domain.LedgerKey{Name: "test-ledger"}, nil)
 	expectPutBoundaries(t, mockStore, domain.LedgerKey{Name: "test-ledger"}, nil)
-	mockStore.EXPECT().IncrementNextSequenceID().Return(uint64(100))
+	mockStore.EXPECT().IncrementNextSequenceID().Return(uint64(100), nil)
 
 	response, err := processor.ProcessOrders(proposal.GetOrders(), mockFactory(mockStore), noopSink{})
 	require.NoError(t, err)
@@ -334,8 +334,8 @@ func TestCreateLedgerAndTransactInSameBatch(t *testing.T) {
 	mockStore.EXPECT().GetNextSequenceID().Return(uint64(1))
 	expectPutTransactionState(t, mockStore, domain.TransactionKey{LedgerName: "myled", ID: 1}, nil)
 
-	mockStore.EXPECT().IncrementNextSequenceID().Return(uint64(1))
-	mockStore.EXPECT().IncrementNextSequenceID().Return(uint64(2))
+	mockStore.EXPECT().IncrementNextSequenceID().Return(uint64(1), nil)
+	mockStore.EXPECT().IncrementNextSequenceID().Return(uint64(2), nil)
 
 	orders := []*raftcmdpb.Order{
 		{Type: &raftcmdpb.Order_LedgerScoped{
@@ -415,13 +415,13 @@ func TestProcessOrders_OrdersResultAccumulator(t *testing.T) {
 	mockStore.EXPECT().GetDate().Return(now).AnyTimes()
 	expectPutLedger(t, mockStore, domain.LedgerKey{Name: "ledger-a"}, nil)
 	expectPutBoundaries(t, mockStore, domain.LedgerKey{Name: "ledger-a"}, nil)
-	mockStore.EXPECT().IncrementNextSequenceID().Return(uint64(100))
+	mockStore.EXPECT().IncrementNextSequenceID().Return(uint64(100), nil)
 
 	expectGetLedger(mockStore, domain.LedgerKey{Name: "ledger-b"}, nil, domain.ErrNotFound)
 	mockStore.EXPECT().IncrementNextLedgerID().Return(uint32(2))
 	expectPutLedger(t, mockStore, domain.LedgerKey{Name: "ledger-b"}, nil)
 	expectPutBoundaries(t, mockStore, domain.LedgerKey{Name: "ledger-b"}, nil)
-	mockStore.EXPECT().IncrementNextSequenceID().Return(uint64(110))
+	mockStore.EXPECT().IncrementNextSequenceID().Return(uint64(110), nil)
 
 	orders := []*raftcmdpb.Order{
 		{Type: &raftcmdpb.Order_LedgerScoped{LedgerScoped: &raftcmdpb.LedgerScopedOrder{
@@ -506,7 +506,7 @@ func TestProcessOrders_SkipOnReferenceConflict(t *testing.T) {
 	})
 
 	// Global proposal-level sequence ID for the skip log.
-	mockStore.EXPECT().IncrementNextSequenceID().Return(uint64(100))
+	mockStore.EXPECT().IncrementNextSequenceID().Return(uint64(100), nil)
 
 	order := &raftcmdpb.Order{
 		Type: &raftcmdpb.Order_LedgerScoped{

--- a/internal/domain/processing/processor_transaction.go
+++ b/internal/domain/processing/processor_transaction.go
@@ -94,6 +94,16 @@ func processCreateTransaction(ledger string, order *raftcmdpb.CreateTransactionO
 		producer = &stdPostingProducer{assetCache: ctx.AssetCache}
 	}
 
+	// The persisted boundary stores the next allocatable ID. MaxUint64 itself
+	// is therefore not allocatable: advancing it would wrap the boundary to zero
+	// and make existing transaction keys reusable (EN-1860). Check before the
+	// posting producer stages any volume mutation.
+	nextTransactionID := boundaries.GetNextTransactionId()
+	advancedTransactionID, exhausted := domain.CheckedNextSequence(nextTransactionID, domain.SequenceCounterTransactionID)
+	if exhausted != nil {
+		return nil, exhausted
+	}
+
 	// Produce postings (handles balance checks and buffer updates)
 	result, err := producer.produce(s, ledger, order, script)
 	if err != nil {
@@ -110,8 +120,7 @@ func processCreateTransaction(ledger string, order *raftcmdpb.CreateTransactionO
 		return nil, domain.ErrEmptyTransaction
 	}
 
-	nextTransactionID := boundaries.GetNextTransactionId()
-	boundaries.NextTransactionId = nextTransactionID + 1
+	boundaries.NextTransactionId = advancedTransactionID
 
 	// posting_count, numscript_execution_count, revert_count, reference_count
 	// are no longer maintained on LedgerBoundaries — they are derived from the

--- a/internal/domain/processing/processor_transaction_test.go
+++ b/internal/domain/processing/processor_transaction_test.go
@@ -1,6 +1,7 @@
 package processing
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,6 +12,80 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
+
+func TestProcessCreateTransactionRejectsExhaustedIDBeforeWrites(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	processor, err := NewRequestProcessor(nil, 0)
+	require.NoError(t, err)
+
+	boundaries := &raftcmdpb.LedgerBoundaries{NextTransactionId: math.MaxUint64, NextLogId: 1}
+	ledgerInfo := (&commonpb.LedgerInfo{Name: "test-ledger"}).AsReader()
+	ledgers := setupLedgersStub(mockStore)
+	ledgers.expectGet(domain.LedgerKey{Name: "test-ledger"}, ledgerInfo, nil)
+	boundariesStub := setupBoundariesStub(mockStore)
+	boundariesStub.expectGet(domain.LedgerKey{Name: "test-ledger"}, boundaries.AsReader(), nil)
+
+	order := &raftcmdpb.Order{Type: &raftcmdpb.Order_LedgerScoped{LedgerScoped: &raftcmdpb.LedgerScopedOrder{
+		Ledger: "test-ledger",
+		Payload: &raftcmdpb.LedgerScopedOrder_Apply{Apply: &raftcmdpb.LedgerApplyOrder{
+			Data: &raftcmdpb.LedgerApplyOrder_CreateTransaction{CreateTransaction: &raftcmdpb.CreateTransactionOrder{
+				Postings: []*commonpb.Posting{{
+					Source: "world", Destination: "users:001", Amount: commonpb.NewUint256FromUint64(1), Asset: "USD",
+				}},
+			}},
+		}},
+	}}}
+
+	result, processErr := processor.ProcessOrder(order, mockStore)
+	require.Nil(t, result)
+	var exhausted *domain.ErrSequenceExhausted
+	require.ErrorAs(t, processErr, &exhausted)
+	require.Equal(t, domain.SequenceCounterTransactionID, exhausted.Counter)
+	require.Equal(t, uint64(math.MaxUint64), boundaries.GetNextTransactionId())
+	require.Equal(t, uint64(1), boundaries.GetNextLogId())
+}
+
+func TestProcessApplyRejectsExhaustedLedgerLogBeforeTransactionWrites(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockStore := NewMockScope(ctrl)
+	processor, err := NewRequestProcessor(nil, 0)
+	require.NoError(t, err)
+
+	boundaries := &raftcmdpb.LedgerBoundaries{NextTransactionId: 1, NextLogId: math.MaxUint64}
+	ledgerInfo := (&commonpb.LedgerInfo{Name: "test-ledger"}).AsReader()
+	ledgers := setupLedgersStub(mockStore)
+	ledgers.expectGet(domain.LedgerKey{Name: "test-ledger"}, ledgerInfo, nil)
+	boundariesStub := setupBoundariesStub(mockStore)
+	boundariesStub.expectGet(domain.LedgerKey{Name: "test-ledger"}, boundaries.AsReader(), nil)
+
+	order := &raftcmdpb.Order{Type: &raftcmdpb.Order_LedgerScoped{LedgerScoped: &raftcmdpb.LedgerScopedOrder{
+		Ledger: "test-ledger",
+		Payload: &raftcmdpb.LedgerScopedOrder_Apply{Apply: &raftcmdpb.LedgerApplyOrder{
+			Data: &raftcmdpb.LedgerApplyOrder_CreateTransaction{CreateTransaction: &raftcmdpb.CreateTransactionOrder{
+				Postings: []*commonpb.Posting{{
+					Source: "world", Destination: "users:001", Amount: commonpb.NewUint256FromUint64(1), Asset: "USD",
+				}},
+			}},
+		}},
+	}}}
+
+	result, processErr := processor.ProcessOrder(order, mockStore)
+	require.Nil(t, result)
+	var exhausted *domain.ErrSequenceExhausted
+	require.ErrorAs(t, processErr, &exhausted)
+	require.Equal(t, domain.SequenceCounterLedgerLogID, exhausted.Counter)
+	require.Equal(t, uint64(math.MaxUint64), boundaries.GetNextLogId())
+	require.Equal(t, uint64(1), boundaries.GetNextTransactionId())
+}
 
 func TestValidatePostings(t *testing.T) {
 	t.Parallel()

--- a/internal/domain/processing/skip_safe_scope.go
+++ b/internal/domain/processing/skip_safe_scope.go
@@ -171,8 +171,10 @@ func (s *skipSafeScope) GetSinkConfig(name string) (commonpb.SinkConfigReader, e
 // or pure reads. Pass through.
 // ──────────────────────────────────────────────────────────────────────────
 
-func (s *skipSafeScope) GetNextSequenceID() uint64         { return s.inner.GetNextSequenceID() }
-func (s *skipSafeScope) IncrementNextSequenceID() uint64   { return s.inner.IncrementNextSequenceID() }
+func (s *skipSafeScope) GetNextSequenceID() uint64 { return s.inner.GetNextSequenceID() }
+func (s *skipSafeScope) IncrementNextSequenceID() (uint64, domain.Describable) {
+	return s.inner.IncrementNextSequenceID()
+}
 func (s *skipSafeScope) GetNextAuditSequenceID() uint64    { return s.inner.GetNextAuditSequenceID() }
 func (s *skipSafeScope) GetLastAuditHash() []byte          { return s.inner.GetLastAuditHash() }
 func (s *skipSafeScope) GetNextLedgerID() uint32           { return s.inner.GetNextLedgerID() }

--- a/internal/domain/processing/skip_safe_scope_test.go
+++ b/internal/domain/processing/skip_safe_scope_test.go
@@ -92,7 +92,9 @@ func TestSkipSafeScope_ReadsAndBufferedWritesPassThrough(t *testing.T) {
 
 	// Buffered counter reads/increments delegate through overlay.
 	require.Equal(t, uint64(100), trap.GetNextSequenceID())
-	require.Equal(t, uint64(100), trap.IncrementNextSequenceID())
+	sequence, err := trap.IncrementNextSequenceID()
+	require.NoError(t, err)
+	require.Equal(t, uint64(100), sequence)
 	require.Equal(t, uint64(101), trap.GetNextSequenceID())
 
 	// Non-buffered counter reads (audit seq is monotonic, read-only via
@@ -138,7 +140,8 @@ func TestSkipSafeScope_RollbackKeepsParentUntouched(t *testing.T) {
 	trap.Ledgers().Put(domain.LedgerKey{Name: "L"}, &commonpb.LedgerInfo{Name: "L"})
 	trap.Boundaries().Put(domain.LedgerKey{Name: "L"}, &raftcmdpb.LedgerBoundaries{})
 	trap.PutReverted(domain.TransactionKey{LedgerName: "L", ID: 1}, true)
-	trap.IncrementNextSequenceID()
+	_, err := trap.IncrementNextSequenceID()
+	require.NoError(t, err)
 	trap.IncrementNextLedgerID()
 	trap.IncrementNextQueryCheckpointID()
 

--- a/internal/domain/processing/store.go
+++ b/internal/domain/processing/store.go
@@ -82,7 +82,7 @@ type Scope interface {
 
 	// Counters and timestamps
 	GetNextSequenceID() uint64
-	IncrementNextSequenceID() uint64
+	IncrementNextSequenceID() (uint64, domain.Describable)
 	GetNextAuditSequenceID() uint64
 	// GetLastAuditHash returns the audit chain head as this proposal began.
 	// Read-only: callers that persist it must copy.

--- a/internal/domain/processing/store_generated_test.go
+++ b/internal/domain/processing/store_generated_test.go
@@ -784,11 +784,12 @@ func (c *MockScopeIncrementNextQueryCheckpointIDCall) DoAndReturn(f func() uint6
 }
 
 // IncrementNextSequenceID mocks base method.
-func (m *MockScope) IncrementNextSequenceID() uint64 {
+func (m *MockScope) IncrementNextSequenceID() (uint64, domain.Describable) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IncrementNextSequenceID")
 	ret0, _ := ret[0].(uint64)
-	return ret0
+	ret1, _ := ret[1].(domain.Describable)
+	return ret0, ret1
 }
 
 // IncrementNextSequenceID indicates an expected call of IncrementNextSequenceID.
@@ -804,19 +805,19 @@ type MockScopeIncrementNextSequenceIDCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockScopeIncrementNextSequenceIDCall) Return(arg0 uint64) *MockScopeIncrementNextSequenceIDCall {
-	c.Call = c.Call.Return(arg0)
+func (c *MockScopeIncrementNextSequenceIDCall) Return(arg0 uint64, arg1 domain.Describable) *MockScopeIncrementNextSequenceIDCall {
+	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockScopeIncrementNextSequenceIDCall) Do(f func() uint64) *MockScopeIncrementNextSequenceIDCall {
+func (c *MockScopeIncrementNextSequenceIDCall) Do(f func() (uint64, domain.Describable)) *MockScopeIncrementNextSequenceIDCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockScopeIncrementNextSequenceIDCall) DoAndReturn(f func() uint64) *MockScopeIncrementNextSequenceIDCall {
+func (c *MockScopeIncrementNextSequenceIDCall) DoAndReturn(f func() (uint64, domain.Describable)) *MockScopeIncrementNextSequenceIDCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/internal/domain/reason.go
+++ b/internal/domain/reason.go
@@ -112,7 +112,8 @@ func KindForReason(code commonpb.ErrorReason) ErrorKind {
 		commonpb.ErrorReason_ERROR_REASON_CLUSTER_UNHEALTHY,
 		commonpb.ErrorReason_ERROR_REASON_WRITES_BLOCKED_CLOCK_SKEW:
 		return KindUnavailable
-	case commonpb.ErrorReason_ERROR_REASON_WRITES_BLOCKED_DISK_FULL:
+	case commonpb.ErrorReason_ERROR_REASON_WRITES_BLOCKED_DISK_FULL,
+		commonpb.ErrorReason_ERROR_REASON_SEQUENCE_EXHAUSTED:
 		return KindResourceExhausted
 	case commonpb.ErrorReason_ERROR_REASON_UNSPECIFIED,
 		commonpb.ErrorReason_ERROR_REASON_INDEX_INCONSISTENT,

--- a/internal/domain/sequence.go
+++ b/internal/domain/sequence.go
@@ -1,0 +1,27 @@
+package domain
+
+import "math"
+
+// SequenceCounter identifies the authoritative allocator that exhausted.
+// These values are exposed as ErrorInfo metadata, so keep them stable.
+type SequenceCounter string
+
+const (
+	SequenceCounterTransactionID SequenceCounter = "transactionId"
+	SequenceCounterLedgerLogID   SequenceCounter = "ledgerLogId"
+	SequenceCounterLog           SequenceCounter = "logSequence"
+	SequenceCounterAudit         SequenceCounter = "auditSequence"
+	SequenceCounterMirrorV2LogID SequenceCounter = "mirrorV2LogId"
+)
+
+// CheckedNextSequence returns the next uint64 sequence value without allowing
+// modular wrap. MaxUint64 is deliberately not allocatable by counters that
+// store the next value: accepting it would make the persisted next value zero
+// and permit identifier/key reuse. See EN-1860.
+func CheckedNextSequence(current uint64, counter SequenceCounter) (uint64, *ErrSequenceExhausted) {
+	if current == math.MaxUint64 {
+		return 0, &ErrSequenceExhausted{Counter: counter}
+	}
+
+	return current + 1, nil
+}

--- a/internal/domain/sequence_test.go
+++ b/internal/domain/sequence_test.go
@@ -1,0 +1,38 @@
+package domain
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckedNextSequence(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ordinary value", func(t *testing.T) {
+		t.Parallel()
+
+		next, err := CheckedNextSequence(41, SequenceCounterTransactionID)
+		require.Nil(t, err)
+		require.Equal(t, uint64(42), next)
+	})
+
+	t.Run("max minus one remains valid", func(t *testing.T) {
+		t.Parallel()
+
+		next, err := CheckedNextSequence(math.MaxUint64-1, SequenceCounterLog)
+		require.Nil(t, err)
+		require.Equal(t, uint64(math.MaxUint64), next)
+	})
+
+	t.Run("max fails explicitly instead of wrapping", func(t *testing.T) {
+		t.Parallel()
+
+		next, err := CheckedNextSequence(math.MaxUint64, SequenceCounterAudit)
+		require.Zero(t, next)
+		require.Equal(t, SequenceCounterAudit, err.Counter)
+		require.Equal(t, ErrReasonSequenceExhausted, err.Reason())
+		require.Equal(t, map[string]string{"counter": "auditSequence"}, err.Metadata())
+	})
+}

--- a/internal/infra/backup/rebuild.go
+++ b/internal/infra/backup/rebuild.go
@@ -978,11 +978,18 @@ func (w *attributeReplayWriter) applyAuditOrderEffects(reader dal.PebbleReader, 
 			return err
 		}
 
+		advancedTransactionID := b.GetNextTransactionId()
 		for _, id := range effects.SkippedTransactionIDs {
-			if next := id + 1; next > b.GetNextTransactionId() {
-				b.NextTransactionId = next
+			next, exhausted := domain.CheckedNextSequence(id, domain.SequenceCounterTransactionID)
+			if exhausted != nil {
+				return fmt.Errorf("advancing skipped mirror transaction id for ledger %q: %w", effects.Ledger, exhausted)
+			}
+
+			if next > advancedTransactionID {
+				advancedTransactionID = next
 			}
 		}
+		b.NextTransactionId = advancedTransactionID
 
 		// Mirror high-water mark. Only the FSM writes LastMirrorV2LogId on the
 		// live path, and the ledger-log stream does not carry the source id
@@ -1216,7 +1223,12 @@ func (w *attributeReplayWriter) advanceLogID(ledgerName string, logID uint64) er
 		return err
 	}
 
-	if next := logID + 1; next > b.GetNextLogId() {
+	next, exhausted := domain.CheckedNextSequence(logID, domain.SequenceCounterLedgerLogID)
+	if exhausted != nil {
+		return fmt.Errorf("advancing ledger-log id for ledger %q: %w", ledgerName, exhausted)
+	}
+
+	if next > b.GetNextLogId() {
 		b.NextLogId = next
 	}
 
@@ -1239,7 +1251,12 @@ func (w *attributeReplayWriter) recordTransactionBoundary(canonicalKey []byte) e
 		return err
 	}
 
-	if next := tk.ID + 1; next > b.GetNextTransactionId() {
+	next, exhausted := domain.CheckedNextSequence(tk.ID, domain.SequenceCounterTransactionID)
+	if exhausted != nil {
+		return fmt.Errorf("advancing transaction id for ledger %q: %w", tk.LedgerName, exhausted)
+	}
+
+	if next > b.GetNextTransactionId() {
 		b.NextTransactionId = next
 	}
 

--- a/internal/infra/backup/rebuild_test.go
+++ b/internal/infra/backup/rebuild_test.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"bytes"
 	"context"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -855,6 +856,42 @@ func newAttributeReplayWriter(t *testing.T) (*attributeReplayWriter, *attributes
 	t.Cleanup(func() { _ = writer.batch.Cancel() })
 
 	return writer, attrs, store
+}
+
+func TestAttributeReplayWriterRejectsExhaustedBoundariesWithoutWrap(t *testing.T) {
+	t.Parallel()
+
+	t.Run("ledger log", func(t *testing.T) {
+		t.Parallel()
+
+		writer, _, _ := newAttributeReplayWriter(t)
+		err := writer.advanceLogID("ledger", math.MaxUint64)
+		var exhausted *domain.ErrSequenceExhausted
+		require.ErrorAs(t, err, &exhausted)
+		require.Equal(t, domain.SequenceCounterLedgerLogID, exhausted.Counter)
+		require.Equal(t, uint64(1), writer.boundaries["ledger"].GetNextLogId())
+	})
+
+	t.Run("transaction", func(t *testing.T) {
+		t.Parallel()
+
+		writer, _, _ := newAttributeReplayWriter(t)
+		err := writer.recordTransactionBoundary(domain.TransactionKey{LedgerName: "ledger", ID: math.MaxUint64}.Bytes())
+		var exhausted *domain.ErrSequenceExhausted
+		require.ErrorAs(t, err, &exhausted)
+		require.Equal(t, domain.SequenceCounterTransactionID, exhausted.Counter)
+		require.Equal(t, uint64(1), writer.boundaries["ledger"].GetNextTransactionId())
+	})
+}
+
+func TestAttributeReplayWriterAllowsLastBoundaryValues(t *testing.T) {
+	t.Parallel()
+
+	writer, _, _ := newAttributeReplayWriter(t)
+	require.NoError(t, writer.advanceLogID("ledger", math.MaxUint64-1))
+	require.NoError(t, writer.recordTransactionBoundary(domain.TransactionKey{LedgerName: "ledger", ID: math.MaxUint64 - 1}.Bytes()))
+	require.Equal(t, uint64(math.MaxUint64), writer.boundaries["ledger"].GetNextLogId())
+	require.Equal(t, uint64(math.MaxUint64), writer.boundaries["ledger"].GetNextTransactionId())
 }
 
 func rebuildTestMetaMap(entries ...string) map[string]*commonpb.MetadataValue {

--- a/internal/infra/state/audit_failure_test.go
+++ b/internal/infra/state/audit_failure_test.go
@@ -287,6 +287,12 @@ func auditFailureCases() []auditFailureCase {
 			wantContext: map[string]string{"name": "kafka-main"},
 		},
 		{
+			name:        "SequenceExhausted",
+			err:         &domain.ErrSequenceExhausted{Counter: domain.SequenceCounterTransactionID},
+			wantReason:  domain.ErrReasonSequenceExhausted,
+			wantContext: map[string]string{"counter": "transactionId"},
+		},
+		{
 			name:        "SinkNotFound",
 			err:         &domain.ErrSinkNotFound{Name: "missing-sink"},
 			wantReason:  domain.ErrReasonSinkNotFound,

--- a/internal/infra/state/audit_test.go
+++ b/internal/infra/state/audit_test.go
@@ -4,16 +4,79 @@ import (
 	"context"
 	"errors"
 	"io"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
 	"github.com/formancehq/ledger/v3/internal/query"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
+
+func TestApplyProposalRejectsAuditExhaustionBeforeStateOrDurableMutation(t *testing.T) {
+	t.Parallel()
+
+	machine, dataStore, _ := newTestMachine(t)
+	machine.State.NextAuditSequenceID = math.MaxUint64
+	stateBefore := *machine.State
+	entry := makeEntry(t, 1, makeProposal(1, createLedgerOrder("never-created")))
+
+	_, err := machine.ApplyEntries(context.Background(), dataStore, entry)
+	var exhausted *domain.ErrSequenceExhausted
+	require.ErrorAs(t, err, &exhausted)
+	require.Equal(t, domain.SequenceCounterAudit, exhausted.Counter)
+	require.Equal(t, stateBefore.NextAuditSequenceID, machine.State.NextAuditSequenceID)
+	require.Equal(t, stateBefore.NextSequenceID, machine.State.NextSequenceID)
+	require.Equal(t, stateBefore.NextLedgerID, machine.State.NextLedgerID)
+
+	require.Empty(t, listAuditEntries(t, dataStore, 0))
+	handle, err := dataStore.NewDirectReadHandle()
+	require.NoError(t, err)
+	defer func() { _ = handle.Close() }()
+	lastLog, err := query.ReadLastLog(handle)
+	require.NoError(t, err)
+	require.Nil(t, lastLog)
+}
+
+func TestApplyProposalRejectsLogSequenceExhaustionWithoutPublishingBusinessWrites(t *testing.T) {
+	t.Parallel()
+
+	machine, dataStore, _ := newTestMachine(t)
+	machine.State.NextSequenceID = math.MaxUint64
+	nextLedgerBefore := machine.State.NextLedgerID
+
+	for i := uint64(1); i <= 2; i++ {
+		result, err := machine.ApplyEntries(
+			context.Background(),
+			dataStore,
+			makeEntry(t, i, makeProposal(i, createLedgerOrder("never-created"))),
+		)
+		require.NoError(t, err)
+		require.Len(t, result.Results, 1)
+		var exhausted *domain.ErrSequenceExhausted
+		require.ErrorAs(t, result.Results[0].Error, &exhausted)
+		require.Equal(t, domain.SequenceCounterLog, exhausted.Counter)
+		require.Equal(t, uint64(math.MaxUint64), machine.State.NextSequenceID)
+		require.Equal(t, nextLedgerBefore, machine.State.NextLedgerID)
+	}
+
+	handle, err := dataStore.NewDirectReadHandle()
+	require.NoError(t, err)
+	defer func() { _ = handle.Close() }()
+	lastLog, err := query.ReadLastLog(handle)
+	require.NoError(t, err)
+	require.Nil(t, lastLog, "an exhausted allocator must not publish a zero or reused log key")
+	entries := listAuditEntries(t, dataStore, 0)
+	require.Len(t, entries, 2)
+	for _, entry := range entries {
+		require.Equal(t, commonpb.ErrorReason_ERROR_REASON_SEQUENCE_EXHAUSTED, entry.GetFailure().GetReason())
+		require.Equal(t, "logSequence", entry.GetFailure().GetContext()["counter"])
+	}
+}
 
 // listAuditEntries collects all audit entries from the store into a slice.
 // Pass afterSequence=0 to return all entries.

--- a/internal/infra/state/fsmstate.go
+++ b/internal/infra/state/fsmstate.go
@@ -3,6 +3,7 @@ package state
 import (
 	"fmt"
 
+	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/domain/processing"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/query"
@@ -118,12 +119,17 @@ func (s *FSMState) UpdateClusterConfig(cfg *commonpb.ClusterConfig) {
 // sequence number the entry should carry (the value before the bump). Tying
 // the hash and the sequence to a single method prevents call sites from
 // advancing one without the other.
-func (s *FSMState) AppendAuditEntry(hash []byte) uint64 {
+func (s *FSMState) AppendAuditEntry(hash []byte) (uint64, *domain.ErrSequenceExhausted) {
 	sequence := s.NextAuditSequenceID
-	s.LastAuditHash = hash
-	s.NextAuditSequenceID++
+	next, exhausted := domain.CheckedNextSequence(sequence, domain.SequenceCounterAudit)
+	if exhausted != nil {
+		return 0, exhausted
+	}
 
-	return sequence
+	s.LastAuditHash = hash
+	s.NextAuditSequenceID = next
+
+	return sequence, nil
 }
 
 // LoadFSMStateFromStore reads every FSM-level field that lives in FSMState
@@ -156,7 +162,12 @@ func LoadFSMStateFromStore(reader dal.RecoveryReader, handle *dal.ReadHandle, cl
 	}
 
 	if lastSeq > 0 {
-		s.NextSequenceID = lastSeq + 1
+		next, exhausted := domain.CheckedNextSequence(lastSeq, domain.SequenceCounterLog)
+		if exhausted != nil {
+			return nil, fmt.Errorf("recovering next log sequence: %w", exhausted)
+		}
+
+		s.NextSequenceID = next
 	}
 
 	lastAuditEntry, err := query.ReadLastAuditEntry(handle)
@@ -165,8 +176,13 @@ func LoadFSMStateFromStore(reader dal.RecoveryReader, handle *dal.ReadHandle, cl
 	}
 
 	if lastAuditEntry != nil {
+		next, exhausted := domain.CheckedNextSequence(lastAuditEntry.GetSequence(), domain.SequenceCounterAudit)
+		if exhausted != nil {
+			return nil, fmt.Errorf("recovering next audit sequence: %w", exhausted)
+		}
+
 		s.LastAuditHash = lastAuditEntry.GetHash()
-		s.NextAuditSequenceID = lastAuditEntry.GetSequence() + 1
+		s.NextAuditSequenceID = next
 	}
 
 	nextQCPID, err := query.ReadNextQueryCheckpointID(reader)

--- a/internal/infra/state/fsmstate_test.go
+++ b/internal/infra/state/fsmstate_test.go
@@ -1,12 +1,29 @@
 package state
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
+
+func TestAppendAuditEntryRejectsExhaustedSequenceWithoutMutation(t *testing.T) {
+	t.Parallel()
+
+	s := NewFSMState("test-cluster")
+	s.NextAuditSequenceID = math.MaxUint64
+	s.LastAuditHash = []byte("previous")
+
+	for range 2 {
+		sequence, err := s.AppendAuditEntry([]byte("hash-max"))
+		require.Zero(t, sequence)
+		require.Equal(t, "auditSequence", string(err.Counter))
+		require.Equal(t, uint64(math.MaxUint64), s.NextAuditSequenceID)
+		require.Equal(t, []byte("previous"), s.LastAuditHash)
+	}
+}
 
 // TestUpdateClusterConfig verifies the invariant the method exists to
 // protect: HashGenerator is rebuilt iff the algorithm changes; LastClusterConfig
@@ -71,7 +88,8 @@ func TestAppendAuditEntry(t *testing.T) {
 		require.Equal(t, uint64(1), s.NextAuditSequenceID)
 		require.Empty(t, s.LastAuditHash)
 
-		seq := s.AppendAuditEntry([]byte("hash-1"))
+		seq, err := s.AppendAuditEntry([]byte("hash-1"))
+		require.Nil(t, err)
 
 		require.Equal(t, uint64(1), seq, "returned sequence must be the pre-bump value")
 		require.Equal(t, []byte("hash-1"), s.LastAuditHash)
@@ -83,9 +101,12 @@ func TestAppendAuditEntry(t *testing.T) {
 
 		s := NewFSMState("test-cluster")
 
-		seq1 := s.AppendAuditEntry([]byte("hash-1"))
-		seq2 := s.AppendAuditEntry([]byte("hash-2"))
-		seq3 := s.AppendAuditEntry([]byte("hash-3"))
+		seq1, err := s.AppendAuditEntry([]byte("hash-1"))
+		require.Nil(t, err)
+		seq2, err := s.AppendAuditEntry([]byte("hash-2"))
+		require.Nil(t, err)
+		seq3, err := s.AppendAuditEntry([]byte("hash-3"))
+		require.Nil(t, err)
 
 		require.Equal(t, []uint64{1, 2, 3}, []uint64{seq1, seq2, seq3})
 		require.Equal(t, []byte("hash-3"), s.LastAuditHash, "LastAuditHash carries the latest hash")
@@ -98,10 +119,24 @@ func TestAppendAuditEntry(t *testing.T) {
 		s := NewFSMState("test-cluster")
 		s.LastAuditHash = []byte("seed")
 
-		seq := s.AppendAuditEntry(nil)
+		seq, err := s.AppendAuditEntry(nil)
+		require.Nil(t, err)
 
 		require.Equal(t, uint64(1), seq)
 		require.Nil(t, s.LastAuditHash, "nil hash overwrites a previous non-nil hash")
 		require.Equal(t, uint64(2), s.NextAuditSequenceID)
+	})
+
+	t.Run("max minus one is the last allocatable sequence", func(t *testing.T) {
+		t.Parallel()
+
+		s := NewFSMState("test-cluster")
+		s.NextAuditSequenceID = math.MaxUint64 - 1
+
+		seq, err := s.AppendAuditEntry([]byte("last"))
+		require.Nil(t, err)
+		require.Equal(t, uint64(math.MaxUint64-1), seq)
+		require.Equal(t, uint64(math.MaxUint64), s.NextAuditSequenceID)
+		require.Equal(t, []byte("last"), s.LastAuditHash)
 	})
 }

--- a/internal/infra/state/machine.go
+++ b/internal/infra/state/machine.go
@@ -1093,6 +1093,20 @@ func (fsm *Machine) applyProposal(ctx context.Context, raftIndex uint64, batch *
 		return nil, fmt.Errorf("checkpoint trigger order not last in proposal id=%d at raft index %d", proposal.GetId(), raftIndex)
 	}
 
+	// Once the audit sequence is exhausted there is no key under which a fresh
+	// success or failure can be recorded. Stop every proposal carrying orders
+	// before preload, HLC, technical updates, or order processing can mutate
+	// state. This terminal cluster state also rejects an idempotency replay: its
+	// replay classification happens after preload and technical updates, which
+	// are deliberately kept beyond this no-mutation guard. MaxUint64 itself is
+	// not allocatable because persisting it would make the next sequence wrap to
+	// zero (EN-1860).
+	if len(proposal.GetOrders()) > 0 {
+		if _, exhausted := domain.CheckedNextSequence(fsm.State.NextAuditSequenceID, domain.SequenceCounterAudit); exhausted != nil {
+			return nil, exhausted
+		}
+	}
+
 	// Build the result up-front so every business-error branch below can
 	// stash its rejection on the same ApplyResult — including the per-order
 	// rejections (e.g. ErrBackupInProgress) that applyTechnicalUpdates
@@ -1386,7 +1400,11 @@ func (fsm *Machine) applyProposal(ctx context.Context, raftIndex uint64, batch *
 		// AppendAuditEntry validates that the peeked sequence matches
 		// the actual next one (no concurrent mutation) and advances
 		// LastAuditHash for the next entry.
-		committedSeq := fsm.State.AppendAuditEntry(auditHash)
+		committedSeq, exhausted := fsm.State.AppendAuditEntry(auditHash)
+		if exhausted != nil {
+			return exhausted
+		}
+
 		if committedSeq != entry.GetSequence() {
 			return fmt.Errorf("audit sequence race for %s: peeked %d, got %d", label, entry.GetSequence(), committedSeq)
 		}

--- a/internal/infra/state/recovery_atomic_test.go
+++ b/internal/infra/state/recovery_atomic_test.go
@@ -3,10 +3,14 @@ package state
 import (
 	"errors"
 	"io"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
 
@@ -67,4 +71,50 @@ func TestRecoverStateAtomicOnLoadFailure(t *testing.T) {
 	require.Equal(t, snapshot.NextLedgerID, machine.State.NextLedgerID)
 	require.Equal(t, snapshot.NextQueryCheckpointID, machine.State.NextQueryCheckpointID)
 	require.Equal(t, snapshot.CacheEpoch, machine.State.CacheEpoch)
+}
+
+func TestRecoverStateRejectsPersistedExhaustedSequencesAtomically(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		counter domain.SequenceCounter
+		seed    func(*testing.T, *dal.Store)
+	}{
+		{
+			name:    "global log",
+			counter: domain.SequenceCounterLog,
+			seed: func(t *testing.T, store *dal.Store) {
+				appendLogs(t, store, 1, &commonpb.Log{Sequence: math.MaxUint64})
+			},
+		},
+		{
+			name:    "audit",
+			counter: domain.SequenceCounterAudit,
+			seed: func(t *testing.T, store *dal.Store) {
+				batch := store.OpenWriteSession()
+				require.NoError(t, appendAuditEntries(batch, &auditpb.AuditEntry{Sequence: math.MaxUint64}))
+				require.NoError(t, batch.Commit())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			machine, store, _ := newTestMachine(t)
+			stateBefore := machine.State
+			snapshot := *stateBefore
+			tt.seed(t, store)
+
+			err := NewRecovery(machine, store).RecoverState()
+			var exhausted *domain.ErrSequenceExhausted
+			require.ErrorAs(t, err, &exhausted)
+			require.Equal(t, tt.counter, exhausted.Counter)
+			require.Same(t, stateBefore, machine.State)
+			require.Equal(t, snapshot.NextSequenceID, machine.State.NextSequenceID)
+			require.Equal(t, snapshot.NextAuditSequenceID, machine.State.NextAuditSequenceID)
+		})
+	}
 }

--- a/internal/infra/state/write_set.go
+++ b/internal/infra/state/write_set.go
@@ -1373,11 +1373,16 @@ func (b *WriteSet) GetLastAuditHash() []byte {
 	return b.LastAuditHash
 }
 
-func (b *WriteSet) IncrementNextSequenceID() uint64 {
+func (b *WriteSet) IncrementNextSequenceID() (uint64, domain.Describable) {
 	id := b.NextSequenceID
-	b.NextSequenceID++
+	next, exhausted := domain.CheckedNextSequence(id, domain.SequenceCounterLog)
+	if exhausted != nil {
+		return 0, exhausted
+	}
 
-	return id
+	b.NextSequenceID = next
+
+	return id, nil
 }
 
 func (b *WriteSet) GetNextLedgerID() uint32 {

--- a/internal/infra/state/write_set_test.go
+++ b/internal/infra/state/write_set_test.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,6 +16,20 @@ import (
 	"github.com/formancehq/ledger/v3/internal/query"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
+
+func TestWriteSetRejectsExhaustedLogSequenceWithoutMutation(t *testing.T) {
+	t.Parallel()
+
+	buf, _, _ := newTestBuffer(t)
+	buf.NextSequenceID = math.MaxUint64
+
+	for range 2 {
+		sequence, err := buf.IncrementNextSequenceID()
+		require.Zero(t, sequence)
+		require.Equal(t, "logSequence", err.Metadata()["counter"])
+		require.Equal(t, uint64(math.MaxUint64), buf.NextSequenceID)
+	}
+}
 
 // newTestBuffer creates a Machine and returns a WriteSet for testing accessor methods.
 // The returned *dal.Store is exposed so tests can open write sessions directly,
@@ -320,9 +335,22 @@ func TestWriteSetSequenceIDOperations(t *testing.T) {
 
 	// NextSequenceID
 	startSeqID := buf.GetNextSequenceID()
-	seqID := buf.IncrementNextSequenceID()
+	seqID, err := buf.IncrementNextSequenceID()
+	require.NoError(t, err)
 	require.Equal(t, startSeqID, seqID)
 	require.Equal(t, startSeqID+1, buf.GetNextSequenceID())
+}
+
+func TestWriteSetAllowsLastLogSequence(t *testing.T) {
+	t.Parallel()
+
+	buf, _, _ := newTestBuffer(t)
+	buf.NextSequenceID = math.MaxUint64 - 1
+
+	sequence, err := buf.IncrementNextSequenceID()
+	require.NoError(t, err)
+	require.Equal(t, uint64(math.MaxUint64-1), sequence)
+	require.Equal(t, uint64(math.MaxUint64), buf.NextSequenceID)
 }
 
 func TestWriteSetDateAndHash(t *testing.T) {

--- a/internal/proto/commonpb/common.pb.go
+++ b/internal/proto/commonpb/common.pb.go
@@ -625,6 +625,12 @@ const (
 	// ERROR_REASON_CHECKPOINT_NOT_FOUND: a DeleteQueryCheckpoint targeted an id
 	// that is not live (never created, or already deleted). See EN-1501.
 	ErrorReason_ERROR_REASON_CHECKPOINT_NOT_FOUND ErrorReason = 67
+	// ERROR_REASON_SEQUENCE_EXHAUSTED: an authoritative transaction, ledger-log,
+	// global-log, or audit sequence reached its final allocatable value. The
+	// operation is rejected before uint64 wrap can publish a zero/reused key.
+	// Permanent (Kind=ResourceExhausted): retrying cannot create another ID.
+	// See EN-1860.
+	ErrorReason_ERROR_REASON_SEQUENCE_EXHAUSTED ErrorReason = 68
 )
 
 // Enum value maps for ErrorReason.
@@ -698,6 +704,7 @@ var (
 		65: "ERROR_REASON_CLUSTER_POLICY_INVALID",
 		66: "ERROR_REASON_CHECKPOINT_LIMIT_REACHED",
 		67: "ERROR_REASON_CHECKPOINT_NOT_FOUND",
+		68: "ERROR_REASON_SEQUENCE_EXHAUSTED",
 	}
 	ErrorReason_value = map[string]int32{
 		"ERROR_REASON_UNSPECIFIED":                      0,
@@ -768,6 +775,7 @@ var (
 		"ERROR_REASON_CLUSTER_POLICY_INVALID":           65,
 		"ERROR_REASON_CHECKPOINT_LIMIT_REACHED":         66,
 		"ERROR_REASON_CHECKPOINT_NOT_FOUND":             67,
+		"ERROR_REASON_SEQUENCE_EXHAUSTED":               68,
 	}
 )
 
@@ -13232,7 +13240,7 @@ const file_common_proto_rawDesc = "" +
 	"\x12LEDGER_MODE_MIRROR\x10\x01*Q\n" +
 	"\x0fMirrorSyncState\x12\x1d\n" +
 	"\x19MIRROR_SYNC_STATE_SYNCING\x10\x00\x12\x1f\n" +
-	"\x1bMIRROR_SYNC_STATE_FOLLOWING\x10\x01*\xbc\x15\n" +
+	"\x1bMIRROR_SYNC_STATE_FOLLOWING\x10\x01*\xe1\x15\n" +
 	"\vErrorReason\x12\x1c\n" +
 	"\x18ERROR_REASON_UNSPECIFIED\x10\x00\x12&\n" +
 	"\"ERROR_REASON_LEDGER_ALREADY_EXISTS\x10\x01\x12!\n" +
@@ -13302,7 +13310,8 @@ const file_common_proto_rawDesc = "" +
 	"-ERROR_REASON_CLUSTER_POLICY_REVISION_CONFLICT\x10@\x12'\n" +
 	"#ERROR_REASON_CLUSTER_POLICY_INVALID\x10A\x12)\n" +
 	"%ERROR_REASON_CHECKPOINT_LIMIT_REACHED\x10B\x12%\n" +
-	"!ERROR_REASON_CHECKPOINT_NOT_FOUND\x10C*Q\n" +
+	"!ERROR_REASON_CHECKPOINT_NOT_FOUND\x10C\x12#\n" +
+	"\x1fERROR_REASON_SEQUENCE_EXHAUSTED\x10D*Q\n" +
 	"\x14ChartEnforcementMode\x12\x1c\n" +
 	"\x18CHART_ENFORCEMENT_STRICT\x10\x00\x12\x1b\n" +
 	"\x17CHART_ENFORCEMENT_AUDIT\x10\x01*i\n" +

--- a/internal/storage/dal/store.go
+++ b/internal/storage/dal/store.go
@@ -1595,8 +1595,11 @@ func ReadLastEntry[T proto.Message](reader PebbleReader, zone, sub byte) (T, err
 	lowerBound := kb.Snapshot()
 	kb.Reset()
 
-	kb.PutZonePrefix(zone, sub).PutBytes(MaxUint64Bytes)
-	upperBound := kb.Build()
+	// Bound by the next sub-prefix, not by a synthetic MaxUint64 key. Pebble's
+	// upper bound is exclusive, so [zone][sub][MaxUint64] must remain visible:
+	// recovery uses it to detect and reject an exhausted persisted sequence
+	// instead of falling back to a lower/reusable next value (EN-1860).
+	upperBound := []byte{zone, sub + 1}
 
 	iter, err := NewBoundedIter(reader, lowerBound, upperBound)
 	if err != nil {

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -1235,6 +1235,12 @@ enum ErrorReason {
   // ERROR_REASON_CHECKPOINT_NOT_FOUND: a DeleteQueryCheckpoint targeted an id
   // that is not live (never created, or already deleted). See EN-1501.
   ERROR_REASON_CHECKPOINT_NOT_FOUND = 67;
+  // ERROR_REASON_SEQUENCE_EXHAUSTED: an authoritative transaction, ledger-log,
+  // global-log, or audit sequence reached its final allocatable value. The
+  // operation is rejected before uint64 wrap can publish a zero/reused key.
+  // Permanent (Kind=ResourceExhausted): retrying cannot create another ID.
+  // See EN-1860.
+  ERROR_REASON_SEQUENCE_EXHAUSTED = 68;
 }
 
 // IdempotencyFailure captures a definitive business rejection so a retried key

--- a/openapi.yml
+++ b/openapi.yml
@@ -1785,7 +1785,8 @@ paths:
              precondition, permission — 4xx): rolled up per
              `continueOnFailure`. `true` → `200`; `false` (default) →
              the highest 4xx among failing elements (typically `400`).
-           - Rate-limit failures (`KindResourceExhausted`, `429`):
+           - Resource exhaustion (`KindResourceExhausted`, `429`), including
+             rate limits and permanent authoritative-sequence exhaustion:
              surface unconditionally as `429`.
            - Retryable infrastructure failures (leader loss,
              cache-horizon exceeded, `KindUnavailable`): surface as
@@ -1839,8 +1840,8 @@ paths:
                 $ref: '#/components/schemas/BulkResponse'
         '429':
           description: |
-            A per-element error mapped to `KindResourceExhausted` (quota
-            or rate-limit hit during processing). Surfaces unconditionally,
+            A per-element error mapped to `KindResourceExhausted` (quota,
+            rate limit, or authoritative-sequence exhaustion during processing). Surfaces unconditionally,
             regardless of `continueOnFailure`. Body carries the per-element
             details in `data`.
           content:


### PR DESCRIPTION
## What changed

Prevent authoritative transaction, ledger-log, global-log, audit, and mirror sequence counters from wrapping and reusing identifiers. Exhausted counters now fail before business-state mutation with a typed error mapped to gRPC `ResourceExhausted` and HTTP 429; recovery, checker, and incremental rebuild paths enforce the same boundary.

## Why

Fix [EN-1860](https://formance-team.atlassian.net/browse/EN-1860): incrementing an authoritative counter at `math.MaxUint64` previously wrapped to zero, allowing identifier reuse and divergent or corrupted ledger state.

## Product / operational motivation

Need: authoritative identifiers must remain unique and monotonic for the lifetime of ledger state.

Current limitation: unsigned counter overflow silently wrapped to zero.

Requirement / constraint: exhaustion must be detected deterministically before mutation across normal apply, mirror, recovery, checker, and rebuild paths.

Evidence: regression coverage in `internal/domain/sequence_test.go` and the affected processing/state/checker/rebuild test suites; the invariant and operational behavior are documented in `docs/technical/architecture/subsystems/fsm/deterministic-fsm.md` and `docs/technical/architecture/subsystems/checker/README.md`.

## Technical decision

Decision: centralize checked sequence advancement, propagate a typed sequence-exhaustion reason through domain/protobuf/API boundaries, and validate reconstructed counters on recovery and verification paths.

Why now / why proportionate: wraparound violates authoritative identity and deterministic-state invariants; a shared checked primitive keeps the boundary consistent without compatibility shims. Ledger v3 is unreleased, so the protobuf enum is added as the next sequential value (`68`).

Alternatives considered: allowing wraparound or adding fallback identifiers would preserve ambiguity and risk reuse; saturating silently would hide the terminal state. Both were rejected in favor of an explicit, deterministic failure.

## Risk

**MEDIUM** — the change intentionally touches authoritative FSM, recovery/checker, mirror, protobuf, and API error paths, with additive regression coverage across each path.

## Validation

- [x] `AI_REVIEW_BASE_SHA=72d51387ec69059137ee901525bd9752264e5e30 bash scripts/agent-check-pr` — PASS at candidate `767eca020ab51a68b698c68d140b07d2bda4cda8` (includes root race suite and repository checks)
- [x] Targeted evidence: `BEFORE_FIX=BUG_REPRODUCED`, `AFTER_FIX=PASS`, `TEST_SENSITIVITY=PASS`
- [x] Exact final review: APPROVE, 0 blocking and 0 non-blocking findings, on the exact candidate SHA
- [x] Full suite / broader validation: E2E business PASS, E2E cluster PASS, Schemathesis 62/62 PASS through the single canonical PR validation

An earlier cross-store drain timeout was reproduced on both target and candidate in same-host A/B runs and classified as baseline/environmental; the final canonical validation passed after host disk space was restored.

## Architecture / behavior impact

FSM/Raft apply now fails deterministically before mutation at sequence exhaustion. Recovery, checker, backup rebuild, mirror, and API translation paths share that terminal condition. No storage migration or compatibility shim is added because Ledger v3 remains unreleased.

## Review focus

Please focus on fail-before-mutation ordering, parity among normal apply/mirror/recovery/checker/rebuild paths, and the `ResourceExhausted` / HTTP 429 translation.

## Known concerns

None. Broad CI and human review remain the publication gates.


[EN-1860]: https://formance-team.atlassian.net/browse/EN-1860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ