### PR TITLE
fix(schemathesis): require successful check execution

### DIFF
--- a/tests/schemathesis/run.sh
+++ b/tests/schemathesis/run.sh
@@ -128,6 +128,10 @@ source "$VENV_DIR/bin/activate"
 echo "==> Installing/verifying pinned Schemathesis dependencies..."
 pip3 install -q -r "$SCRIPT_DIR/requirements.txt"
 
+echo "==> Verifying Schemathesis event accounting..."
+PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover \
+    -s "$SCRIPT_DIR" -p 'test_reporting.py'
+
 echo "==> Running Schemathesis tests..."
 echo ""
 SHRINK_FLAG=""

--- a/tests/schemathesis/test_api.py
+++ b/tests/schemathesis/test_api.py
@@ -30,6 +30,7 @@ from schemathesis.checks import (
 # application/json on all non-204 responses (verified manually).
 from schemathesis.runner import from_schema
 from schemathesis.runner.events import AfterExecution, Finished
+from schemathesis.models import Status
 from schemathesis.stateful import Stateful
 
 OPENAPI_PATH = Path(
@@ -276,11 +277,6 @@ def main():
     else:
         phases = [p for p in hypothesis_settings.default.phases if p is not Phase.shrink]
 
-    has_failures = False
-    has_errors = False
-    tested_count = 0
-    network_error_count = 0
-
     runner = from_schema(
         schema,
         checks=[
@@ -314,7 +310,24 @@ def main():
             database=None,
         ),
     )
-    for event in runner.execute():
+    sys.exit(_report_events(runner.execute()))
+
+
+def _report_events(events):
+    """Report runner events and require proof that checks actually succeeded.
+
+    Network errors are tolerated only after a later execution completes real
+    checks successfully, proving that the runner recovered before finishing.
+    """
+    has_failures = False
+    has_errors = False
+    tested_count = 0
+    successful_execution_count = 0
+    recovered_network_error_count = 0
+    pending_network_error_count = 0
+    finished = False
+
+    for event in events:
         if isinstance(event, AfterExecution):
             tested_count += 1
             method = event.method.upper()
@@ -345,21 +358,30 @@ def main():
 
             if event.result.has_errors:
                 # Distinguish real server errors from transient network errors
-                is_network_error = all(
-                    _is_network_error(error)
-                    for error in event.result.errors
+                is_network_error = bool(event.result.errors) and all(
+                    _is_network_error(error) for error in event.result.errors
                 )
                 if is_network_error:
-                    network_error_count += 1
+                    pending_network_error_count += 1
                 else:
                     has_errors = True
                     for error in event.result.errors:
                         print(f"    ERROR: {error}", file=sys.stderr)
 
+            if (
+                not event.result.has_failures
+                and not event.result.has_errors
+                and any(check.value is Status.success for check in event.result.checks)
+            ):
+                successful_execution_count += 1
+                recovered_network_error_count += pending_network_error_count
+                pending_network_error_count = 0
+
         elif isinstance(event, Finished):
+            finished = True
             print("=" * 60)
-            passed = event.passed_count + network_error_count
-            errored = event.errored_count - network_error_count
+            passed = event.passed_count
+            errored = event.errored_count - recovered_network_error_count
             print(
                 f"Tested {tested_count} endpoint(s) | "
                 f"Passed: {passed} | "
@@ -367,23 +389,42 @@ def main():
                 f"Errored: {errored} | "
                 f"Skipped: {event.skipped_count}"
             )
-            if network_error_count > 0:
+            if recovered_network_error_count > 0:
                 print(
-                    f"  (ignored {network_error_count} transient network error(s))"
+                    "  (ignored "
+                    f"{recovered_network_error_count} recovered transient network "
+                    "error(s))"
+                )
+            if pending_network_error_count > 0:
+                has_errors = True
+                print(
+                    f"  ERROR: {pending_network_error_count} transient network "
+                    "error(s) were not followed by a successful check execution",
+                    file=sys.stderr,
+                )
+            if successful_execution_count == 0:
+                has_errors = True
+                print(
+                    "  ERROR: no successful check execution was observed",
+                    file=sys.stderr,
                 )
             if has_failures or has_errors:
                 print("RESULT: FAILURES DETECTED")
             else:
                 print("RESULT: ALL CHECKS PASSED")
 
-    sys.exit(1 if has_failures or has_errors else 0)
+    if not finished:
+        print("ERROR: Schemathesis runner ended without a Finished event", file=sys.stderr)
+        return 1
+    return 1 if has_failures or has_errors else 0
 
 
 def _is_network_error(error):
     """Check if an error is a transient network error (connection reset, etc.).
 
     These occur intermittently due to HTTP connection pooling and the Go
-    server's connection lifecycle. They are not indicative of API bugs.
+    server's connection lifecycle. The reporter still requires a later
+    successful check execution as proof that the runner recovered.
     """
     error_str = str(error)
     network_indicators = [

--- a/tests/schemathesis/test_reporting.py
+++ b/tests/schemathesis/test_reporting.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+
+import contextlib
+import io
+import unittest
+from types import SimpleNamespace
+
+from schemathesis.models import Status
+from schemathesis.runner.events import AfterExecution, Finished
+
+from test_api import _report_events
+
+
+def after_execution(*, checks=(), errors=()):
+    return AfterExecution(
+        method="GET",
+        path="/v3/test",
+        relative_path="/v3/test",
+        verbose_name="GET /v3/test",
+        status="error" if errors else "success",
+        data_generation_method=[],
+        result=SimpleNamespace(
+            has_failures=False,
+            has_errors=bool(errors),
+            checks=list(checks),
+            errors=list(errors),
+        ),
+        elapsed_time=0,
+        correlation_id="test",
+    )
+
+
+def finished(*, passed=0, errored=0):
+    return Finished(
+        passed_count=passed,
+        skipped_count=0,
+        failed_count=0,
+        errored_count=errored,
+        has_failures=False,
+        has_errors=bool(errored),
+        has_logs=False,
+        is_empty=passed == 0 and errored == 0,
+        generic_errors=[],
+        warnings=[],
+        total={},
+        running_time=0,
+    )
+
+
+class ReportingTest(unittest.TestCase):
+    def report(self, events):
+        output = io.StringIO()
+        with contextlib.redirect_stdout(output), contextlib.redirect_stderr(output):
+            exit_code = _report_events(events)
+        return exit_code, output.getvalue()
+
+    def test_transport_error_without_recovery_fails(self):
+        exit_code, output = self.report(
+            [
+                after_execution(errors=["ConnectionRefusedError: refused"]),
+                finished(errored=1),
+            ]
+        )
+
+        self.assertEqual(1, exit_code)
+        self.assertIn("were not followed by a successful check execution", output)
+        self.assertIn("RESULT: FAILURES DETECTED", output)
+
+    def test_transport_error_followed_by_successful_checks_passes(self):
+        exit_code, output = self.report(
+            [
+                after_execution(errors=["ConnectionRefusedError: refused"]),
+                after_execution(
+                    checks=[SimpleNamespace(value=Status.success, message=None)]
+                ),
+                finished(passed=1, errored=1),
+            ]
+        )
+
+        self.assertEqual(0, exit_code)
+        self.assertIn("Passed: 1 | Failed: 0 | Errored: 0", output)
+        self.assertIn("ignored 1 recovered transient network error(s)", output)
+        self.assertIn("RESULT: ALL CHECKS PASSED", output)
+
+    def test_success_before_transport_error_does_not_prove_recovery(self):
+        exit_code, output = self.report(
+            [
+                after_execution(
+                    checks=[SimpleNamespace(value=Status.success, message=None)]
+                ),
+                after_execution(errors=["ConnectionRefusedError: refused"]),
+                finished(passed=1, errored=1),
+            ]
+        )
+
+        self.assertEqual(1, exit_code)
+        self.assertIn("were not followed by a successful check execution", output)
+        self.assertIn("RESULT: FAILURES DETECTED", output)
+
+    def test_zero_executions_fail(self):
+        exit_code, output = self.report([finished()])
+
+        self.assertEqual(1, exit_code)
+        self.assertIn("no successful check execution was observed", output)
+        self.assertIn("RESULT: FAILURES DETECTED", output)
+
+    def test_execution_without_checks_does_not_prove_success(self):
+        exit_code, output = self.report(
+            [after_execution(), finished(passed=1)]
+        )
+
+        self.assertEqual(1, exit_code)
+        self.assertIn("no successful check execution was observed", output)
+
+    def test_skipped_check_does_not_prove_success(self):
+        exit_code, output = self.report(
+            [
+                after_execution(
+                    checks=[SimpleNamespace(value=Status.skip, message=None)]
+                ),
+                finished(passed=1),
+            ]
+        )
+
+        self.assertEqual(1, exit_code)
+        self.assertIn("no successful check execution was observed", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

Schemathesis reporting now keeps transport failures pending until a later execution completes at least one real successful check. It no longer counts ignored transport errors as passed endpoints, and it fails when no successful check execution is observed. A focused unittest suite is part of the Schemathesis runner gate.

## Why

Jira: https://formance-team.atlassian.net/browse/EN-1974

The harness could report both unrecovered connection failures and an empty event stream as success, allowing a blocking conformance gate to pass without evidence that assertions ran.

## Product / operational motivation

N/A

## Technical decision

N/A

## Risk

**LOW** — the change is isolated to test-runner event accounting and preserves transient-error tolerance only when recovery is demonstrated.

## Validation

- [x] `AI_REVIEW_BASE_SHA=47ae5b0482d5c58ad70b1bebb72da23818d5d1a7 bash scripts/agent-check-pr`
- [x] Targeted tests: `PYTHONDONTWRITEBYTECODE=1 tests/schemathesis/.venv/bin/python -m unittest discover -s tests/schemathesis -p test_reporting.py -v`
- [x] Full Schemathesis gate: 62 endpoints, 61 passed, one recovered transport error, zero final failures/errors

## Architecture / behavior impact

N/A — no production, API, persistence, FSM, or compatibility behavior changes.

## Review focus

Please verify the event-order invariant: a network error is tolerated only when a later `Status.success` check proves recovery, and no-error/empty-check events do not constitute execution proof.

## Known concerns

None

## Bugfix evidence

DISCOVERY: NO_EXISTING_WORK
BEFORE_FIX: BUG_REPRODUCED
AFTER_FIX: PASS