### PR TITLE
chore(deps): upgrade sonic to v1.15.3 for go1.27

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.45.8
 	github.com/aws/smithy-go v1.27.10
 	github.com/benbjohnson/immutable v0.4.3
-	github.com/bytedance/sonic v1.15.0
+	github.com/bytedance/sonic v1.15.3
 	github.com/cockroachdb/pebble/v2 v2.1.4
 	github.com/databricks/databricks-sql-go v1.10.0
 	github.com/dustin/go-humanize v1.0.1
@@ -133,7 +133,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic/loader v0.5.0 // indirect
+	github.com/bytedance/sonic/loader v0.5.2 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -154,10 +154,10 @@ github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJ
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
-github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
-github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
-github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
-github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/bytedance/sonic v1.15.3 h1:P3akjLPBtV/i6bHC6LbcLjY3KuoOvfiqF8wFHeP5IhY=
+github.com/bytedance/sonic v1.15.3/go.mod h1:8e51yTPdY8M6t+vvGL1c2Y1xL9i+frEeIAQAEl75NUc=
+github.com/bytedance/sonic/loader v0.5.2 h1:0QtP1gevc1OZ6/H8Lb9BRZiCXd1Ftjd3OKuj1T1lBIo=
+github.com/bytedance/sonic/loader v0.5.2/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=

--- a/tests/antithesis/workload/go.mod
+++ b/tests/antithesis/workload/go.mod
@@ -32,8 +32,8 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/bytedance/gopkg v0.1.3 // indirect
-	github.com/bytedance/sonic v1.15.0 // indirect
-	github.com/bytedance/sonic/loader v0.5.0 // indirect
+	github.com/bytedance/sonic v1.15.3 // indirect
+	github.com/bytedance/sonic/loader v0.5.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/cockroachdb/crlib v0.0.0-20241112164430-1264a2edc35b // indirect

--- a/tests/antithesis/workload/go.sum
+++ b/tests/antithesis/workload/go.sum
@@ -24,10 +24,10 @@ github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJ
 github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/bytedance/gopkg v0.1.3 h1:TPBSwH8RsouGCBcMBktLt1AymVo2TVsBVCY4b6TnZ/M=
 github.com/bytedance/gopkg v0.1.3/go.mod h1:576VvJ+eJgyCzdjS+c4+77QF3p7ubbtiKARP3TxducM=
-github.com/bytedance/sonic v1.15.0 h1:/PXeWFaR5ElNcVE84U0dOHjiMHQOwNIx3K4ymzh/uSE=
-github.com/bytedance/sonic v1.15.0/go.mod h1:tFkWrPz0/CUCLEF4ri4UkHekCIcdnkqXw9VduqpJh0k=
-github.com/bytedance/sonic/loader v0.5.0 h1:gXH3KVnatgY7loH5/TkeVyXPfESoqSBSBEiDd5VjlgE=
-github.com/bytedance/sonic/loader v0.5.0/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
+github.com/bytedance/sonic v1.15.3 h1:P3akjLPBtV/i6bHC6LbcLjY3KuoOvfiqF8wFHeP5IhY=
+github.com/bytedance/sonic v1.15.3/go.mod h1:8e51yTPdY8M6t+vvGL1c2Y1xL9i+frEeIAQAEl75NUc=
+github.com/bytedance/sonic/loader v0.5.2 h1:0QtP1gevc1OZ6/H8Lb9BRZiCXd1Ftjd3OKuj1T1lBIo=
+github.com/bytedance/sonic/loader v0.5.2/go.mod h1:AR4NYCk5DdzZizZ5djGqQ92eEhCCcdf5x77udYiSJRo=
 github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
 github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
## What changed

Upgrades `github.com/bytedance/sonic` v1.15.0 → v1.15.3 (and the transitive `sonic/loader` v0.5.0 → v0.5.2), in the root module and in `tests/antithesis/workload`, which pins the root through a local `replace` directive. No source changes — go.mod/go.sum only.

## Why

sonic v1.15.0 gates its native/JIT codec behind `!go1.27` build tags. Since the toolchain moved to go1.27.1, every sonic package selected its `*_compat.go` variant, which prints at init:

```
WARNING: sonic/ast only supports (go1.17~1.26 and amd64 CPU) or (go1.20~1.26 and arm64 CPU),
but your environment is not suitable and will fallback to encoding/json
```

and then delegates to `encoding/json`. So the two call sites (`internal/adapter/json/json.go`, `internal/adapter/v2/translator.go`) were paying for sonic without getting it. v1.15.3 widens the ceiling to `!go1.28`, restoring the native path on both amd64 and arm64.

## Product / operational motivation

N/A — mechanical dependency bump following the go1.27 toolchain upgrade.

## Technical decision

N/A

## Risk

**LOW**

Dependency-only change, patch-level within the same minor. The behavioral direction is a restoration of the intended codec, not a new one.

## Validation

- [x] `bash scripts/agent-check`
- [x] Targeted tests: `go test ./internal/adapter/json/... ./internal/adapter/v2/...`; `go build ./... && go vet ./...` in `tests/antithesis/workload`
- [x] Full CI green on 409a98d9b (Dirty, Tests, Tests-Model, Tests-Antithesis-Workload, Tests-E2E-Business, Tests-E2E-Cluster, Tests-Operator, Tests-Scenarios, Tests-Schemathesis, Build, invariants)

Additionally verified that under go1.27.1 the native files are now selected (`ast/api.go`, `decoder/decoder_native.go`, `encoder/encoder_native.go`, `internal/encoder/alg/spec.go`) and that a program importing `sonic` + `sonic/ast` runs with no warning on stderr.

## Architecture / behavior impact

The JSON codec used at those two call sites returns from `encoding/json` to sonic's native implementation. That is the pre-go1.27 behavior, so no persisted format, API, or FSM surface changes — but it does mean sonic's number formatting and error strings apply again rather than the stdlib's.

## Review focus

Whether restoring the native sonic path is desired now, versus deliberately staying on the `encoding/json` fallback. The fallback was silent and unintended, but it has been what CI and local runs actually exercised since the toolchain bump.

## Known concerns

sonic's build tags cap at a specific Go minor, so this dependency needs re-checking on each future toolchain bump rather than only when a build breaks — noted as a `Directive:` trailer on the first commit.

The second commit exists because the root bump alone left `tests/antithesis/workload` out of sync (it replaces the root locally), failing Dirty, Tests-Model and Tests-Antithesis-Workload. Recorded as a `Directive:` trailer there: root dependency bumps must be tidied across all three modules `just lint` covers, not the root alone.
