### PR TITLE
test(operator): fix Chainsaw cleanup schema

### DIFF
--- a/misc/operator/e2e/tests/disk-full-write-gate/chainsaw-test.yaml
+++ b/misc/operator/e2e/tests/disk-full-write-gate/chainsaw-test.yaml
@@ -18,6 +18,15 @@ spec:
                 df -h /mnt/tiny-data
               '
             timeout: 30s
+      # Chainsaw cleanup blocks belong to a step and run after the whole test.
+      # Keep this on the step that owns the host-side tmpfs lifecycle so it is
+      # registered before any later assertion can stop the test.
+      cleanup:
+        - script:
+            content: |
+              kubectl delete cluster disk-gate -n $NAMESPACE --ignore-not-found=true
+              docker exec ledger-e2e-control-plane sh -c 'umount /mnt/tiny-data 2>/dev/null || true'
+            timeout: 60s
 
     # 2. Deploy the 1-replica Cluster and wait for it to be Ready.
     - name: Deploy Cluster
@@ -152,10 +161,3 @@ spec:
     - podLogs:
         name: disk-gate-0
         container: ledger
-
-  cleanup:
-    - script:
-        content: |
-          kubectl delete cluster disk-gate -n $NAMESPACE --ignore-not-found=true
-          docker exec ledger-e2e-control-plane sh -c 'umount /mnt/tiny-data 2>/dev/null || true'
-        timeout: 60s


### PR DESCRIPTION
## What changed

The disk-full operator E2E cleanup is moved from the invalid test-level location to the setup step that owns the tmpfs lifecycle.

## Why

[EN-1785](https://formance-team.atlassian.net/browse/EN-1785) records that Chainsaw v0.2.15 rejected this one spec and therefore prevented the complete operator corpus from loading.

## Product / operational motivation

Need: the operator E2E corpus must load before any scenario can exercise release-critical behavior.
Current limitation: spec.cleanup is not part of the Chainsaw v0.2.15 TestSpec schema.
Requirement / constraint: register cleanup before later assertions while retaining end-of-test semantics.
Evidence: exact HEAD mutation fails and all 28 candidate specs lint.
Durable repository evidence: the corrected executable test specification.

## Technical decision

Decision: attach cleanup to the first TestStepSpec, which owns and registers the tmpfs lifecycle.
Why now / why proportionate: this is a schema-only relocation with unchanged cleanup commands.
Alternatives considered: finally was rejected because it runs at the end of that setup step rather than after the test.

## Risk

**LOW** — one operator E2E YAML lifecycle block moves without changing its commands.

## Validation

- [x] bash scripts/agent-check
- [x] Chainsaw v0.2.15 exact HEAD failure and candidate success
- [x] All 28 Chainsaw specs lint
- [x] Full corpus loads with the repository configuration
- [x] cd misc/operator && go test ./... -count=1
- [ ] Full Docker/Kind E2E execution

## Architecture / behavior impact

No product runtime change. Restores reachability of the operator E2E corpus.

## Review focus

Review Chainsaw cleanup timing and ownership of the host-side tmpfs.

## Known concerns

The contributor helper still installs Chainsaw from unpinned @latest; that pre-existing tooling issue is outside this PR.


[EN-1785]: https://formance-team.atlassian.net/browse/EN-1785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ