### PR TITLE
fix(operator): run backup verifiers from owner module

### DIFF
--- a/misc/operator/e2e/tests/full-backup/chainsaw-test.yaml
+++ b/misc/operator/e2e/tests/full-backup/chainsaw-test.yaml
@@ -53,6 +53,9 @@ spec:
       try:
         - script:
             content: |
-              cd "$(git rev-parse --show-toplevel)"
-              go test -tags e2e -v -count=1 -run TestFullBackup_S3Objects -timeout 30s ./e2e/...
+              set -eu
+              cd "$(git rev-parse --show-toplevel)/misc/operator"
+              test_name=TestFullBackup_S3Objects
+              go test -tags e2e -count=1 -list "^${test_name}$" ./e2e/... | grep -Fqx "${test_name}"
+              go test -tags e2e -v -count=1 -run "^${test_name}$" -timeout 30s ./e2e/...
             timeout: 60s

--- a/misc/operator/e2e/tests/incremental-backup/chainsaw-test.yaml
+++ b/misc/operator/e2e/tests/incremental-backup/chainsaw-test.yaml
@@ -62,6 +62,9 @@ spec:
       try:
         - script:
             content: |
-              cd "$(git rev-parse --show-toplevel)"
-              go test -tags e2e -v -count=1 -run TestIncrementalBackup_S3Segments -timeout 30s ./e2e/...
+              set -eu
+              cd "$(git rev-parse --show-toplevel)/misc/operator"
+              test_name=TestIncrementalBackup_S3Segments
+              go test -tags e2e -count=1 -list "^${test_name}$" ./e2e/... | grep -Fqx "${test_name}"
+              go test -tags e2e -v -count=1 -run "^${test_name}$" -timeout 30s ./e2e/...
             timeout: 60s


### PR DESCRIPTION
## What changed

The full and incremental backup Chainsaw verifier steps now enter the nested `misc/operator` Go module that owns `./e2e/...`. Each step first requires exact discovery of its named verifier, then executes the same anchored test selector.

## Why

The previous scripts changed to the repository root and selected a package that does not exist there, so neither S3 verifier could run. Tracks [EN-1976](https://formance-team.atlassian.net/browse/EN-1976) and audit finding `test-reachability-enforcement/operator-backup-verifier-wrong-module`.

## Product / operational motivation

N/A — mechanical test-launcher correction.

## Technical decision

N/A

## Risk

**LOW** — the diff is limited to two Chainsaw script blocks; no production code, dependencies, or Chainsaw version changes.

## Validation

- [x] `AI_REVIEW_BASE_SHA=47ae5b0482d5c58ad70b1bebb72da23818d5d1a7 bash scripts/agent-check-pr`
- [x] Targeted tests: both corrected commands discovered and executed `TestFullBackup_S3Objects` and `TestIncrementalBackup_S3Segments` successfully against a local S3-compatible response
- [x] Sensitivity: nonexistent variants of both names were rejected by the discovery guard
- [ ] Full Kind/Chainsaw campaigns: Docker daemon unavailable locally; CI owns the broad clean run

## Architecture / behavior impact

N/A — test execution only.

## Review focus

Confirm that both scripts select the owning nested module and that the discovery guard cannot silently accept a missing test.

## Known concerns

Full Kind/Chainsaw campaigns were not run locally because Docker was unavailable. PR #1938 remains open and changes a different operator E2E scenario.

[EN-1976]: https://formance-team.atlassian.net/browse/EN-1976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ