### PR TITLE
fix(test): require verified model outcomes (EN-1975)

### DIFF
--- a/docs/technical/contributing/testing.md
+++ b/docs/technical/contributing/testing.md
@@ -506,7 +506,11 @@ tests/antithesis/run_model_test.sh --nodes 5 300
 
 Both targets call `tests/antithesis/run_model_test.sh`, which builds the server
 and driver and runs the checker. It exits non-zero on the first finding by
-default. Common tunables (full list in the script header):
+default. A successful run also requires at least one
+`singleton_driver_model: model outcome verified` assertion hit, emitted only
+after a definitive server outcome reaches model validation. Driver liveness,
+assertion registration, and ledger-setup assertions do not satisfy that gate.
+Common tunables (full list in the script header):
 
 | Variable | Meaning |
 |----------|---------|

--- a/tests/antithesis/run_model_test.sh
+++ b/tests/antithesis/run_model_test.sh
@@ -17,8 +17,9 @@
 #                transfer + follower restore.
 #
 # A "finding" is a failed antithesis assertion (a hit Unreachable, or an
-# Always/Sometimes whose condition was false), a server/driver panic, or (N>1)
-# the cluster failing to recover to N voters after a restart.
+# Always/Sometimes whose condition was false), no verified model outcome, a
+# server/driver panic, or (N>1) the cluster failing to recover to N voters after
+# a restart.
 #
 # Usage:
 #   ./run_model_test.sh [--nodes N | --cluster] [--restore] [DURATION_SECONDS]
@@ -368,6 +369,23 @@ check_fail_fast() {
 	[ -n "$ff" ]
 }
 
+# True (0) only after the driver has processed a definitive server outcome
+# through the model checker. Assertion registration and setup-only assertions
+# are deliberately insufficient: they prove the process started, not that the
+# conformance invariant ran.
+has_verified_model_outcome() {
+	[ -s "$ASSERTIONS" ] || return 1
+	if command -v jq >/dev/null 2>&1; then
+		jq -e 'select(.antithesis_assert.message == "singleton_driver_model: model outcome verified" and .antithesis_assert.hit == true and .antithesis_assert.condition == true)' \
+			"$ASSERTIONS" >/dev/null 2>&1
+		return
+	fi
+
+	grep -E '"message":[[:space:]]*"singleton_driver_model: model outcome verified"' "$ASSERTIONS" 2>/dev/null \
+		| grep -E '"hit":[[:space:]]*true' \
+		| grep -qE '"condition":[[:space:]]*true'
+}
+
 # ---------------------------------------------------------------------------
 # Build (server + driver; ledgerctl only when a cluster needs health checks).
 # ---------------------------------------------------------------------------
@@ -596,7 +614,18 @@ if [ "$DRIVER_EXITED_EARLY" -ne 0 ] && [ "$findings" -eq 0 ]; then
 	findings=$((findings + 1))
 fi
 
-# 6. --restore ran zero cycles: the restore path was never exercised, so a
+# 6. A live process and the absence of failed assertions do not prove that the
+# model checker processed an outcome. setupLedgers runs before Checker exists,
+# so registration-only or setup-only output must not satisfy this gate. Avoid
+# adding a second finding when an earlier failure already explains the run.
+if ! has_verified_model_outcome && [ "$findings" -eq 0 ]; then
+	echo
+	echo "NO VERIFIED MODEL OUTCOMES: the driver completed no model-conformance check"
+	echo "  (process liveness and setup assertions are not model-result evidence)"
+	findings=$((findings + 1))
+fi
+
+# 7. --restore ran zero cycles: the restore path was never exercised, so a
 # green run says nothing about RebuildDelta -- that vacuous pass is itself a
 # failure. Skipped when a finding already stopped the run early (fail-fast
 # legitimately preempts the first cycle).
@@ -607,7 +636,7 @@ if [ "$RESTORE" = 1 ] && [ "$RESTORE_CYCLES" -eq 0 ] && [ "$findings" -eq 0 ]; t
 	findings=$((findings + 1))
 fi
 
-# 7. A restore cycle failed mid-run (backup RPC, no exports, bootstrap, or the
+# 8. A restore cycle failed mid-run (backup RPC, no exports, bootstrap, or the
 # post-restore leader wait). The driver resumes so later cycles still run, but
 # a broken restore path is a defect regardless of how many cycles succeeded.
 if [ "$RESTORE" = 1 ] && [ "$RESTORE_FAILED_CYCLES" -gt 0 ]; then

--- a/tests/antithesis/run_model_test_test.go
+++ b/tests/antithesis/run_model_test_test.go
@@ -1,0 +1,169 @@
+package antithesis_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunModelTestRequiresVerifiedOutcome(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		scenario   string
+		wantPass   bool
+		wantOutput string
+	}{
+		{name: "driver blocked in first setup Apply", scenario: "blocked", wantOutput: "NO VERIFIED MODEL OUTCOMES"},
+		{name: "driver exits before deadline", scenario: "early-exit", wantOutput: "DRIVER EXITED EARLY"},
+		{name: "registration only", scenario: "registration-only", wantOutput: "NO VERIFIED MODEL OUTCOMES"},
+		{name: "setup assertions only", scenario: "setup-only", wantOutput: "NO VERIFIED MODEL OUTCOMES"},
+		{name: "output without verified hit", scenario: "unverified-output", wantOutput: "NO VERIFIED MODEL OUTCOMES"},
+		{name: "completed model result", scenario: "verified", wantPass: true, wantOutput: "RESULT: PASS"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			output, driverLog, err := runModelTestFixture(t, tt.scenario)
+			if tt.wantPass {
+				require.NoError(t, err, output)
+			} else {
+				require.Error(t, err, output)
+			}
+			require.Contains(t, output, tt.wantOutput)
+
+			if tt.scenario == "blocked" {
+				require.Contains(t, driverLog, "first setup Apply entered")
+				require.NotContains(t, driverLog, "first setup Apply completed")
+				require.NotContains(t, output, "driver exited early")
+			}
+		})
+	}
+}
+
+func runModelTestFixture(t *testing.T, scenario string) (string, string, error) {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	repoDir := filepath.Join(tempDir, "repo")
+	harnessDir := filepath.Join(tempDir, "harness")
+	binDir := filepath.Join(tempDir, "bin")
+	require.NoError(t, os.MkdirAll(repoDir, 0o755))
+	require.NoError(t, os.MkdirAll(filepath.Join(harnessDir, "tests", "antithesis", "workload"), 0o755))
+	require.NoError(t, os.MkdirAll(binDir, 0o755))
+
+	fakeGo := filepath.Join(binDir, "go")
+	fakeSeq := filepath.Join(binDir, "seq")
+	fakeServer := filepath.Join(tempDir, "fake-server")
+	fakeDriver := filepath.Join(tempDir, "fake-driver")
+	writeExecutable(t, fakeGo, `#!/bin/sh
+out=
+previous=
+for arg in "$@"; do
+	if [ "$previous" = "-o" ]; then out="$arg"; break; fi
+	previous="$arg"
+done
+case "$out" in
+	*/ledger-server) cp "$FAKE_SERVER_BIN" "$out" ;;
+	*/model-driver) cp "$FAKE_DRIVER_BIN" "$out" ;;
+	*) echo "unexpected fake go invocation: $*" >&2; exit 1 ;;
+esac
+chmod +x "$out"
+`)
+	writeExecutable(t, fakeSeq, `#!/bin/sh
+if [ "$#" -eq 2 ] && [ "$1" = "1" ] && [ "$2" = "0" ]; then exit 0; fi
+exec /usr/bin/seq "$@"
+`)
+	writeExecutable(t, fakeServer, `#!/bin/sh
+echo "Became leader"
+trap 'exit 0' TERM INT
+while :; do sleep 1; done
+`)
+	writeExecutable(t, fakeDriver, `#!/bin/sh
+write_assertion() {
+	printf '%s\n' "$1" >>"$ANTITHESIS_SDK_LOCAL_OUTPUT"
+}
+stay_alive() {
+	trap 'exit 0' TERM INT
+	while :; do sleep 1; done
+}
+case "$FAKE_MODEL_SCENARIO" in
+	blocked)
+		write_assertion '{"antithesis_assert":{"display_type":"Reachable","message":"singleton_driver_model: model outcome verified","condition":true,"hit":false}}'
+		echo "first setup Apply entered"
+		stay_alive
+		echo "first setup Apply completed"
+		;;
+	early-exit)
+		exit 0
+		;;
+	registration-only)
+		write_assertion '{"antithesis_assert":{"display_type":"Reachable","message":"singleton_driver_model: model outcome verified","condition":true,"hit":false}}'
+		stay_alive
+		;;
+	setup-only)
+		write_assertion '{"antithesis_assert":{"display_type":"Sometimes","message":"should be able to create ledger","condition":true,"hit":true}}'
+		write_assertion '{"antithesis_assert":{"display_type":"Sometimes","message":"should always be able to get created ledger","condition":true,"hit":true}}'
+		stay_alive
+		;;
+	unverified-output)
+		write_assertion '{"antithesis_assert":{"display_type":"Reachable","message":"singleton_driver_model: unrelated path exercised","condition":true,"hit":true}}'
+		write_assertion '{"antithesis_assert":{"display_type":"Reachable","message":"singleton_driver_model: model outcome verified","condition":true,"hit":false}}'
+		stay_alive
+		;;
+	verified)
+		write_assertion '{"antithesis_assert":{"display_type":"Reachable","message":"singleton_driver_model: model outcome verified","condition":true,"hit":true}}'
+		stay_alive
+		;;
+	*)
+		echo "unknown scenario: $FAKE_MODEL_SCENARIO" >&2
+		exit 2
+		;;
+esac
+`)
+
+	packageDir, err := os.Getwd()
+	require.NoError(t, err)
+	runner := filepath.Join(packageDir, "run_model_test.sh")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, runner, "2")
+	cmd.Env = append(os.Environ(),
+		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"IN_NIX_SHELL=1",
+		"KEEP_WORKDIR=1",
+		"TMPDIR="+tempDir,
+		"REPO="+repoDir,
+		"MODEL_HARNESS_REPO="+harnessDir,
+		"FAKE_SERVER_BIN="+fakeServer,
+		"FAKE_DRIVER_BIN="+fakeDriver,
+		"FAKE_MODEL_SCENARIO="+scenario,
+	)
+	combined, err := cmd.CombinedOutput()
+	require.NoError(t, ctx.Err(), string(combined))
+
+	workDirs, globErr := filepath.Glob(filepath.Join(tempDir, "model-test.*"))
+	require.NoError(t, globErr)
+	require.Len(t, workDirs, 1, string(combined))
+	driverLogPath := filepath.Join(workDirs[0], "driver.log")
+	require.FileExists(t, driverLogPath, string(combined))
+	driverLog, readErr := os.ReadFile(driverLogPath)
+	require.NoError(t, readErr, string(combined))
+
+	return string(combined), strings.TrimSpace(string(driverLog)), err
+}
+
+func writeExecutable(t *testing.T, path, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
+}

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/processor.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/processor.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 
+	"github.com/antithesishq/antithesis-sdk-go/assert"
+
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/tests/oracle"
 
@@ -101,6 +103,7 @@ func (c *Checker) handleObservation(obs observation) {
 		// high-water reproduces the observed error (validateFailure).
 		dbg("BULK ERR: ledgers=%s kinds=%s meta=%s err=%v", bulkLedgers(obs.bulk), requestKinds(obs.bulk), bulkMeta(obs.bulk), obs.err)
 		c.validateFailure(obs.observeTicket, obs.bulk, obs.err)
+		markModelOutcomeVerified()
 		return
 	}
 
@@ -108,6 +111,7 @@ func (c *Checker) handleObservation(obs observation) {
 	if minSeq == 0 {
 		// Success with no committed log is impossible under the model.
 		c.validateEmptyCommit(obs.bulk)
+		markModelOutcomeVerified()
 		return
 	}
 
@@ -131,7 +135,15 @@ func (c *Checker) tryDrain() {
 
 		c.pending = c.pending[1:]
 		c.validateBulkSuccess(head.obs.bulk, head.obs.resp)
+		markModelOutcomeVerified()
 	}
+}
+
+// markModelOutcomeVerified is the report-visible proof that a definitive
+// server result reached a model validation path. Keep this separate from setup
+// assertions: setup runs before Checker exists and cannot establish conformance.
+func markModelOutcomeVerified() {
+	assert.Reachable("singleton_driver_model: model outcome verified", internal.Details{})
 }
 
 // Inserts into c.pending, kept sorted ascending by minSeq. Caller holds c.mu.

--- a/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/setup_test.go
+++ b/tests/antithesis/workload/bin/cmds/model/singleton_driver_model/setup_test.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+)
+
+func TestSetupLedgersCanRemainBlockedBeforeFirstOutcome(t *testing.T) {
+	t.Parallel()
+
+	listener := bufconn.Listen(1024 * 1024)
+	server := grpc.NewServer()
+	applyEntered := make(chan struct{})
+	servicepb.RegisterBucketServiceServer(server, &blockingSetupServer{applyEntered: applyEntered})
+	go func() {
+		_ = server.Serve(listener) // Stop terminates Serve with an expected error.
+	}()
+	t.Cleanup(server.Stop)
+
+	dialCtx, cancelDial := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelDial()
+	conn, err := grpc.DialContext(dialCtx, "bufconn",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return listener.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	setupCtx, cancelSetup := context.WithCancel(context.Background())
+	setupDone := make(chan bool, 1)
+	go func() {
+		setupDone <- setupLedgers(setupCtx, servicepb.NewBucketServiceClient(conn), []string{"model-blocked-0"}, map[string][]*commonpb.SetMetadataFieldTypeCommand{})
+	}()
+
+	requireSignal(t, applyEntered, "first setup Apply was not entered")
+	select {
+	case result := <-setupDone:
+		t.Fatalf("setup returned %v before the blocked Apply was released", result)
+	default:
+	}
+
+	cancelSetup()
+	select {
+	case result := <-setupDone:
+		require.False(t, result)
+	case <-time.After(5 * time.Second):
+		t.Fatal("setup did not return after cancellation")
+	}
+}
+
+func requireSignal(t *testing.T, signal <-chan struct{}, message string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(5 * time.Second):
+		t.Fatal(message)
+	}
+}
+
+type blockingSetupServer struct {
+	servicepb.UnimplementedBucketServiceServer
+	applyEntered chan struct{}
+}
+
+func (s *blockingSetupServer) Apply(ctx context.Context, _ *servicepb.ApplyRequest) (*servicepb.ApplyResponse, error) {
+	close(s.applyEntered)
+	<-ctx.Done()
+	return nil, ctx.Err()
+}


### PR DESCRIPTION
## What changed

The model driver now emits a dedicated reachability assertion only after a definitive server outcome reaches model validation. The local runner requires a verified hit for that assertion before reporting success, so liveness, registration-only output, and setup-only output can no longer produce a vacuous pass.

A deterministic regression suite covers the stalled first-Apply path, premature exit, registration-only/setup-only/unverified output, and a completed-result control.

## Why

Fixes the confirmed audit finding tracked by [EN-1975](https://formance-team.atlassian.net/browse/EN-1975): a driver could remain alive while blocked before its first checked outcome and still receive `RESULT: PASS` at the shell deadline.

## Product / operational motivation

N/A (narrow test-harness correctness fix; no product or persisted-state decision).

## Technical decision

N/A

## Risk

**LOW** — changes are limited to model-test observability and the local model result gate; no production server behavior or model semantics change.

## Validation

- [x] `AI_REVIEW_BASE_SHA=47ae5b0482d5c58ad70b1bebb72da23818d5d1a7 bash scripts/agent-check-pr`
- [x] Targeted tests: `go test -race ./tests/antithesis -count=1`
- [x] Targeted tests: `cd tests/antithesis/workload && go test -race ./bin/cmds/model/singleton_driver_model -count=1`
- [x] Sensitivity: bypassing the new gate restores the old PASS and makes the stalled-driver regression fail
- [x] Real-driver control: 5-second single-node run emitted `hit:true`, `condition:true` for `singleton_driver_model: model outcome verified` and returned PASS

## Architecture / behavior impact

N/A — test harness only.

## Review focus

Confirm that the proof is emitted only after a definitive outcome reaches validation, and that the runner accepts only the exact verified hit.

## Known concerns

None


[EN-1975]: https://formance-team.atlassian.net/browse/EN-1975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ