### PR TITLE
fix(ledgerctl): use Formance config namespace

### DIFF
--- a/cmd/ledgerctl/cmdutil/config.go
+++ b/cmd/ledgerctl/cmdutil/config.go
@@ -31,14 +31,14 @@ type Config struct {
 }
 
 // ConfigDir returns the ledgerctl configuration directory
-// (~/.config/ledgerctl on Linux, ~/Library/Application Support/ledgerctl on macOS).
+// under the OS-native Formance application namespace.
 func ConfigDir() (string, error) {
 	base, err := os.UserConfigDir()
 	if err != nil {
 		return "", fmt.Errorf("determining config directory: %w", err)
 	}
 
-	return filepath.Join(base, "ledgerctl"), nil
+	return filepath.Join(base, "formance", "ledgerctl"), nil
 }
 
 // ConfigPath returns the path to the configuration file.
@@ -52,7 +52,7 @@ func ConfigPath() (string, error) {
 }
 
 // LoadConfig reads the configuration file. If the file does not exist,
-// a zero-value Config is returned (backward compatible with fresh installs).
+// a zero-value Config is returned for a fresh install.
 func LoadConfig() (Config, error) {
 	path, err := ConfigPath()
 	if err != nil {

--- a/cmd/ledgerctl/cmdutil/config_test.go
+++ b/cmd/ledgerctl/cmdutil/config_test.go
@@ -70,15 +70,16 @@ func TestSaveConfigPermissions(t *testing.T) {
 }
 
 // isolateConfigDir redirects os.UserConfigDir to a temp directory so the test
-// never touches the developer's real ledgerctl config. It sets both HOME
-// (used on macOS) and XDG_CONFIG_HOME (used on Linux) to keep the test
-// cross-platform. Env mutation precludes t.Parallel.
+// never touches the developer's real ledgerctl config. It sets HOME (used on
+// macOS), XDG_CONFIG_HOME (used on Linux), and APPDATA (used on Windows) to
+// keep the test cross-platform. Env mutation precludes t.Parallel.
 func isolateConfigDir(t *testing.T) {
 	t.Helper()
 
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("APPDATA", dir)
 }
 
 func TestCompleteProfileNames(t *testing.T) {

--- a/cmd/ledgerctl/cmdutil/config_test.go
+++ b/cmd/ledgerctl/cmdutil/config_test.go
@@ -1,11 +1,73 @@
 package cmdutil
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
+
+func TestConfigDirUsesFormanceNamespace(t *testing.T) {
+	isolateConfigDir(t)
+
+	base, err := os.UserConfigDir()
+	require.NoError(t, err)
+
+	dir, err := ConfigDir()
+	require.NoError(t, err)
+	require.Equal(t, filepath.Join(base, "formance", "ledgerctl"), dir)
+}
+
+func TestLoadConfigIgnoresLegacyPath(t *testing.T) {
+	isolateConfigDir(t)
+
+	base, err := os.UserConfigDir()
+	require.NoError(t, err)
+
+	legacyDir := filepath.Join(base, "ledgerctl")
+	require.NoError(t, os.MkdirAll(legacyDir, 0o700))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(legacyDir, "config.json"),
+		[]byte(`{"activeProfile":"legacy","profiles":{"legacy":{"server":"legacy:8888"}}}`),
+		0o600,
+	))
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	require.Empty(t, cfg.ActiveProfile)
+	require.Empty(t, cfg.Profiles)
+}
+
+func TestSaveConfigPermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX permission bits are not available on Windows")
+	}
+
+	isolateConfigDir(t)
+
+	require.NoError(t, SaveConfig(Config{
+		ActiveProfile: "prod",
+		Profiles: map[string]Profile{
+			"prod": {Server: "prod:8888"},
+		},
+	}))
+
+	dir, err := ConfigDir()
+	require.NoError(t, err)
+	path, err := ConfigPath()
+	require.NoError(t, err)
+
+	dirInfo, err := os.Stat(dir)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o700), dirInfo.Mode().Perm())
+
+	fileInfo, err := os.Stat(path)
+	require.NoError(t, err)
+	require.Equal(t, os.FileMode(0o600), fileInfo.Mode().Perm())
+}
 
 // isolateConfigDir redirects os.UserConfigDir to a temp directory so the test
 // never touches the developer's real ledgerctl config. It sets both HOME

--- a/cmd/ledgerctl/e2e_complete_test.go
+++ b/cmd/ledgerctl/e2e_complete_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
+	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
@@ -49,9 +50,8 @@ func TestE2ECompletionUsesExplicitProfileNotActive(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", tmp)
 	t.Setenv("LEDGERCTL_PROFILE", "")
 	t.Setenv("LEDGERCTL_SERVER", "")
-	base, err := os.UserConfigDir()
+	dir, err := cmdutil.ConfigDir()
 	require.NoError(t, err)
-	dir := filepath.Join(base, "ledgerctl")
 	require.NoError(t, os.MkdirAll(dir, 0o700))
 	cfg := `{"activeProfile":"acme","profiles":{` +
 		`"acme":{"server":"` + activeAddr + `","insecure":true},` +

--- a/cmd/ledgerctl/e2e_complete_test.go
+++ b/cmd/ledgerctl/e2e_complete_test.go
@@ -48,6 +48,7 @@ func TestE2ECompletionUsesExplicitProfileNotActive(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("HOME", tmp)
 	t.Setenv("XDG_CONFIG_HOME", tmp)
+	t.Setenv("APPDATA", tmp)
 	t.Setenv("LEDGERCTL_PROFILE", "")
 	t.Setenv("LEDGERCTL_SERVER", "")
 	dir, err := cmdutil.ConfigDir()

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -3071,7 +3071,16 @@ Manage named connection profiles. Each profile stores a server address and TLS s
 
 **Aliases:** `profiles`, `prof`
 
-**Config file location:** `~/.config/ledgerctl/config.json` (Linux), `~/Library/Application Support/ledgerctl/config.json` (macOS)
+**Config file location:** ledgerctl uses the OS-native user configuration
+directory under the shared Formance namespace:
+
+- Linux: `$XDG_CONFIG_HOME/formance/ledgerctl/config.json` when set, otherwise
+  `~/.config/formance/ledgerctl/config.json`
+- macOS: `~/Library/Application Support/formance/ledgerctl/config.json`
+- Windows: `%AppData%\formance\ledgerctl\config.json`
+
+The former alpha location directly under the user configuration directory
+(`.../ledgerctl/config.json`) is intentionally ignored rather than migrated.
 
 **Flag resolution priority:** Explicit CLI flag > Environment variable > Profile value > Cobra default
 


### PR DESCRIPTION
## What changed

ledgerctl now stores non-secret profile configuration under the OS-native Formance namespace: `UserConfigDir/formance/ledgerctl/config.json`. Tests prove the former alpha path is ignored and completion uses the canonical resolver.

## Why

[EN-1284](https://formance-team.atlassian.net/browse/EN-1284) establishes one native vendor namespace across Linux/XDG, macOS and Windows.

## Product / operational motivation

Need: Formance CLI configuration should live under the platform-native vendor namespace.
Current limitation: ledgerctl wrote directly below the user configuration directory.
Requirement / constraint: no migration, fallback or keyring identity change.
Evidence: path, legacy-ignore, permissions and completion regressions.
Durable repository evidence: docs/ops/cli.md.

## Technical decision

Decision: append formance/ledgerctl to os.UserConfigDir().
Why now / why proportionate: Ledger v3 is unreleased and the previous path was alpha-only.
Alternatives considered: copying fctl literal home paths or adding compatibility lookup was rejected.

## Risk

**LOW** — narrow relocation of unreleased, non-secret CLI configuration.

## Validation

- [x] bash scripts/agent-check
- [x] go test ./cmd/ledgerctl/... -count=1
- [x] go test -race ./cmd/ledgerctl ./cmd/ledgerctl/cmdutil ./cmd/ledgerctl/auth -count=1
- [x] go vet ./cmd/ledgerctl/...
- [x] go build ./cmd/ledgerctl

## Architecture / behavior impact

No server, persisted ledger or keyring change. Existing alpha config files are intentionally ignored.

## Review focus

Review cross-platform path composition, absence of compatibility fallback and preservation of file permissions.

## Known concerns

Native Windows execution was not available; the implementation delegates platform roots to the Go standard library.


[EN-1284]: https://formance-team.atlassian.net/browse/EN-1284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ