### PR TITLE
fix(api): correlate internal errors with request traces

### DIFF
--- a/docs/technical/architecture/subsystems/api/grpc-api.md
+++ b/docs/technical/architecture/subsystems/api/grpc-api.md
@@ -512,6 +512,8 @@ See [Idempotency](../admission/idempotency.md) for detailed documentation.
 
 Processing errors (insufficient funds, ledger not found, etc.) are wrapped in a `BusinessError` struct in the FSM layer. The gRPC interceptor converts `BusinessError` instances to proper gRPC status codes with structured `google.rpc.ErrorInfo` details. This allows clients to programmatically identify error types without parsing error messages.
 
+Unknown errors, `KindInternal` errors, and recovered panics are logged with a generated `correlation_id`. When the RPC span is recording, the same log also carries `trace_id` and `span_id`, and the span records the correlation ID and error. This applies to both unary and streaming interceptors. Existing wire contracts remain distinct: unknown errors and panics return sanitized messages containing the correlation ID, while recognized `KindInternal` errors keep their existing status, reason, and message.
+
 Each business error response includes:
 - A **gRPC status code** (e.g., `NOT_FOUND`, `ALREADY_EXISTS`, `FAILED_PRECONDITION`)
 - A **human-readable message** (the original error string)

--- a/docs/technical/architecture/subsystems/api/http-api.md
+++ b/docs/technical/architecture/subsystems/api/http-api.md
@@ -93,12 +93,13 @@ same guarantee for the `Request` oneof.
 
 Business errors (validation, not-found, conflict, etc.) map to specific status codes and carry a machine-readable `errorCode` and a descriptive `errorMessage`, mirroring the gRPC adapter's `Describable` contract.
 
-Two paths, however, must never expose internal error text to clients — the raw value could contain filesystem paths, wrapped Pebble/storage errors, or internal invariant strings:
+Three paths need correlated server-side diagnostics because the raw value can contain filesystem paths, wrapped Pebble/storage errors, or internal invariant strings:
 
 1. **Panic recovery** (`jsonRecoverer`) — a panic in any handler.
 2. **Unmapped errors** (`handleError` fallthrough → `writeInternalServerError`) — any error that is not a domain `Describable` or a known sentinel.
+3. **`KindInternal` domain errors** — recognized internal failures whose existing status, reason, and response message contract is preserved.
 
-Both paths are sanitized identically to the gRPC adapter: the raw cause is logged **server-side** with a `correlation_id` field (and, for a panic, additionally recorded on the OTel span together with the stack), while the client receives only a generic body:
+Every path logs the raw cause **server-side** with a `correlation_id` field. When the request span is recording, the log also carries `trace_id` and `span_id`, and the span records both the correlation ID and the error. Panic spans additionally carry the panic value and stack. Unmapped errors and panics remain sanitized identically to the gRPC adapter, so the client receives only a generic body:
 
 ```json
 {
@@ -107,7 +108,7 @@ Both paths are sanitized identically to the gRPC adapter: the raw cause is logge
 }
 ```
 
-The correlation ID is the request's `X-Request-Id` (Chi `RequestID`) so operators can grep the server logs for the exact ID a caller reports. Adding a new persisted error path that reaches `handleError`'s fallthrough inherits this sanitization automatically; do not add a branch that serializes a raw non-domain error into the response body.
+The correlation ID reuses the request's `X-Request-Id` (Chi `RequestID`) when it is valid, so operators can grep the server logs for the exact ID a caller reports. Empty IDs, values longer than 128 bytes, invalid UTF-8, and values containing control characters are replaced with a generated token before they reach logs or responses. Adding a new persisted error path that reaches `handleError`'s fallthrough inherits this sanitization automatically; do not add a branch that serializes a raw non-domain error into the response body.
 
 ### Retry-After Header
 

--- a/internal/adapter/apitrace/apitrace.go
+++ b/internal/adapter/apitrace/apitrace.go
@@ -1,0 +1,40 @@
+// Package apitrace keeps API error logs and request spans correlated.
+package apitrace
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/formancehq/go-libs/v5/pkg/observe"
+)
+
+// Fields returns trace identifiers suitable for structured logs when the
+// request span is recording. A non-recording span deliberately contributes no
+// identifiers: exporting identifiers without an accompanying trace makes the
+// log correlation misleading.
+func Fields(ctx context.Context) map[string]any {
+	fields := map[string]any{}
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return fields
+	}
+
+	spanContext := span.SpanContext()
+	fields["trace_id"] = spanContext.TraceID().String()
+	fields["span_id"] = spanContext.SpanID().String()
+
+	return fields
+}
+
+// Stamp records the correlation ID and raw error on a recording request span.
+func Stamp(ctx context.Context, correlationID string, err error) {
+	span := trace.SpanFromContext(ctx)
+	if !span.IsRecording() {
+		return
+	}
+
+	span.SetAttributes(attribute.String("correlation_id", correlationID))
+	observe.RecordError(ctx, err)
+}

--- a/internal/adapter/grpc/errors_test.go
+++ b/internal/adapter/grpc/errors_test.go
@@ -1,6 +1,7 @@
 package grpc
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -8,7 +9,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.etcd.io/raft/v3"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	ggrpc "google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -36,8 +41,15 @@ func TestHandlePanic_DoesNotLeakStackToClient(t *testing.T) {
 
 	const secretInternal = "panic message leaking /internal/path"
 	stack := []byte("goroutine 1 [running]:\nmain.veryRevealingFunctionName(...)\n\t/build/ledger/internal/secret.go:42")
+	var logs bytes.Buffer
+	logger := logging.NewDefaultLogger(&logs, false, false, false)
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+	ctx, span := provider.Tracer("test").Start(context.Background(), "request")
 
-	grpcErr := handlePanic(context.Background(), testLogger(), secretInternal, stack)
+	grpcErr := handlePanic(ctx, logger, secretInternal, stack)
+	span.End()
 
 	st, ok := status.FromError(grpcErr)
 	require.True(t, ok)
@@ -49,6 +61,13 @@ func TestHandlePanic_DoesNotLeakStackToClient(t *testing.T) {
 	require.NotContains(t, st.Message(), "/build",
 		"file paths MUST NOT leak through to the client (#326)")
 	require.Contains(t, st.Message(), "correlation ID")
+	require.Contains(t, logs.String(), span.SpanContext().TraceID().String())
+	require.Contains(t, logs.String(), span.SpanContext().SpanID().String())
+
+	ended := recorder.Ended()
+	require.Len(t, ended, 1)
+	require.NotEmpty(t, grpcSpanAttribute(ended[0], "correlation_id"))
+	require.NotEmpty(t, ended[0].Events())
 }
 
 func TestBusinessErrorToGRPCStatus_LedgerAlreadyExists(t *testing.T) {
@@ -449,6 +468,121 @@ func TestConvertToGRPCError_UnknownErrorIsSanitized(t *testing.T) {
 	require.NotContains(t, st.Message(), secretInternalDetail,
 		"raw internal error string MUST NOT leak through to the client (#326)")
 	require.Contains(t, st.Message(), "correlation ID")
+}
+
+func TestErrorConversionInterceptorsRecordCorrelatedDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		err      error
+		wantCode codes.Code
+	}{
+		{name: "unknown", err: errors.New("unknown storage failure"), wantCode: codes.Unknown},
+		{name: "kind internal", err: &domain.ErrInvalidExecutionPlan{Reason_: "secret structural detail"}, wantCode: codes.Internal},
+	}
+
+	transports := []struct {
+		name string
+		run  func(context.Context, logging.Logger, error) error
+	}{
+		{
+			name: "unary",
+			run: func(ctx context.Context, logger logging.Logger, injected error) error {
+				_, err := errorConversionInterceptor(logger)(ctx, nil, &ggrpc.UnaryServerInfo{FullMethod: "/test.Service/Method"},
+					func(context.Context, any) (any, error) { return nil, injected })
+
+				return err
+			},
+		},
+		{
+			name: "stream",
+			run: func(ctx context.Context, logger logging.Logger, injected error) error {
+				stream := &loggerServerStream{ctx: ctx}
+
+				return errorConversionStreamInterceptor(logger)(nil, stream, &ggrpc.StreamServerInfo{FullMethod: "/test.Service/Stream"},
+					func(any, ggrpc.ServerStream) error { return injected })
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		for _, transport := range transports {
+			t.Run(tt.name+"/"+transport.name, func(t *testing.T) {
+				var logs bytes.Buffer
+				logger := logging.NewDefaultLogger(&logs, false, false, false)
+				recorder := tracetest.NewSpanRecorder()
+				provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+				t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
+				ctx, span := provider.Tracer("test").Start(context.Background(), "request")
+				grpcErr := transport.run(ctx, logger, tt.err)
+				span.End()
+
+				st, ok := status.FromError(grpcErr)
+				require.True(t, ok)
+				require.Equal(t, tt.wantCode, st.Code())
+				if tt.wantCode == codes.Internal {
+					require.Equal(t, tt.err.Error(), st.Message(), "KindInternal response contracts stay unchanged")
+				}
+
+				require.Contains(t, logs.String(), tt.err.Error())
+				require.Contains(t, logs.String(), span.SpanContext().TraceID().String())
+				require.Contains(t, logs.String(), span.SpanContext().SpanID().String())
+
+				ended := recorder.Ended()
+				require.Len(t, ended, 1)
+				require.NotEmpty(t, grpcSpanAttribute(ended[0], "correlation_id"))
+				require.NotEmpty(t, ended[0].Events())
+			})
+		}
+	}
+}
+
+func TestErrorConversionInterceptorOmitsTraceFieldsForNonRecordingSpan(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	logger := logging.NewDefaultLogger(&logs, false, false, false)
+	spanContext := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{1},
+		SpanID:  trace.SpanID{2},
+		Remote:  true,
+	})
+	ctx := trace.ContextWithRemoteSpanContext(context.Background(), spanContext)
+
+	_, err := errorConversionInterceptor(logger)(ctx, nil, &ggrpc.UnaryServerInfo{FullMethod: "/test.Service/Method"},
+		func(context.Context, any) (any, error) { return nil, errors.New("boom") })
+
+	require.Equal(t, codes.Unknown, status.Code(err))
+	require.Contains(t, logs.String(), "correlation_id")
+	require.NotContains(t, logs.String(), "trace_id")
+	require.NotContains(t, logs.String(), "span_id")
+}
+
+func TestErrorConversionInterceptorPreservesSequenceExhausted(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	logger := logging.NewDefaultLogger(&logs, false, false, false)
+	_, err := errorConversionInterceptor(logger)(context.Background(), nil,
+		&ggrpc.UnaryServerInfo{FullMethod: "/test.Service/Method"},
+		func(context.Context, any) (any, error) {
+			return nil, &domain.ErrSequenceExhausted{Counter: domain.SequenceCounterLog}
+		})
+
+	require.Equal(t, codes.ResourceExhausted, status.Code(err))
+	require.Empty(t, logs.String())
+}
+
+func grpcSpanAttribute(span sdktrace.ReadOnlySpan, key string) string {
+	for _, attr := range span.Attributes() {
+		if string(attr.Key) == key {
+			return attr.Value.AsString()
+		}
+	}
+
+	return ""
 }
 
 // TestConvertToGRPCError_BareValidationSentinels pins EN-1253: request

--- a/internal/adapter/grpc/server.go
+++ b/internal/adapter/grpc/server.go
@@ -30,6 +30,7 @@ import (
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
+	"github.com/formancehq/ledger/v3/internal/adapter/apitrace"
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/domain/crypto/signing"
 	"github.com/formancehq/ledger/v3/internal/infra/backup"
@@ -369,9 +370,9 @@ func newCorrelationID() string {
 // `correlation_id=<id>` against the logs.
 func handlePanic(ctx context.Context, logger logging.Logger, r any, stack []byte) error {
 	correlationID := newCorrelationID()
-	logger.WithFields(map[string]any{
-		"correlation_id": correlationID,
-	}).Errorf("gRPC handler panicked: %v\n%s", r, stack)
+	fields := apitrace.Fields(ctx)
+	fields["correlation_id"] = correlationID
+	logger.WithFields(fields).Errorf("gRPC handler panicked: %v\n%s", r, stack)
 
 	span := trace.SpanFromContext(ctx)
 	span.SetAttributes(
@@ -481,7 +482,7 @@ func errorConversionInterceptor(logger logging.Logger) ggrpc.UnaryServerIntercep
 	return func(ctx context.Context, req any, info *ggrpc.UnaryServerInfo, handler ggrpc.UnaryHandler) (any, error) {
 		resp, err := handler(ctx, req)
 		if err != nil {
-			err = convertToGRPCError(err, logger)
+			err = convertToGRPCErrorWithContext(ctx, err, logger)
 		}
 
 		return resp, err
@@ -493,7 +494,7 @@ func errorConversionStreamInterceptor(logger logging.Logger) ggrpc.StreamServerI
 	return func(srv any, ss ggrpc.ServerStream, info *ggrpc.StreamServerInfo, handler ggrpc.StreamHandler) error {
 		err := handler(srv, ss)
 		if err != nil {
-			err = convertToGRPCError(err, logger)
+			err = convertToGRPCErrorWithContext(ss.Context(), err, logger)
 		}
 
 		return err
@@ -511,6 +512,10 @@ func errorConversionStreamInterceptor(logger logging.Logger) ggrpc.StreamServerI
 // strings, file paths, invariant messages) are not disclosed to API
 // clients (#326).
 func convertToGRPCError(err error, logger logging.Logger) error {
+	return convertToGRPCErrorWithContext(context.Background(), err, logger)
+}
+
+func convertToGRPCErrorWithContext(ctx context.Context, err error, logger logging.Logger) error {
 	// Already a gRPC status error, return as-is
 	if _, ok := status.FromError(err); ok {
 		return err
@@ -667,6 +672,10 @@ func convertToGRPCError(err error, logger logging.Logger) error {
 	// whether wrapped in BusinessError or returned raw, flows through one
 	// exhaustive Kind switch in describableToGRPCStatus.
 	if d, ok := errors.AsType[domain.Describable](err); ok {
+		if domain.Kind(d) == domain.KindInternal {
+			recordGRPCInternalError(ctx, logger, err)
+		}
+
 		return describableToGRPCStatus(d).Err()
 	}
 
@@ -714,12 +723,19 @@ func convertToGRPCError(err error, logger logging.Logger) error {
 	// file system paths, or internal invariant messages; do not leak any
 	// of that to the client. Log server-side with a correlation ID and
 	// return a generic Unknown.
-	correlationID := newCorrelationID()
-	logger.WithFields(map[string]any{
-		"correlation_id": correlationID,
-	}).Errorf("Unmapped gRPC handler error: %v", err)
+	correlationID := recordGRPCInternalError(ctx, logger, err)
 
 	return status.Errorf(codes.Unknown, "unknown server error (correlation ID: %s)", correlationID)
+}
+
+func recordGRPCInternalError(ctx context.Context, logger logging.Logger, err error) string {
+	correlationID := newCorrelationID()
+	fields := apitrace.Fields(ctx)
+	fields["correlation_id"] = correlationID
+	logger.WithFields(fields).Errorf("Internal gRPC handler error: %v", err)
+	apitrace.Stamp(ctx, correlationID, err)
+
+	return correlationID
 }
 
 // Option configures a Raft or Service gRPC server.

--- a/internal/adapter/grpc/server_bootstrap.go
+++ b/internal/adapter/grpc/server_bootstrap.go
@@ -92,7 +92,7 @@ func (impl *ClusterBootstrapServiceServerImpl) GetPeers(ctx context.Context, req
 	if !impl.node.IsLeader() {
 		conn, err := impl.leaderRaftConn()
 		if err != nil {
-			return nil, convertToGRPCError(err, impl.logger)
+			return nil, convertToGRPCErrorWithContext(ctx, err, impl.logger)
 		}
 
 		outCtx := ctx
@@ -105,7 +105,7 @@ func (impl *ClusterBootstrapServiceServerImpl) GetPeers(ctx context.Context, req
 
 	peers, err := impl.membership.ListPeers(ctx)
 	if err != nil {
-		return nil, convertToGRPCError(err, impl.logger)
+		return nil, convertToGRPCErrorWithContext(ctx, err, impl.logger)
 	}
 
 	out := make([]*clusterbootstrappb.PeerInfo, 0, len(peers))
@@ -150,7 +150,7 @@ func (impl *ClusterBootstrapServiceServerImpl) JoinAsLearner(ctx context.Context
 			// map commonpb.ErrNoLeader to codes.Unavailable here so
 			// tryAddLearner treats it as transient and tries the
 			// next peer instead of failing fatally.
-			return nil, convertToGRPCError(err, impl.logger)
+			return nil, convertToGRPCErrorWithContext(ctx, err, impl.logger)
 		}
 
 		impl.logger.Infof("JoinAsLearner: forwarding to leader")
@@ -263,7 +263,7 @@ func (impl *ClusterBootstrapServiceServerImpl) JoinAsLearner(ctx context.Context
 		// Notably:
 		//   - ErrNotLeader / ErrProposalDropped / ErrNoLeader → Unavailable
 		//     (retried by the client)
-		return nil, convertToGRPCError(err, impl.logger)
+		return nil, convertToGRPCErrorWithContext(ctx, err, impl.logger)
 	}
 
 	return &clusterbootstrappb.JoinAsLearnerResponse{}, nil

--- a/internal/adapter/http/correlation.go
+++ b/internal/adapter/http/correlation.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/go-chi/chi/v5/middleware"
 )
@@ -18,11 +20,27 @@ import (
 // request ID is set it falls back to a freshly generated token so the caller
 // always has something to quote.
 func correlationID(r *http.Request) string {
-	if id := middleware.GetReqID(r.Context()); id != "" {
+	if id := middleware.GetReqID(r.Context()); validCorrelationID(id) {
 		return id
 	}
 
 	return generatedCorrelationID()
+}
+
+const maxCorrelationIDLength = 128
+
+func validCorrelationID(id string) bool {
+	if id == "" || len(id) > maxCorrelationIDLength || !utf8.ValidString(id) {
+		return false
+	}
+
+	for _, r := range id {
+		if unicode.IsControl(r) {
+			return false
+		}
+	}
+
+	return true
 }
 
 // generatedCorrelationID returns a short hex token. Mirrors the gRPC adapter's

--- a/internal/adapter/http/correlation_test.go
+++ b/internal/adapter/http/correlation_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5/middleware"
@@ -27,4 +28,40 @@ func TestCorrelationID_FallsBackWhenNoRequestID(t *testing.T) {
 	// No RequestID middleware ran: still return a non-empty token so the
 	// client always has something to quote.
 	require.NotEmpty(t, correlationID(r))
+}
+
+func TestCorrelationID_RejectsUnsafeInboundValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		id   string
+	}{
+		{name: "too long", id: strings.Repeat("a", maxCorrelationIDLength+1)},
+		{name: "line break", id: "forged\nlog-entry"},
+		{name: "invalid utf8", id: string([]byte{0xff, 0xfe})},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.WithValue(context.Background(), middleware.RequestIDKey, tt.id)
+			r := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+			got := correlationID(r)
+
+			require.NotEqual(t, tt.id, got)
+			require.Len(t, got, 16)
+		})
+	}
+}
+
+func TestCorrelationID_AcceptsMaximumLength(t *testing.T) {
+	t.Parallel()
+
+	id := strings.Repeat("a", maxCorrelationIDLength)
+	ctx := context.WithValue(context.Background(), middleware.RequestIDKey, id)
+	r := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+
+	require.Equal(t, id, correlationID(r))
 }

--- a/internal/adapter/http/error_handler.go
+++ b/internal/adapter/http/error_handler.go
@@ -103,6 +103,9 @@ func handleError(w http.ResponseWriter, r *http.Request, err error) {
 		if httpStatus == http.StatusServiceUnavailable {
 			w.Header().Set("Retry-After", "1")
 		}
+		if httpStatus == http.StatusInternalServerError {
+			recordHTTPInternalError(r, correlationID(r), err)
+		}
 
 		writeErrorResponse(w, httpStatus, d.Reason(), err)
 

--- a/internal/adapter/http/error_handler_test.go
+++ b/internal/adapter/http/error_handler_test.go
@@ -1,15 +1,23 @@
 package http
 
 import (
+	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/infra/plan"
@@ -205,4 +213,53 @@ func TestHandleError(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHandleErrorKindInternalRecordsCorrelatedDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	logger := logging.NewDefaultLogger(&logs, false, false, false)
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
+	ctx, span := provider.Tracer("test").Start(context.Background(), "request")
+	ctx = logging.ContextWithLogger(ctx, logger)
+	ctx = context.WithValue(ctx, middleware.RequestIDKey, "corr-internal")
+	err := &domain.ErrInvalidExecutionPlan{Reason_: "secret structural detail"}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+	handleError(w, r, err)
+	span.End()
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	resp := decodeResponse[ErrorResponse](t, w)
+	require.Equal(t, domain.ErrReasonInvalidExecutionPlan, resp.ErrorCode)
+	require.Equal(t, err.Error(), resp.ErrorMessage, "KindInternal response contracts stay unchanged")
+	assert.Contains(t, logs.String(), err.Error())
+	assert.Contains(t, logs.String(), "corr-internal")
+	assert.Contains(t, logs.String(), span.SpanContext().TraceID().String())
+	assert.Contains(t, logs.String(), span.SpanContext().SpanID().String())
+
+	ended := recorder.Ended()
+	require.Len(t, ended, 1)
+	assert.Equal(t, "corr-internal", httpSpanAttribute(ended[0], "correlation_id"))
+	assert.NotEmpty(t, ended[0].Events())
+}
+
+func TestHandleErrorSequenceExhaustedDoesNotEnterInternalDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	ctx := logging.ContextWithLogger(context.Background(), logging.NewDefaultLogger(&logs, false, false, false))
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+
+	handleError(w, r, &domain.ErrSequenceExhausted{Counter: domain.SequenceCounterLog})
+
+	require.Equal(t, http.StatusTooManyRequests, w.Code)
+	require.Equal(t, domain.ErrReasonSequenceExhausted, decodeResponse[ErrorResponse](t, w).ErrorCode)
+	require.Empty(t, logs.String())
 }

--- a/internal/adapter/http/middleware_recoverer.go
+++ b/internal/adapter/http/middleware_recoverer.go
@@ -9,6 +9,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/adapter/apitrace"
 )
 
 // jsonRecoverer is a middleware that recovers from panics and returns a JSON
@@ -33,9 +35,9 @@ func jsonRecoverer(next http.Handler) http.Handler {
 				id := correlationID(r)
 				stack := debug.Stack()
 
-				logging.FromContext(r.Context()).WithFields(map[string]any{
-					"correlation_id": id,
-				}).Errorf("HTTP handler panicked: %v\n%s", rvr, stack)
+				fields := apitrace.Fields(r.Context())
+				fields["correlation_id"] = id
+				logging.FromContext(r.Context()).WithFields(fields).Errorf("HTTP handler panicked: %v\n%s", rvr, stack)
 
 				if span := trace.SpanFromContext(r.Context()); span.SpanContext().IsValid() {
 					span.SetAttributes(

--- a/internal/adapter/http/middleware_recoverer_test.go
+++ b/internal/adapter/http/middleware_recoverer_test.go
@@ -9,7 +9,10 @@ import (
 	"testing"
 
 	"github.com/go-chi/chi/v5/middleware"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.uber.org/mock/gomock"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
@@ -25,18 +28,23 @@ func TestJSONRecoverer_SanitizesPanic(t *testing.T) {
 
 	var logs bytes.Buffer
 	logger := logging.NewDefaultLogger(&logs, false, false, false)
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
 
 	panicking := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
 		panic("secret invariant: /var/lib/ledger/pebble corrupted")
 	})
 
-	ctx := logging.ContextWithLogger(context.Background(), logger)
+	ctx, span := provider.Tracer("test").Start(context.Background(), "request")
+	ctx = logging.ContextWithLogger(ctx, logger)
 	ctx = context.WithValue(ctx, middleware.RequestIDKey, "corr-panic")
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
 
 	jsonRecoverer(panicking).ServeHTTP(w, r)
+	span.End()
 
 	require.Equal(t, http.StatusInternalServerError, w.Code)
 	require.Equal(t, "application/json", w.Header().Get("Content-Type"))
@@ -55,6 +63,13 @@ func TestJSONRecoverer_SanitizesPanic(t *testing.T) {
 	require.Contains(t, logged, "secret invariant: /var/lib/ledger/pebble corrupted")
 	require.Contains(t, logged, "corr-panic")
 	require.Contains(t, logged, "HTTP handler panicked")
+	assert.Contains(t, logged, span.SpanContext().TraceID().String())
+	assert.Contains(t, logged, span.SpanContext().SpanID().String())
+
+	ended := recorder.Ended()
+	require.Len(t, ended, 1)
+	assert.Equal(t, "corr-panic", httpSpanAttribute(ended[0], "correlation_id"))
+	assert.NotEmpty(t, ended[0].Events())
 }
 
 func TestJSONRecoverer_PropagatesErrAbortHandler(t *testing.T) {

--- a/internal/adapter/http/response.go
+++ b/internal/adapter/http/response.go
@@ -12,6 +12,7 @@ import (
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
+	"github.com/formancehq/ledger/v3/internal/adapter/apitrace"
 	"github.com/formancehq/ledger/v3/internal/adapter/json"
 	"github.com/formancehq/ledger/v3/internal/query"
 )
@@ -174,10 +175,7 @@ func writeBadRequest(w http.ResponseWriter, errorCode string, err error) {
 // (mirrors the gRPC adapter's convertToGRPCError default branch, #375).
 func writeInternalServerError(w http.ResponseWriter, r *http.Request, err error) {
 	id := correlationID(r)
-
-	logging.FromContext(r.Context()).WithFields(map[string]any{
-		"correlation_id": id,
-	}).Errorf("HTTP unmapped handler error: %v", err)
+	recordHTTPInternalError(r, id, err)
 
 	writeErrorResponse(
 		w,
@@ -185,6 +183,13 @@ func writeInternalServerError(w http.ResponseWriter, r *http.Request, err error)
 		"INTERNAL_ERROR",
 		fmt.Errorf("internal server error (correlation ID: %s)", id),
 	)
+}
+
+func recordHTTPInternalError(r *http.Request, correlationID string, err error) {
+	fields := apitrace.Fields(r.Context())
+	fields["correlation_id"] = correlationID
+	logging.FromContext(r.Context()).WithFields(fields).Errorf("HTTP internal handler error: %v", err)
+	apitrace.Stamp(r.Context(), correlationID, err)
 }
 
 // queryParamBool returns true if the query parameter exists and is "true".

--- a/internal/adapter/http/response_test.go
+++ b/internal/adapter/http/response_test.go
@@ -14,6 +14,9 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/proto"
 
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
@@ -86,13 +89,18 @@ func TestWriteInternalServerError(t *testing.T) {
 
 	var logs bytes.Buffer
 	logger := logging.NewDefaultLogger(&logs, false, false, false)
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
 
-	ctx := logging.ContextWithLogger(context.Background(), logger)
+	ctx, span := provider.Tracer("test").Start(context.Background(), "request")
+	ctx = logging.ContextWithLogger(ctx, logger)
 	ctx = context.WithValue(ctx, middleware.RequestIDKey, "corr-123")
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
 	writeInternalServerError(w, r, errors.New("boom: /var/lib/pebble path leaked"))
+	span.End()
 
 	require.Equal(t, http.StatusInternalServerError, w.Code)
 	resp := decodeResponse[ErrorResponse](t, w)
@@ -109,6 +117,46 @@ func TestWriteInternalServerError(t *testing.T) {
 	logged := logs.String()
 	require.Contains(t, logged, "boom: /var/lib/pebble path leaked")
 	require.Contains(t, logged, "corr-123")
+	assert.Contains(t, logged, span.SpanContext().TraceID().String())
+	assert.Contains(t, logged, span.SpanContext().SpanID().String())
+
+	ended := recorder.Ended()
+	require.Len(t, ended, 1)
+	assert.Equal(t, "corr-123", httpSpanAttribute(ended[0], "correlation_id"))
+	assert.NotEmpty(t, ended[0].Events(), "the server error must be recorded on the request span")
+}
+
+func TestWriteInternalServerErrorOmitsTraceFieldsForNonRecordingSpan(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	logger := logging.NewDefaultLogger(&logs, false, false, false)
+	spanContext := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID: trace.TraceID{1},
+		SpanID:  trace.SpanID{2},
+		Remote:  true,
+	})
+	ctx := trace.ContextWithRemoteSpanContext(context.Background(), spanContext)
+	ctx = logging.ContextWithLogger(ctx, logger)
+	ctx = context.WithValue(ctx, middleware.RequestIDKey, "corr-unrecorded")
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx)
+	writeInternalServerError(w, r, errors.New("boom"))
+
+	require.Contains(t, logs.String(), "corr-unrecorded")
+	require.NotContains(t, logs.String(), "trace_id")
+	require.NotContains(t, logs.String(), "span_id")
+}
+
+func httpSpanAttribute(span sdktrace.ReadOnlySpan, key string) string {
+	for _, attr := range span.Attributes() {
+		if string(attr.Key) == key {
+			return attr.Value.AsString()
+		}
+	}
+
+	return ""
 }
 
 func TestWriteErrorResponse_NilError(t *testing.T) {


### PR DESCRIPTION
## What changed

Internal HTTP and gRPC errors now carry correlation, trace and span identifiers in server diagnostics when a request span is recording. The same correlation identifier is stamped onto the span, and unsafe inbound request IDs are replaced.

## Why

[EN-1623](https://formance-team.atlassian.net/browse/EN-1623) documents error paths where the caller-visible correlation token could not be joined to traces or sufficiently contextualized logs.

## Product / operational motivation

Need: operators must be able to move from a reported error token to the corresponding log and trace.
Current limitation: non-panic paths dropped span context and zap context propagation is a no-op.
Requirement / constraint: preserve existing HTTP and gRPC response contracts.
Evidence: recording and non-recording span regressions in both adapters.
Durable repository evidence: docs/technical/architecture/subsystems/api/http-api.md and grpc-api.md.

## Technical decision

Decision: introduce a small adapter-level trace helper, thread context into gRPC conversion, and stamp structured identifiers only for recording spans.
Why now / why proportionate: it fixes the concrete correlation break without changing public error bodies.
Alternatives considered: globally sanitizing every KindInternal response was rejected because some messages are intentional client diagnostics.

## Risk

**MEDIUM** — changes cross-cutting HTTP and gRPC error diagnostics while preserving wire output.

## Validation

- [x] bash scripts/agent-check
- [x] go test -race ./internal/adapter/apitrace ./internal/adapter/http ./internal/adapter/grpc -count=1
- [x] Recording-span, non-recording-span, panic and KindInternal regressions
- [ ] Full OTLP exporter integration

## Architecture / behavior impact

No persisted state or wire-contract change. Server-side observability gains request trace correlation.

## Review focus

Review recording-span gating, gRPC context threading and inbound correlation-ID validation.

## Known concerns

This is the minimal correlation slice of EN-1623. Separate type-level disclosure fixes and service metadata alignment remain outside this PR.


[EN-1623]: https://formance-team.atlassian.net/browse/EN-1623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ