### PR TITLE
test(http): lock metadata schema wire shape

### DIFF
--- a/internal/adapter/http/handlers_get_metadata_schema_test.go
+++ b/internal/adapter/http/handlers_get_metadata_schema_test.go
@@ -39,6 +39,13 @@ func TestHandleGetMetadataSchema_Success(t *testing.T) {
 	srv.handleGetMetadataSchema(w, r)
 
 	require.Equal(t, http.StatusOK, w.Code)
+	require.JSONEq(t, `{
+		"data": {
+			"accountFields": {"role": {"declaredType": "string"}},
+			"transactionFields": {},
+			"ledgerFields": {"env": {"declaredType": "string"}}
+		}
+	}`, w.Body.String())
 }
 
 func TestHandleGetMetadataSchema_MissingLedgerName(t *testing.T) {


### PR DESCRIPTION
## What changed

The metadata-schema HTTP handler regression now asserts the complete non-empty JSON wire shape, including the deliberate absence of the removed status field.

## Why

[EN-1690](https://formance-team.atlassian.net/browse/EN-1690) was fixed by PR #1857, but the handler test only checked the status code and did not protect the corrected SDK-facing contract.

## Product / operational motivation

N/A

## Technical decision

N/A

## Risk

**LOW** — test-only contract coverage.

## Validation

- [x] bash scripts/agent-check
- [x] Focused handler tests repeated 10 times
- [x] Mutation-sensitive OpenAPI component validation

## Architecture / behavior impact

N/A

## Review focus

Confirm the expected JSON exactly matches the declaredType-only contract established by #1857.

## Known concerns

Strict full-file OpenAPI loading currently finds a pre-existing duplicate 400 response on /promote; this PR does not expand into that unrelated defect.


[EN-1690]: https://formance-team.atlassian.net/browse/EN-1690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ