### PR TITLE
fix(events): retry failed sinks after startup

### DIFF
--- a/docs/technical/architecture/subsystems/events-mirror/events.md
+++ b/docs/technical/architecture/subsystems/events-mirror/events.md
@@ -236,6 +236,15 @@ sequenceDiagram
 
 The Manager reconciles emitter lifecycles on leadership changes and config updates. Each emitter independently tails the log, publishes to its sink, and advances its cursor via Raft. Failed publishes are recorded as sink errors in Pebble (visible via `GetEventsSinks`), and the emitter retries with exponential backoff.
 
+If a sink cannot be constructed or its emitter cannot read its persisted cursor
+at startup, the leader keeps the Raft-replicated configuration unchanged and
+retries startup after a bounded delay. Constructor failures therefore recover
+without another configuration write or leadership transition when an external
+dependency becomes available. Retry wake-ups are deduplicated per sink and are
+canceled with the Manager lifecycle; followers never start a sink. Constructors
+must release resources acquired by a failed attempt because the Manager may
+retry them repeatedly.
+
 Leadership callbacks do not own reconciliation goroutines. Bootstrap records
 each transition inline, preserving Raft observer order, while the Manager's
 existing loop owns the slow Pebble scan and worker mutations. A monotonically

--- a/internal/application/events/manager.go
+++ b/internal/application/events/manager.go
@@ -277,6 +277,7 @@ func (m *Manager) startSink(sc *commonpb.SinkConfig) *managedSink {
 	sink, err := m.createSink(sc)
 	if err != nil {
 		m.logger.Errorf("Failed to create sink %q: %v", sc.GetName(), err)
+		m.scheduleStartupRetry(sc.GetName())
 
 		return nil
 	}

--- a/internal/application/events/manager_startup_retry_test.go
+++ b/internal/application/events/manager_startup_retry_test.go
@@ -1,0 +1,133 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/pkg/signal"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/eventspb"
+)
+
+type startupRetryTestSink struct{}
+
+func (startupRetryTestSink) Publish(context.Context, []*eventspb.Event) error { return nil }
+func (startupRetryTestSink) Close() error                                     { return nil }
+
+func pendingStartupRetry(m *Manager, name string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	_, ok := m.retries[name]
+
+	return ok
+}
+
+func TestManager_RetriesTransientSinkConstructorFailure(t *testing.T) {
+	// This test temporarily replaces a package-global factory. Keep it
+	// sequential so parallel package tests remain paused until cleanup restores
+	// the registry.
+	previous, existed := sinkFactories["nats"]
+	t.Cleanup(func() {
+		if existed {
+			sinkFactories["nats"] = previous
+
+			return
+		}
+
+		delete(sinkFactories, "nats")
+	})
+
+	var attempts atomic.Int64
+	sinkFactories["nats"] = func(*commonpb.SinkConfig, Format) (Sink, error) {
+		if attempts.Add(1) == 1 {
+			return nil, errors.New("dependency temporarily unavailable")
+		}
+
+		return startupRetryTestSink{}, nil
+	}
+
+	builder, store := newTestBuilder(t)
+	attrs := attributes.New()
+	config := &commonpb.SinkConfig{
+		Name: "transient-constructor-failure",
+		Type: &commonpb.SinkConfig_Nats{
+			Nats: &commonpb.NatsSinkConfig{
+				Url:   "nats://dependency.invalid:4222",
+				Topic: "ledger.events",
+			},
+		},
+	}
+	saveManagedSinkConfig(t, attrs, store, config)
+
+	m := NewManager(store, attrs, nil, builder, logging.Testing(), signal.NewNotifications())
+	m.Start()
+	t.Cleanup(m.Stop)
+	m.OnLeadershipChange(true)
+
+	require.Eventually(t, func() bool {
+		return attempts.Load() == 1 && pendingStartupRetry(m, config.GetName())
+	}, time.Second, 10*time.Millisecond, "the initial leadership reconcile must try the sink constructor and schedule a retry")
+
+	require.Eventually(t, func() bool {
+		return attempts.Load() == 2 &&
+			managedSinkByName(m, config.GetName()) != nil &&
+			!pendingStartupRetry(m, config.GetName())
+	}, 3*time.Second, 10*time.Millisecond,
+		"the unchanged sink config must recover after its constructor dependency becomes available")
+}
+
+func TestManager_StopCancelsSinkConstructorRetry(t *testing.T) {
+	previous, existed := sinkFactories["nats"]
+	t.Cleanup(func() {
+		if existed {
+			sinkFactories["nats"] = previous
+
+			return
+		}
+
+		delete(sinkFactories, "nats")
+	})
+
+	var attempts atomic.Int64
+	sinkFactories["nats"] = func(*commonpb.SinkConfig, Format) (Sink, error) {
+		attempts.Add(1)
+
+		return nil, errors.New("dependency unavailable")
+	}
+
+	builder, store := newTestBuilder(t)
+	attrs := attributes.New()
+	config := &commonpb.SinkConfig{
+		Name: "constructor-failure-during-stop",
+		Type: &commonpb.SinkConfig_Nats{
+			Nats: &commonpb.NatsSinkConfig{
+				Url:   "nats://dependency.invalid:4222",
+				Topic: "ledger.events",
+			},
+		},
+	}
+	saveManagedSinkConfig(t, attrs, store, config)
+
+	m := NewManager(store, attrs, nil, builder, logging.Testing(), signal.NewNotifications())
+	m.Start()
+	m.OnLeadershipChange(true)
+
+	require.Eventually(t, func() bool {
+		return attempts.Load() == 1 && pendingStartupRetry(m, config.GetName())
+	}, time.Second, 10*time.Millisecond, "the constructor failure must schedule a retry before shutdown")
+
+	m.Stop()
+	require.Never(t, func() bool {
+		return attempts.Load() > 1
+	}, 2*sinkStartupRetryDelay, 10*time.Millisecond,
+		"manager shutdown must cancel the pending constructor retry")
+}

--- a/internal/application/events/sink_clickhouse.go
+++ b/internal/application/events/sink_clickhouse.go
@@ -125,11 +125,25 @@ func NewClickHouseSink(ctx context.Context, cfg ClickHouseSinkConfig) (*ClickHou
 		return nil, fmt.Errorf("opening ClickHouse connection: %w", err)
 	}
 
+	return initializeClickHouseSink(ctx, conn, cfg.Table)
+}
+
+// initializeClickHouseSink completes the fallible initialization steps after
+// clickhouse.Open. It owns conn until success so constructor retries cannot
+// leak connections when Ping or table creation fails.
+func initializeClickHouseSink(ctx context.Context, conn driver.Conn, configuredTable string) (*ClickHouseSink, error) {
+	success := false
+	defer func() {
+		if !success {
+			_ = conn.Close()
+		}
+	}()
+
 	if err := conn.Ping(ctx); err != nil {
 		return nil, fmt.Errorf("pinging ClickHouse: %w", err)
 	}
 
-	table := cfg.Table
+	table := configuredTable
 	if table == "" {
 		table = defaultClickHouseTable
 	}
@@ -137,6 +151,8 @@ func NewClickHouseSink(ctx context.Context, cfg ClickHouseSinkConfig) (*ClickHou
 	if err := conn.Exec(ctx, ClickHouseCreateTableDDL(table)); err != nil {
 		return nil, fmt.Errorf("creating ClickHouse table %s: %w", table, err)
 	}
+
+	success = true
 
 	return &ClickHouseSink{
 		conn:  conn,

--- a/internal/application/events/sink_clickhouse_constructor_test.go
+++ b/internal/application/events/sink_clickhouse_constructor_test.go
@@ -1,0 +1,89 @@
+//go:build clickhouse
+
+package events
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/stretchr/testify/require"
+)
+
+type clickHouseConstructorConn struct {
+	driver.Conn
+
+	pingErr    error
+	execErr    error
+	execCalls  int
+	closeCalls int
+}
+
+func (c *clickHouseConstructorConn) Ping(context.Context) error {
+	return c.pingErr
+}
+
+func (c *clickHouseConstructorConn) Exec(context.Context, string, ...any) error {
+	c.execCalls++
+
+	return c.execErr
+}
+
+func (c *clickHouseConstructorConn) Close() error {
+	c.closeCalls++
+
+	return nil
+}
+
+func TestInitializeClickHouseSink_ClosesConnectionOnFailure(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name          string
+		pingErr       error
+		execErr       error
+		wantExecCalls int
+	}{
+		{
+			name:          "ping",
+			pingErr:       errors.New("clickhouse unavailable"),
+			wantExecCalls: 0,
+		},
+		{
+			name:          "create table",
+			execErr:       errors.New("create table failed"),
+			wantExecCalls: 1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			conn := &clickHouseConstructorConn{
+				pingErr: tc.pingErr,
+				execErr: tc.execErr,
+			}
+
+			sink, err := initializeClickHouseSink(t.Context(), conn, "ledger_events_test")
+			require.Error(t, err)
+			require.Nil(t, sink)
+			require.Equal(t, tc.wantExecCalls, conn.execCalls)
+			require.Equal(t, 1, conn.closeCalls,
+				"each failed construction attempt must release its opened connection")
+		})
+	}
+}
+
+func TestInitializeClickHouseSink_TransfersConnectionOwnershipOnSuccess(t *testing.T) {
+	t.Parallel()
+
+	conn := &clickHouseConstructorConn{}
+	sink, err := initializeClickHouseSink(t.Context(), conn, "")
+	require.NoError(t, err)
+	require.Equal(t, defaultClickHouseTable, sink.table)
+	require.Equal(t, 1, conn.execCalls)
+	require.Zero(t, conn.closeCalls, "a live sink must retain its connection")
+
+	require.NoError(t, sink.Close())
+	require.Equal(t, 1, conn.closeCalls)
+}


### PR DESCRIPTION
## What changed

Failed event sinks now enter the existing startup retry lifecycle when their constructor fails. ClickHouse connections are closed when ping or schema initialization fails, preventing retry-driven leaks.

## Why

[EN-1318](https://formance-team.atlassian.net/browse/EN-1318) showed that a sink failing during startup was logged once and then permanently abandoned.

## Product / operational motivation

Need: transient sink outages must recover without restarting Ledger.
Current limitation: constructor errors never scheduled another attempt.
Requirement / constraint: retries remain per-sink and stop cancellation prevents later attempts.
Evidence: internal/application/events/manager_startup_retry_test.go.
Durable repository evidence: docs/technical/architecture/subsystems/events-mirror/events.md.

## Technical decision

Decision: reuse the existing generation-aware retry scheduler on constructor failure and make ClickHouse construction close partially initialized connections.
Why now / why proportionate: this extends the established lifecycle with one missing transition.
Alternatives considered: failing the entire process startup was rejected because sinks are independently recoverable.

## Risk

**MEDIUM** — touches asynchronous sink lifecycle and connection ownership.

## Validation

- [x] bash scripts/agent-check
- [x] go test -race ./internal/application/events -count=1
- [x] Focused retry, shutdown-cancellation, ping-failure and DDL-failure regressions
- [ ] ClickHouse-tagged race execution; rootless Docker is unavailable on this host

## Architecture / behavior impact

No persisted format or API change. Startup failures now follow the documented per-sink retry lifecycle.

## Review focus

Review retry scheduling after constructor failure, Stop cancellation, and ownership of failed ClickHouse connections.

## Known concerns

The ClickHouse-tagged race suite requires a Docker environment not available on this host.


[EN-1318]: https://formance-team.atlassian.net/browse/EN-1318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ