### PR TITLE
feat(grpc)!: require a matching service protocol revision (EN-1851)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,19 @@ This file is the always-loaded entry point for AI agents working on Ledger v3. K
 - When removing protobuf fields, delete them and realign field numbers sequentially. The EN-1551 cleanup removed every existing `reserved` declaration from `misc/proto/`; do not reintroduce any.
 - Read `docs/technical/contributing/protobuf.md` before changing `.proto` files.
 
+### Service protocol revision — required during pre-release
+
+Every agent changing the service gRPC contract must assess compatibility and
+**increment `pkg/grpcprotocol.Version` by one in the same PR for an incompatible
+change**. This includes exposed protobuf field renumbering and changed request,
+response, or operation semantics even when no `.proto` file changes. Read the
+[protocol maintenance rules](docs/technical/architecture/subsystems/api/protocol-compatibility.md#maintaining-the-revision)
+before making such a change. Check the target branch again before publication
+or after a rebase: incompatible contracts must not reuse its revision. State the
+compatibility assessment and revision change (or why no increment is needed) in
+the PR. The counter lets testers detect an incompatible client immediately; it
+does not require supporting older Ledger versions or storage formats.
+
 ## Configuration safety checks
 
 Critical persisted configuration such as node/cluster identity and storage schema is validated on boot. Do not weaken or bypass those checks without an explicit task requiring it. Read `docs/ops/deployment.md` and the relevant `internal/bootstrap/**` code before changing persisted/config-validation behavior.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,16 +12,10 @@ This file is the always-loaded entry point for AI agents working on Ledger v3. K
 
 ### Service protocol revision — required during pre-release
 
-Every agent changing the service gRPC contract must assess compatibility and
-**increment `pkg/grpcprotocol.Version` by one in the same PR for an incompatible
-change**. This includes exposed protobuf field renumbering and changed request,
-response, or operation semantics even when no `.proto` file changes. Read the
+Every incompatible service gRPC contract change must increment
+`pkg/grpcprotocol.Version` in the same PR, including during pre-release. Read the
 [protocol maintenance rules](docs/technical/architecture/subsystems/api/protocol-compatibility.md#maintaining-the-revision)
-before making such a change. Check the target branch again before publication
-or after a rebase: incompatible contracts must not reuse its revision. State the
-compatibility assessment and revision change (or why no increment is needed) in
-the PR. The counter lets testers detect an incompatible client immediately; it
-does not require supporting older Ledger versions or storage formats.
+before modifying this contract.
 
 ## Configuration safety checks
 

--- a/cmd/ledgerctl/cmdutil/client.go
+++ b/cmd/ledgerctl/cmdutil/client.go
@@ -20,6 +20,7 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/clusterpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 	"github.com/formancehq/ledger/v3/pkg/actions"
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
 )
 
 const (
@@ -133,6 +134,7 @@ func GetClient(cmd *cobra.Command) (servicepb.BucketServiceClient, *grpc.ClientC
 	}
 
 	conn, err := grpc.NewClient(serverAddr,
+		grpcprotocol.ClientOption(),
 		grpc.WithTransportCredentials(creds),
 		grpc.WithDefaultServiceConfig(actions.GRPCRetryPolicy), // Retry on UNAVAILABLE (no leader) up to 50 times with 200ms delay (10s max)
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()),     // Emit a client span per RPC and propagate W3C trace context.
@@ -155,6 +157,7 @@ func GetClusterClient(cmd *cobra.Command) (clusterpb.ClusterServiceClient, *grpc
 	}
 
 	conn, err := grpc.NewClient(serverAddr,
+		grpcprotocol.ClientOption(),
 		grpc.WithTransportCredentials(creds),
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()), // Emit a client span per RPC and propagate W3C trace context.
 		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxRecvMsgSize)),

--- a/cmd/ledgerctl/cmdutil/client_protocol_test.go
+++ b/cmd/ledgerctl/cmdutil/client_protocol_test.go
@@ -1,0 +1,107 @@
+package cmdutil
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
+)
+
+// Exercise the production constructors, not ClientOption in isolation: both
+// command families must advertise their protocol on unary and streaming RPCs.
+func TestClientsAdvertiseProtocol(t *testing.T) {
+	t.Parallel()
+
+	constructors := map[string]func(*cobra.Command) (*grpc.ClientConn, error){
+		"bucket": func(cmd *cobra.Command) (*grpc.ClientConn, error) {
+			_, conn, err := GetClient(cmd)
+
+			return conn, err
+		},
+		"cluster": func(cmd *cobra.Command) (*grpc.ClientConn, error) {
+			_, conn, err := GetClusterClient(cmd)
+
+			return conn, err
+		},
+	}
+
+	for name, connect := range constructors {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			listener, err := net.Listen("tcp4", "127.0.0.1:0")
+			require.NoError(t, err)
+			server := grpc.NewServer(
+				grpc.UnaryInterceptor(func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+					md, _ := metadata.FromIncomingContext(ctx)
+					if err := grpc.SendHeader(ctx, protocolTestHeaders(md)); err != nil {
+						return nil, err
+					}
+
+					return handler(ctx, req)
+				}),
+				grpc.StreamInterceptor(func(srv any, stream grpc.ServerStream, _ *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+					md, _ := metadata.FromIncomingContext(stream.Context())
+					if err := stream.SendHeader(protocolTestHeaders(md)); err != nil {
+						return err
+					}
+
+					return handler(srv, stream)
+				}),
+			)
+			healthpb.RegisterHealthServer(server, health.NewServer())
+			go func() { _ = server.Serve(listener) }() // Stop closes the owned listener.
+			t.Cleanup(server.Stop)
+
+			cmd := newTLSFlagCommand()
+			cmd.Flags().String("server", listener.Addr().String(), "")
+			cmd.Flags().String("auth-token", "test-token", "")
+			cmd.Flags().String("consistency", "stale", "")
+			require.NoError(t, cmd.Flags().Set("insecure", "true"))
+			cmd.SetContext(context.Background())
+
+			conn, err := connect(cmd)
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, conn.Close()) })
+			ctx, cancel := GetContext(cmd)
+			defer cancel()
+			ctx, cancelDeadline := context.WithTimeout(ctx, 5*time.Second)
+			defer cancelDeadline()
+
+			client := healthpb.NewHealthClient(conn)
+			var unaryHeaders metadata.MD
+			_, err = client.Check(ctx, &healthpb.HealthCheckRequest{}, grpc.Header(&unaryHeaders))
+			require.NoError(t, err)
+
+			stream, err := client.Watch(ctx, &healthpb.HealthCheckRequest{})
+			require.NoError(t, err)
+			_, err = stream.Recv()
+			require.NoError(t, err)
+			streamHeaders, err := stream.Header()
+			require.NoError(t, err)
+
+			for _, headers := range []metadata.MD{unaryHeaders, streamHeaders} {
+				require.Equal(t, []string{grpcprotocol.Version}, headers.Get(grpcprotocol.MetadataKey))
+				require.Equal(t, []string{"Bearer test-token"}, headers.Get("authorization"))
+				require.Equal(t, []string{"stale"}, headers.Get("x-consistency"))
+			}
+		})
+	}
+}
+
+func protocolTestHeaders(md metadata.MD) metadata.MD {
+	return metadata.MD{
+		grpcprotocol.MetadataKey: md.Get(grpcprotocol.MetadataKey),
+		"authorization":          md.Get("authorization"),
+		"x-consistency":          md.Get("x-consistency"),
+	}
+}

--- a/cmd/ledgerctl/main.go
+++ b/cmd/ledgerctl/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/transactions"
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/upgrade"
 	"github.com/formancehq/ledger/v3/internal/pkg/version"
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
 )
 
 func main() {
@@ -275,7 +276,9 @@ func newVersionCommand() *cobra.Command {
 			pterm.Println(banner)
 
 			pterm.DefaultBox.WithTitle(pterm.LightGreen("Version Info")).
-				Println(pterm.Sprintf("%s %s", pterm.LightCyan("Version:"), pterm.Green(version.Get().Version)))
+				Println(pterm.Sprintf("%s %s\n%s %s",
+					pterm.LightCyan("Version:"), pterm.Green(version.Get().Version),
+					pterm.LightCyan("Protocol:"), pterm.Green(grpcprotocol.Version)))
 		},
 	}
 }

--- a/cmd/ledgerctl/restore/command.go
+++ b/cmd/ledgerctl/restore/command.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
 	"github.com/formancehq/ledger/v3/internal/proto/restorepb"
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
 )
 
 func NewCommand() *cobra.Command {
@@ -41,6 +42,7 @@ func getRestoreClient(cmd *cobra.Command) (restorepb.RestoreServiceClient, *grpc
 	}
 
 	conn, err := grpc.NewClient(serverAddr,
+		grpcprotocol.ClientOption(),
 		grpc.WithTransportCredentials(creds),
 		grpc.WithStatsHandler(otelgrpc.NewClientHandler()), // Emit a client span per RPC and propagate W3C trace context.
 	)

--- a/cmd/ledgerctl/restore/command_test.go
+++ b/cmd/ledgerctl/restore/command_test.go
@@ -1,0 +1,53 @@
+package restore
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
+)
+
+// Restore has its own connection constructor and must not depend on a
+// BucketService Discovery preflight: restore-mode servers do not expose it.
+func TestRestoreClientAdvertisesProtocol(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	server := grpc.NewServer(grpc.UnaryInterceptor(func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		md, _ := metadata.FromIncomingContext(ctx)
+		if err := grpc.SendHeader(ctx, metadata.MD{grpcprotocol.MetadataKey: md.Get(grpcprotocol.MetadataKey)}); err != nil {
+			return nil, err
+		}
+
+		return handler(ctx, req)
+	}))
+	healthpb.RegisterHealthServer(server, health.NewServer())
+	go func() { _ = server.Serve(listener) }() // Stop closes the owned listener.
+	t.Cleanup(server.Stop)
+
+	cmd := &cobra.Command{Use: "restore"}
+	cmd.Flags().String("server", listener.Addr().String(), "")
+	cmd.Flags().Bool("insecure", true, "")
+	cmd.Flags().String("tls-ca-cert", "", "")
+	cmd.Flags().String("tls-server-name", "", "")
+	_, conn, err := getRestoreClient(cmd)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var headers metadata.MD
+	_, err = healthpb.NewHealthClient(conn).Check(ctx, &healthpb.HealthCheckRequest{}, grpc.Header(&headers))
+	require.NoError(t, err)
+	require.Equal(t, []string{grpcprotocol.Version}, headers.Get(grpcprotocol.MetadataKey))
+}

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -16,7 +16,10 @@ Releases publish platform archives on
 - Linux/macOS: `ledger_linux-amd64.tar.gz`, `ledger_darwin-arm64.tar.gz`, and the corresponding architectures. These archives contain `ledger-server` and `ledgerctl`.
 - Windows: `ledger_windows-amd64.zip` and `ledger_windows-arm64.zip`. These archives contain `ledgerctl.exe` only.
 
-Extract the archive and put `ledgerctl` or `ledgerctl.exe` on your `PATH`. Once installed, `ledgerctl upgrade` keeps the CLI current.
+Extract the archive and put `ledgerctl` or `ledgerctl.exe` on your `PATH`. Prefer
+the CLI distributed with the deployed server build. `ledgerctl upgrade` selects
+the latest release in a channel, which may use a different protocol from that
+server.
 
 ### Build from source
 
@@ -26,6 +29,26 @@ just build-client
 # Or directly with Go
 go build -o build/ledgerctl ./cmd/ledgerctl
 ```
+
+## Server compatibility
+
+`ledgerctl` sends its compiled protocol revision on every gRPC call. The server
+blocks business RPCs when the revision is absent, invalid, or different, returning
+`FailedPrecondition` before executing the operation. This includes streaming and
+restore commands. There is no flag to bypass the check.
+
+Run `ledgerctl version` locally to see the CLI's protocol revision. In normal
+server mode, `GET /_info` and gRPC Discovery expose the server's `protocolVersion`.
+Discovery, gRPC health, and reflection are exempt from the gate. Restore mode has
+no Discovery service; a rejected restore call reports the required protocol
+revision and metadata key directly.
+
+On a mismatch, use the CLI distributed with the server or build a client that
+implements the same protocol. A newer release is not necessarily compatible with
+an older server. Release versions and commit IDs can differ when the protocol
+matches; source builds reporting `dev` still carry a defined protocol revision.
+See the [service protocol contract](../technical/architecture/subsystems/api/protocol-compatibility.md)
+for SDKs, custom gRPC clients, and internal forwarding.
 
 ## Global Flags
 
@@ -1833,7 +1856,10 @@ ledgerctl accounts aggregate-volumes --ledger my-ledger --json
 
 ### version
 
-Print version information for `ledgerctl`. Release builds report the real version (injected at link time via goreleaser ldflags into `internal/pkg/version`); a binary built without ldflags reports `dev`.
+Print version information and the local service protocol revision for `ledgerctl`
+without contacting a server. Release builds report the real version (injected at
+link time via goreleaser ldflags into `internal/pkg/version`); a binary built
+without ldflags reports `dev` but still reports its compiled protocol revision.
 
 ```bash
 ledgerctl version
@@ -1841,8 +1867,8 @@ ledgerctl version
 
 The **server** exposes the same build metadata over two unauthenticated channels:
 
-- **HTTP** — `GET /_info` returns flat JSON (no `data` envelope): `{"version":"…","commit":"…","buildDate":"…","goVersion":"…"}`.
-- **gRPC** — the `Discovery` RPC's `DiscoveryResponse` carries a `ServerInfo` message with the same fields.
+- **HTTP** — `GET /_info` returns flat JSON (no `data` envelope): `{"version":"…","commit":"…","buildDate":"…","goVersion":"…","protocolVersion":"1"}`.
+- **gRPC** — the `Discovery` RPC's `DiscoveryResponse` carries a `ServerInfo` message with the same information, including `protocol_version`.
 
 This is useful for monitoring deployed nodes and spotting version skew across a cluster (the per-node `version` is also surfaced on each `NodeInfo` in `GetClusterState`).
 
@@ -4825,6 +4851,10 @@ See [Event System Architecture](../technical/architecture/subsystems/events-mirr
 ### upgrade
 
 Self-update `ledgerctl` to the latest version from GitHub releases. Downloads the archive, verifies the SHA256 checksum, and replaces the installed binary.
+
+This command does not select a version matching a target server. If a business
+command reports a protocol mismatch, obtain the CLI distributed with that server
+build; upgrading to the channel's latest release can leave the mismatch in place.
 
 ```bash
 ledgerctl upgrade [flags]

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -4,6 +4,18 @@
 
 This document describes the different deployment methods for Ledger v3 POC, from local configuration to production deployment on Kubernetes.
 
+### Service protocol compatibility
+
+Deploy the server and `ledgerctl` from the same delivery, and update other gRPC
+service clients to declare the protocol they implement. Servers implementing
+EN-1851 reject business RPCs with a missing or different protocol revision.
+Servers predating EN-1851 do not enforce this gate: the new CLI sends a protocol
+declaration without a preflight, so it cannot protect calls to an older, ungated
+server. Different builds may communicate when they implement the same service
+protocol, but mixed wire-format rolling upgrades are not guaranteed. See the
+[service protocol contract](../technical/architecture/subsystems/api/protocol-compatibility.md)
+for scope and failure behavior.
+
 ## Local Deployment
 
 ### Prerequisites

--- a/docs/technical/architecture/subsystems/api/README.md
+++ b/docs/technical/architecture/subsystems/api/README.md
@@ -8,6 +8,7 @@ Client-facing transport layers (`internal/adapter/grpc`, `internal/adapter/http`
 |----------|-------------|
 | [grpc-api.md](grpc-api.md) | gRPC service, methods, request/response types, and client examples. |
 | [grpc-connections.md](grpc-connections.md) | gRPC connection mechanics, reconnection, and rolling deployment optimizations. |
+| [protocol-compatibility.md](protocol-compatibility.md) | Mandatory service protocol revision, client/server rejection behavior, diagnostics, and revision maintenance (EN-1851). |
 | [http-api.md](http-api.md) | HTTP REST API endpoints, response formats, and error handling. |
 | [auth.md](auth.md) | Client JWT authentication (OIDC + Ed25519), scope-based authorization, and the Raft inter-node cluster-secret auth layer. |
 

--- a/docs/technical/architecture/subsystems/api/grpc-api.md
+++ b/docs/technical/architecture/subsystems/api/grpc-api.md
@@ -24,11 +24,13 @@ The gRPC service server listens on port `8888` by default (configurable via `--g
 import (
     "google.golang.org/grpc"
     "google.golang.org/grpc/credentials/insecure"
-    "github.com/formancehq/ledger/internal/proto/servicepb"
+    "github.com/formancehq/ledger/v3/internal/proto/servicepb"
+    "github.com/formancehq/ledger/v3/pkg/grpcprotocol"
 )
 
 conn, err := grpc.NewClient(
     "localhost:8888",
+    grpcprotocol.ClientOption(),
     grpc.WithTransportCredentials(insecure.NewCredentials()),
 )
 if err != nil {
@@ -38,6 +40,13 @@ defer conn.Close()
 
 client := servicepb.NewBucketServiceClient(conn)
 ```
+
+Every business RPC must declare the client's compiled service protocol revision.
+`grpcprotocol.ClientOption()` supplies it on each unary and streaming call;
+omitting it causes `FailedPrecondition` on servers enforcing EN-1851. Other
+clients must send the revision they implement as `ledger-protocol-version`
+metadata. See [service protocol compatibility](protocol-compatibility.md) for
+diagnostic exemptions, revision maintenance, and adoption scope.
 
 ## Service Definition
 

--- a/docs/technical/architecture/subsystems/api/protocol-compatibility.md
+++ b/docs/technical/architecture/subsystems/api/protocol-compatibility.md
@@ -90,12 +90,23 @@ their own contracts.
 
 The author of a service contract change must determine whether an existing
 client or server would interpret requests, responses, or operations differently.
-Bump `pkg/grpcprotocol.Version` in the same change for an incompatible wire or
-semantic change, and rebuild every service client and server that will
-communicate. This includes renumbering or changing the interpretation of exposed
+Increment the decimal counter `pkg/grpcprotocol.Version` by one in the same PR
+for an incompatible wire or semantic change (for example, `"1"` to `"2"`), and
+rebuild every service client and server that will communicate. This includes
+renumbering or changing the interpretation of exposed
 protobuf fields, and incompatible semantics even when the `.proto` text stays
 unchanged. Reviewers must check this classification; the revision is not inferred
 from a release tag or automatically negotiated from a schema hash.
+
+This obligation applies to AI agents throughout pre-release development, even
+though older Ledger versions and storage formats are not supported. Before
+publication, and again after a rebase or target-branch update, compare the
+revision with the target branch. If another PR has already consumed the planned
+number, increment from the target branch's current value so a newly incompatible
+contract does not reuse that number. Keep examples of the current revision in
+sync. State the compatibility assessment and the old/new revision in the PR;
+when no increment is needed, explain why. Documentation-only changes do not
+increment the counter.
 
 Compatible additions need not bump the revision only when both directions remain
 compatible under the declared service contract. A change confined to a persisted

--- a/docs/technical/architecture/subsystems/api/protocol-compatibility.md
+++ b/docs/technical/architecture/subsystems/api/protocol-compatibility.md
@@ -1,0 +1,117 @@
+# Service gRPC protocol compatibility
+
+## Requirement and decision (EN-1851)
+
+[EN-1851](https://formance-team.atlassian.net/browse/EN-1851) requires detecting
+an incompatible `ledgerctl` before it executes a business operation. Ledger v3
+is unreleased: its protobuf fields may be renumbered between development
+revisions, and a mismatched request can decode with a different meaning rather
+than fail to decode. Build versions and commit IDs do not establish protocol
+compatibility.
+
+The approved decision is to **block requests with a different or missing
+protocol revision**, using a revision independent of the software release.
+Each server supports exactly one revision. There is no negotiation, historical
+format support, or bypass flag. An advisory warning would not enforce the
+requirement; exact commit matching would also reject builds whose service
+contract has not changed. Release SemVer does not currently encode the
+compatibility of development revisions.
+
+## Wire contract and failure behavior
+
+`pkg/grpcprotocol.Version` is the compiled service protocol revision, currently
+`"1"`. `pkg/grpcprotocol.MetadataKey` is `ledger-protocol-version`. Clients send
+exactly one value for this metadata key on every RPC. The Go
+`grpcprotocol.ClientOption()` dial option supplies the local revision for unary
+and streaming calls. Local `dev` builds carry the same constant without release
+ldflags.
+
+The ServiceServer checks the metadata before invoking service handlers,
+including `BucketService`, `ClusterService`, and `RestoreService`. Missing,
+invalid, duplicate, or different values return gRPC `FailedPrecondition` with a
+diagnostic identifying the required revision and metadata key. The error does
+not echo client-controlled metadata. No business handler
+runs on rejection. Repeating the request with the same client does not fix this
+failure: install or build a client implementing the server's protocol.
+
+The check is per RPC, including stream establishment; a prior discovery result
+is not authorization for subsequent calls. A connection or backend change does
+not reuse a successful compatibility handshake. gRPC's generated unary handler
+decodes the request before entering interceptors, so malformed protobuf can
+return a decoding error before the compatibility diagnostic. The business
+handler still does not execute.
+
+`BucketService.Discovery`, gRPC health, and server reflection are exempt so
+clients can diagnose a mismatch. Discovery's `ServerInfo.protocol_version`
+and HTTP `GET /_info`'s `protocolVersion` report the server revision.
+`ledgerctl version` reports the local revision without connecting to a server.
+Restore mode does not register Discovery: its service gate provides the
+compatibility error without requiring a preliminary Discovery call, while
+health and reflection remain exempt.
+
+## Client and deployment scope
+
+Enforcement starts with servers implementing EN-1851: they reject old clients
+that omit the declaration. Servers predating this gate ignore the new metadata.
+The new CLI sends its declaration but performs no compatibility preflight, so
+it cannot protect an operation sent to an older, ungated server. Adopt the
+updated server and CLI together, and update other service clients as part of
+that deployment. This is not a guarantee of compatibility with historical
+servers or support for mixed wire-format upgrades.
+
+Every consumer of the service gRPC endpoint must declare its protocol,
+including SDKs, automation, `grpcurl`, and internal requests forwarded to a
+leader. For example, with a schema implementing revision 1:
+
+```bash
+grpcurl -plaintext -H 'ledger-protocol-version: 1' \
+  localhost:8888 cluster.ClusterService.GetClusterState
+```
+
+Use the revision implemented by the client schema and semantics. Merely copying
+the server's advertised value into an incompatible client defeats the check;
+metadata is a compatibility declaration, not authentication. JWT, TLS,
+authorization, and request-signature requirements still apply independently.
+
+The CLI distributed with the server build is a straightforward way to obtain a
+matching client. Different software releases or commits may also work when they
+implement the same protocol revision. `ledgerctl upgrade` selects the latest
+release in its channel, which may not match the deployed server; it is not a
+server-specific compatibility repair.
+
+HTTP consumers do not send this gRPC metadata. Internal forwarding from HTTP
+uses the server's service client and is subject to the same gate at the peer.
+Nodes with different service revisions can therefore fail forwarded requests;
+this mechanism does not establish support for mixed-version clusters or rolling
+wire-format upgrades. The separate Raft transport and snapshot server retain
+their own contracts.
+
+## Maintaining the revision
+
+The author of a service contract change must determine whether an existing
+client or server would interpret requests, responses, or operations differently.
+Bump `pkg/grpcprotocol.Version` in the same change for an incompatible wire or
+semantic change, and rebuild every service client and server that will
+communicate. This includes renumbering or changing the interpretation of exposed
+protobuf fields, and incompatible semantics even when the `.proto` text stays
+unchanged. Reviewers must check this classification; the revision is not inferred
+from a release tag or automatically negotiated from a schema hash.
+
+Compatible additions need not bump the revision only when both directions remain
+compatible under the declared service contract. A change confined to a persisted
+or Raft message does not automatically change the service protocol; inspect any
+shared types exposed through the service API. See
+[protobuf contributor rules](../../../contributing/protobuf.md).
+
+The gate is a transport admission check. Its metadata and revision are not
+persisted, included in audited business intent, or consulted during Raft apply.
+It introduces no storage migration or incremental-restore state. It does not
+validate whether a backup's persisted format matches the restore binary.
+
+## Validation contract
+
+Tests must prove that missing, malformed, duplicate, and different revisions
+cannot enter unary or streaming business handlers, while the matching revision
+does. Keep diagnostic exemptions usable without a revision. Exercise the real
+client/server paths, restoration without Discovery, and internal service
+forwarding so the gate cannot make the repository's own clients incompatible.

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -10,6 +10,24 @@ This document compares the POC's API with the original Formance ledger API and d
 
 ## Summary
 
+### Service protocol compatibility (EN-1851)
+
+The v3 gRPC service requires one `ledger-protocol-version` metadata value per
+business RPC, equal to `pkg/grpcprotocol.Version` (currently `"1"`). Missing,
+invalid, duplicate, or different revisions fail with `FailedPrecondition` before
+business handler execution. This applies to unary and streaming Bucket, Cluster,
+and Restore operations, including internal forwarding. Discovery, gRPC health,
+and reflection remain available without this declaration. This is independent
+of release SemVer and commits; there is no legacy negotiation or bypass.
+
+Discovery's `ServerInfo.protocol_version` and the flat JSON response from
+`GET /_info` (`protocolVersion`) expose the server revision. HTTP callers do not
+need gRPC metadata. The gate does not version the HTTP API or Raft/storage
+formats. See [the service protocol contract](../architecture/subsystems/api/protocol-compatibility.md)
+for client setup, restore behavior, failure limitations, and revision changes.
+
+### Feature comparison
+
 | Feature | POC | Original | Notes |
 |---------|-----|----------|-------|
 | **Transactions (Write)** |

--- a/docs/technical/contributing/protobuf.md
+++ b/docs/technical/contributing/protobuf.md
@@ -59,6 +59,17 @@ go install github.com/planetscale/vtprotobuf/cmd/protoc-gen-go-vtproto@v0.6.1-0.
 
 ## Modifying Protocol Definitions
 
+The service API has a compiled protocol revision independent of release versions.
+For every exposed wire or semantic change, assess client/server compatibility and
+bump `pkg/grpcprotocol.Version` in the same change when the contract breaks.
+Renumbering exposed fields is a breaking change even if the generated code still
+compiles. Internal persisted/Raft-only changes require an impact assessment of
+shared service types rather than an automatic service revision bump. See the
+[service protocol contract](../architecture/subsystems/api/protocol-compatibility.md)
+for the gate, client obligations, and review criteria. This does not change the
+unreleased-v3 rule: remove obsolete fields and realign their numbers; do not add
+migrations, reserved fields, or support for older v3 formats.
+
 1. Edit the `.proto` file in `misc/proto/`
 2. **Realign field numbers sequentially** when adding/removing fields (no gaps, remove obsolete `reserved` entries)
 3. **Audit the hand-rolled wire sites** before renumbering — see below

--- a/internal/adapter/grpc/protocol_interceptor.go
+++ b/internal/adapter/grpc/protocol_interceptor.go
@@ -1,0 +1,58 @@
+package grpc
+
+import (
+	"context"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
+)
+
+// checkProtocolVersion gates the service listener only, not Raft transport.
+// Discovery, health and reflection remain available to incompatible clients.
+// There is no authenticated-client bypass: internal forwarding also declares
+// the protocol of the binary encoding the forwarded request.
+func checkProtocolVersion(ctx context.Context, method string) error {
+	if method == servicepb.BucketService_Discovery_FullMethodName ||
+		strings.HasPrefix(method, "/grpc.health.v1.Health/") ||
+		strings.HasPrefix(method, "/grpc.reflection.v1.ServerReflection/") ||
+		strings.HasPrefix(method, "/grpc.reflection.v1alpha.ServerReflection/") {
+		return nil
+	}
+
+	md, _ := metadata.FromIncomingContext(ctx)
+	versions := md.Get(grpcprotocol.MetadataKey)
+	if len(versions) == 1 && versions[0] == grpcprotocol.Version {
+		return nil
+	}
+
+	// Do not echo unbounded, client-controlled metadata into the status message.
+	return status.Errorf(codes.FailedPrecondition,
+		"incompatible Ledger gRPC protocol: missing, invalid or unsupported version; required %s=%s; use a client built for this protocol (the ledgerctl shipped with the server)",
+		grpcprotocol.MetadataKey, grpcprotocol.Version)
+}
+
+func protocolVersionInterceptor() grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if err := checkProtocolVersion(ctx, info.FullMethod); err != nil {
+			return nil, err
+		}
+
+		return handler(ctx, req)
+	}
+}
+
+func protocolVersionStreamInterceptor() grpc.StreamServerInterceptor {
+	return func(srv any, stream grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if err := checkProtocolVersion(stream.Context(), info.FullMethod); err != nil {
+			return err
+		}
+
+		return handler(srv, stream)
+	}
+}

--- a/internal/adapter/grpc/protocol_interceptor_test.go
+++ b/internal/adapter/grpc/protocol_interceptor_test.go
@@ -1,0 +1,139 @@
+package grpc
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+	reflectionpb "google.golang.org/grpc/reflection/grpc_reflection_v1"
+	"google.golang.org/grpc/status"
+
+	"github.com/formancehq/ledger/v3/internal/proto/clusterpb"
+	"github.com/formancehq/ledger/v3/internal/proto/restorepb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
+)
+
+// Drive the real ServiceServer chain. Generated unimplemented handlers return
+// a distinct status when reached; rejected calls must never reach them.
+func TestServiceServerProtocolVersion(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv, err := NewServiceServer("", 0, noopLogger{}, false, time.Second, nil, true, WithListener(listener))
+	require.NoError(t, err)
+	servicepb.RegisterBucketServiceServer(srv.GetServer(), &servicepb.UnimplementedBucketServiceServer{})
+	clusterpb.RegisterClusterServiceServer(srv.GetServer(), &clusterpb.UnimplementedClusterServiceServer{})
+	restorepb.RegisterRestoreServiceServer(srv.GetServer(), &restorepb.UnimplementedRestoreServiceServer{})
+	healthpb.RegisterHealthServer(srv.GetServer(), health.NewServer())
+	require.NoError(t, srv.Listen())
+	go func() {
+		_ = srv.Serve() // Stop below terminates the listener.
+	}()
+	t.Cleanup(func() { require.NoError(t, srv.Stop()) })
+
+	conn, err := grpc.NewClient(listener.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	calls := []struct {
+		name string
+		call func(context.Context) error
+	}{
+		{"apply", func(ctx context.Context) error {
+			_, err := servicepb.NewBucketServiceClient(conn).Apply(ctx, &servicepb.ApplyRequest{})
+
+			return err
+		}},
+		{"list", func(ctx context.Context) error {
+			stream, err := servicepb.NewBucketServiceClient(conn).ListLedgers(ctx, &servicepb.ListLedgersRequest{})
+			if err != nil {
+				return err
+			}
+			_, err = stream.Recv()
+
+			return err
+		}},
+		{"cluster", func(ctx context.Context) error {
+			_, err := clusterpb.NewClusterServiceClient(conn).GetClusterState(ctx, &clusterpb.GetClusterStateRequest{})
+
+			return err
+		}},
+		{"restore", func(ctx context.Context) error {
+			_, err := restorepb.NewRestoreServiceClient(conn).FinalizeRestore(ctx, &restorepb.FinalizeRestoreRequest{})
+
+			return err
+		}},
+		{"restore-stream", func(ctx context.Context) error {
+			stream, err := restorepb.NewRestoreServiceClient(conn).ValidateRestore(ctx, &restorepb.ValidateRestoreRequest{})
+			if err != nil {
+				return err
+			}
+			_, err = stream.Recv()
+
+			return err
+		}},
+	}
+
+	for _, call := range calls {
+		t.Run(call.name, func(t *testing.T) {
+			t.Parallel()
+			for _, tc := range []struct {
+				name     string
+				versions []string
+			}{
+				{"missing", nil},
+				{"empty", []string{""}},
+				{"older", []string{"0"}},
+				{"newer", []string{"2"}},
+				{"invalid", []string{"dev"}},
+				{"duplicate", []string{grpcprotocol.Version, grpcprotocol.Version}},
+				{"conflicting", []string{grpcprotocol.Version, "0"}},
+				{"matching", []string{grpcprotocol.Version}},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					t.Parallel()
+					ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+					defer cancel()
+					ctx = metadata.NewOutgoingContext(ctx, metadata.MD{grpcprotocol.MetadataKey: tc.versions})
+					err := call.call(ctx)
+					if tc.name == "matching" {
+						require.Equal(t, codes.Unimplemented, status.Code(err), "matching protocol must reach the handler")
+
+						return
+					}
+					require.Equal(t, codes.FailedPrecondition, status.Code(err))
+					require.Contains(t, err.Error(), "incompatible Ledger gRPC protocol")
+					require.Contains(t, err.Error(), grpcprotocol.MetadataKey+"="+grpcprotocol.Version)
+				})
+			}
+		})
+	}
+
+	t.Run("diagnostics-without-version", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		defer cancel()
+		_, err := healthpb.NewHealthClient(conn).Check(ctx, &healthpb.HealthCheckRequest{})
+		require.NoError(t, err)
+		_, err = servicepb.NewBucketServiceClient(conn).Discovery(ctx, &servicepb.DiscoveryRequest{})
+		require.Equal(t, codes.Unimplemented, status.Code(err), "Discovery must reach its handler without version metadata")
+		reflection, err := reflectionpb.NewServerReflectionClient(conn).ServerReflectionInfo(ctx)
+		require.NoError(t, err)
+		require.NoError(t, reflection.Send(&reflectionpb.ServerReflectionRequest{
+			MessageRequest: &reflectionpb.ServerReflectionRequest_ListServices{ListServices: ""},
+		}))
+		services, err := reflection.Recv()
+		require.NoError(t, err)
+		require.NotEmpty(t, services.GetListServicesResponse().GetService())
+	})
+}

--- a/internal/adapter/grpc/server.go
+++ b/internal/adapter/grpc/server.go
@@ -854,6 +854,7 @@ func NewServiceServer(host string, port int, logger logging.Logger, debug bool, 
 		consistencyInterceptor(),
 		loggingInterceptor(logger, slowThreshold),
 		errorConversionInterceptor(logger),
+		protocolVersionInterceptor(),
 	}
 	streamInterceptors := []ggrpc.StreamServerInterceptor{
 		recoveryStreamInterceptor(logger),
@@ -861,6 +862,7 @@ func NewServiceServer(host string, port int, logger logging.Logger, debug bool, 
 		consistencyStreamInterceptor(),
 		loggingStreamInterceptor(logger, slowThreshold),
 		errorConversionStreamInterceptor(logger),
+		protocolVersionStreamInterceptor(),
 	}
 
 	serverOpts := []ggrpc.ServerOption{

--- a/internal/adapter/grpc/server_bucket.go
+++ b/internal/adapter/grpc/server_bucket.go
@@ -38,6 +38,7 @@ import (
 	"github.com/formancehq/ledger/v3/internal/query"
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
 )
 
 var bucketTracer = otel.Tracer("grpc.bucket")
@@ -1464,10 +1465,11 @@ func (impl *BucketServiceServerImpl) Barrier(ctx context.Context, _ *servicepb.B
 func (impl *BucketServiceServerImpl) Discovery(_ context.Context, _ *servicepb.DiscoveryRequest) (*servicepb.DiscoveryResponse, error) {
 	resp := &servicepb.DiscoveryResponse{
 		ServerInfo: &servicepb.ServerInfo{
-			Version:   impl.info.Version,
-			Commit:    impl.info.Commit,
-			BuildDate: impl.info.BuildDate,
-			GoVersion: impl.info.GoVersion,
+			Version:         impl.info.Version,
+			Commit:          impl.info.Commit,
+			BuildDate:       impl.info.BuildDate,
+			GoVersion:       impl.info.GoVersion,
+			ProtocolVersion: grpcprotocol.Version,
 		},
 	}
 	if impl.responseSigner != nil {

--- a/internal/adapter/grpc/server_info_test.go
+++ b/internal/adapter/grpc/server_info_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/formancehq/ledger/v3/internal/pkg/version"
 	"github.com/formancehq/ledger/v3/internal/proto/clusterpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
 )
 
 func TestDiscoveryReturnsServerInfo(t *testing.T) {
@@ -30,6 +31,7 @@ func TestDiscoveryReturnsServerInfo(t *testing.T) {
 	require.Equal(t, "abc1234", resp.GetServerInfo().GetCommit())
 	require.Equal(t, "2026-06-19T00:00:00Z", resp.GetServerInfo().GetBuildDate())
 	require.Equal(t, "go1.24", resp.GetServerInfo().GetGoVersion())
+	require.Equal(t, grpcprotocol.Version, resp.GetServerInfo().GetProtocolVersion())
 }
 
 func TestGetClusterStateMapsPeerVersion(t *testing.T) {

--- a/internal/adapter/http/handlers_info.go
+++ b/internal/adapter/http/handlers_info.go
@@ -5,15 +5,17 @@ import (
 	"net/http"
 
 	"github.com/formancehq/ledger/v3/internal/pkg/version"
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
 )
 
 // infoResponse is the flat JSON body of GET /_info (camelCase, unwrapped to
 // match the platform _info convention).
 type infoResponse struct {
-	Version   string `json:"version"`
-	Commit    string `json:"commit"`
-	BuildDate string `json:"buildDate"`
-	GoVersion string `json:"goVersion"`
+	Version         string `json:"version"`
+	Commit          string `json:"commit"`
+	BuildDate       string `json:"buildDate"`
+	GoVersion       string `json:"goVersion"`
+	ProtocolVersion string `json:"protocolVersion"`
 }
 
 // infoHandler returns an unauthenticated handler reporting the server build
@@ -25,10 +27,11 @@ func infoHandler(info version.Info) http.HandlerFunc {
 		// best-effort: status 200 + Content-Type are already written, so there
 		// is nothing actionable to do on an encode failure of this static payload.
 		_ = json.NewEncoder(w).Encode(infoResponse{
-			Version:   info.Version,
-			Commit:    info.Commit,
-			BuildDate: info.BuildDate,
-			GoVersion: info.GoVersion,
+			Version:         info.Version,
+			Commit:          info.Commit,
+			BuildDate:       info.BuildDate,
+			GoVersion:       info.GoVersion,
+			ProtocolVersion: grpcprotocol.Version,
 		})
 	}
 }

--- a/internal/adapter/http/handlers_info_test.go
+++ b/internal/adapter/http/handlers_info_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/formancehq/ledger/v3/internal/pkg/version"
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
 )
 
 func TestInfoHandler(t *testing.T) {
@@ -33,6 +34,7 @@ func TestInfoHandler(t *testing.T) {
 	require.Equal(t, "abc1234", got["commit"])
 	require.Equal(t, "2026-06-19T00:00:00Z", got["buildDate"])
 	require.Equal(t, "go1.24", got["goVersion"])
+	require.Equal(t, grpcprotocol.Version, got["protocolVersion"])
 	_, wrapped := got["data"]
 	require.False(t, wrapped)
 }

--- a/internal/infra/transport/connection_pool.go
+++ b/internal/infra/transport/connection_pool.go
@@ -17,6 +17,8 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/encoding/gzip"
+
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
 )
 
 const (
@@ -110,6 +112,7 @@ func BearerTokenDialOption(token string) grpc.DialOption {
 // dialOptions returns the common gRPC dial options derived from PoolConfig.
 func dialOptions(creds credentials.TransportCredentials, cfg PoolConfig) []grpc.DialOption {
 	opts := []grpc.DialOption{
+		grpcprotocol.ClientOption(),
 		grpc.WithTransportCredentials(creds),
 		// NOTE: BackoffMaxDelay must stay below the election timeout.
 		grpc.WithConnectParams(grpc.ConnectParams{

--- a/internal/infra/transport/connection_pool_protocol_test.go
+++ b/internal/infra/transport/connection_pool_protocol_test.go
@@ -1,0 +1,54 @@
+package transport
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
+)
+
+// Service forwarding uses this pool for both Bucket and Cluster RPCs. Its
+// protocol credentials must coexist with the cluster-secret credentials.
+func TestConnectionPoolAdvertisesProtocolWithBearerToken(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	server := grpc.NewServer(grpc.UnaryInterceptor(func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		md, _ := metadata.FromIncomingContext(ctx)
+		headers := metadata.MD{
+			grpcprotocol.MetadataKey: md.Get(grpcprotocol.MetadataKey),
+			"authorization":          md.Get("authorization"),
+		}
+		if err := grpc.SendHeader(ctx, headers); err != nil {
+			return nil, err
+		}
+
+		return handler(ctx, req)
+	}))
+	healthpb.RegisterHealthServer(server, health.NewServer())
+	go func() { _ = server.Serve(listener) }() // Stop closes the owned listener.
+	t.Cleanup(server.Stop)
+
+	pool := NewConnectionPool(TLSPolicy{}, PoolConfig{AuthToken: "test-cluster-secret"})
+	t.Cleanup(func() { require.NoError(t, pool.Close()) })
+	require.NoError(t, pool.AddPeer(1, listener.Addr().String()))
+	conn := pool.GetConnection(1)
+	require.NotNil(t, conn)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	var headers metadata.MD
+	_, err = healthpb.NewHealthClient(conn).Check(ctx, &healthpb.HealthCheckRequest{}, grpc.Header(&headers))
+	require.NoError(t, err)
+	require.Equal(t, []string{grpcprotocol.Version}, headers.Get(grpcprotocol.MetadataKey))
+	require.Equal(t, []string{"Bearer test-cluster-secret"}, headers.Get("authorization"))
+}

--- a/internal/proto/servicepb/bucket.pb.go
+++ b/internal/proto/servicepb/bucket.pb.go
@@ -3124,13 +3124,14 @@ func (*DiscoveryRequest) Descriptor() ([]byte, []int) {
 
 // ServerInfo carries the server build metadata (unauthenticated).
 type ServerInfo struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Version       string                 `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`                      // semver / git tag (e.g. v3.1.0), "dev" if unset
-	Commit        string                 `protobuf:"bytes,2,opt,name=commit,proto3" json:"commit,omitempty"`                        // git SHA, "unknown" if unset
-	BuildDate     string                 `protobuf:"bytes,3,opt,name=build_date,json=buildDate,proto3" json:"build_date,omitempty"` // RFC3339, "unknown" if unset
-	GoVersion     string                 `protobuf:"bytes,4,opt,name=go_version,json=goVersion,proto3" json:"go_version,omitempty"` // runtime Go version
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Version         string                 `protobuf:"bytes,1,opt,name=version,proto3" json:"version,omitempty"`                                        // semver / git tag (e.g. v3.1.0), "dev" if unset
+	Commit          string                 `protobuf:"bytes,2,opt,name=commit,proto3" json:"commit,omitempty"`                                          // git SHA, "unknown" if unset
+	BuildDate       string                 `protobuf:"bytes,3,opt,name=build_date,json=buildDate,proto3" json:"build_date,omitempty"`                   // RFC3339, "unknown" if unset
+	GoVersion       string                 `protobuf:"bytes,4,opt,name=go_version,json=goVersion,proto3" json:"go_version,omitempty"`                   // runtime Go version
+	ProtocolVersion string                 `protobuf:"bytes,5,opt,name=protocol_version,json=protocolVersion,proto3" json:"protocol_version,omitempty"` // Required ledger-protocol-version RPC metadata
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
 }
 
 func (x *ServerInfo) Reset() {
@@ -3187,6 +3188,13 @@ func (x *ServerInfo) GetBuildDate() string {
 func (x *ServerInfo) GetGoVersion() string {
 	if x != nil {
 		return x.GoVersion
+	}
+	return ""
+}
+
+func (x *ServerInfo) GetProtocolVersion() string {
+	if x != nil {
+		return x.ProtocolVersion
 	}
 	return ""
 }
@@ -8991,7 +8999,7 @@ const file_bucket_proto_rawDesc = "" +
 	"!SetQueryCheckpointScheduleRequest\x12\x12\n" +
 	"\x04cron\x18\x01 \x01(\tR\x04cron\"&\n" +
 	"$DeleteQueryCheckpointScheduleRequest\"\x12\n" +
-	"\x10DiscoveryRequest\"|\n" +
+	"\x10DiscoveryRequest\"\xa7\x01\n" +
 	"\n" +
 	"ServerInfo\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\x16\n" +
@@ -8999,7 +9007,8 @@ const file_bucket_proto_rawDesc = "" +
 	"\n" +
 	"build_date\x18\x03 \x01(\tR\tbuildDate\x12\x1d\n" +
 	"\n" +
-	"go_version\x18\x04 \x01(\tR\tgoVersion\"\x90\x01\n" +
+	"go_version\x18\x04 \x01(\tR\tgoVersion\x12)\n" +
+	"\x10protocol_version\x18\x05 \x01(\tR\x0fprotocolVersion\"\x90\x01\n" +
 	"\x11DiscoveryResponse\x12F\n" +
 	"\x10response_signing\x18\x01 \x01(\v2\x1b.ledger.ResponseSigningInfoR\x0fresponseSigning\x123\n" +
 	"\vserver_info\x18\x02 \x01(\v2\x12.ledger.ServerInfoR\n" +

--- a/internal/proto/servicepb/bucket_reader.pb.go
+++ b/internal/proto/servicepb/bucket_reader.pb.go
@@ -3085,6 +3085,7 @@ type ServerInfoReader interface {
 	GetCommit() string
 	GetBuildDate() string
 	GetGoVersion() string
+	GetProtocolVersion() string
 	Mutate() *ServerInfo
 }
 
@@ -3104,6 +3105,10 @@ func (r *serverInfoReadonly) GetBuildDate() string {
 
 func (r *serverInfoReadonly) GetGoVersion() string {
 	return (*ServerInfo)(r).GetGoVersion()
+}
+
+func (r *serverInfoReadonly) GetProtocolVersion() string {
+	return (*ServerInfo)(r).GetProtocolVersion()
 }
 
 func (r *serverInfoReadonly) Mutate() *ServerInfo {

--- a/internal/proto/servicepb/bucket_vtproto.pb.go
+++ b/internal/proto/servicepb/bucket_vtproto.pb.go
@@ -1085,6 +1085,7 @@ func (m *ServerInfo) CloneVT() *ServerInfo {
 	r.Commit = m.Commit
 	r.BuildDate = m.BuildDate
 	r.GoVersion = m.GoVersion
+	r.ProtocolVersion = m.ProtocolVersion
 	if len(m.unknownFields) > 0 {
 		r.unknownFields = make([]byte, len(m.unknownFields))
 		copy(r.unknownFields, m.unknownFields)
@@ -4784,6 +4785,9 @@ func (this *ServerInfo) EqualVT(that *ServerInfo) bool {
 		return false
 	}
 	if this.GoVersion != that.GoVersion {
+		return false
+	}
+	if this.ProtocolVersion != that.ProtocolVersion {
 		return false
 	}
 	return string(this.unknownFields) == string(that.unknownFields)
@@ -10404,6 +10408,13 @@ func (m *ServerInfo) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	if m.unknownFields != nil {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
+	}
+	if len(m.ProtocolVersion) > 0 {
+		i -= len(m.ProtocolVersion)
+		copy(dAtA[i:], m.ProtocolVersion)
+		i = protohelpers.EncodeVarint(dAtA, i, uint64(len(m.ProtocolVersion)))
+		i--
+		dAtA[i] = 0x2a
 	}
 	if len(m.GoVersion) > 0 {
 		i -= len(m.GoVersion)
@@ -16604,6 +16615,10 @@ func (m *ServerInfo) SizeVT() (n int) {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
 	l = len(m.GoVersion)
+	if l > 0 {
+		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
+	}
+	l = len(m.ProtocolVersion)
 	if l > 0 {
 		n += 1 + l + protohelpers.SizeOfVarint(uint64(l))
 	}
@@ -24692,6 +24707,38 @@ func (m *ServerInfo) UnmarshalVT(dAtA []byte) error {
 				return io.ErrUnexpectedEOF
 			}
 			m.GoVersion = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 5:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field ProtocolVersion", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return protohelpers.ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return protohelpers.ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.ProtocolVersion = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
 		default:
 			iNdEx = preIndex

--- a/misc/pg-import/main.go
+++ b/misc/pg-import/main.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
 )
 
 func main() {
@@ -89,7 +90,7 @@ func run() error {
 		creds = credentials.NewTLS(&tls.Config{MinVersion: tls.VersionTLS12})
 	}
 
-	dialOpts := []grpc.DialOption{grpc.WithTransportCredentials(creds)}
+	dialOpts := []grpc.DialOption{grpcprotocol.ClientOption(), grpc.WithTransportCredentials(creds)}
 	if *authToken != "" {
 		dialOpts = append(dialOpts,
 			grpc.WithUnaryInterceptor(bearerInterceptor(*authToken)),

--- a/misc/proto/bucket.proto
+++ b/misc/proto/bucket.proto
@@ -445,6 +445,7 @@ message ServerInfo {
   string commit = 2;      // git SHA, "unknown" if unset
   string build_date = 3;  // RFC3339, "unknown" if unset
   string go_version = 4;  // runtime Go version
+  string protocol_version = 5; // Required ledger-protocol-version RPC metadata
 }
 
 message DiscoveryResponse {

--- a/openapi.yml
+++ b/openapi.yml
@@ -5304,6 +5304,7 @@ components:
         - commit
         - buildDate
         - goVersion
+        - protocolVersion
       properties:
         version:
           type: string
@@ -5317,6 +5318,9 @@ components:
         goVersion:
           type: string
           description: Go runtime version the binary was built with
+        protocolVersion:
+          type: string
+          description: Required ledger-protocol-version metadata on Ledger gRPC business RPCs; independent of the release version
 
     SegmentType:
       type: object

--- a/pkg/grpcprotocol/protocol.go
+++ b/pkg/grpcprotocol/protocol.go
@@ -1,0 +1,36 @@
+// Package grpcprotocol identifies the client-facing Ledger gRPC contract.
+// It is independent of release versions and is required on every business RPC.
+package grpcprotocol
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+const (
+	// Version must change when the client-facing wire format or semantics break.
+	// See docs/technical/architecture/subsystems/api/protocol-compatibility.md.
+	// A compiled constant also identifies local builds without release ldflags.
+	Version = "1"
+	// MetadataKey carries the protocol version, not authentication credentials.
+	MetadataKey = "ledger-protocol-version"
+)
+
+// ClientOption declares this client's protocol on every unary and streaming
+// RPC, including retries and calls made after the connection changes backend.
+// Other clients must send MetadataKey with their own supported version.
+func ClientOption() grpc.DialOption {
+	return grpc.WithPerRPCCredentials(protocolCredentials{})
+}
+
+type protocolCredentials struct{}
+
+func (protocolCredentials) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
+	return map[string]string{MetadataKey: Version}, nil
+}
+
+func (protocolCredentials) RequireTransportSecurity() bool {
+	// The version is public metadata; plaintext deployments remain supported.
+	return false
+}

--- a/tests/antithesis/workload/internal/client.go
+++ b/tests/antithesis/workload/internal/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/antithesishq/antithesis-sdk-go/assert"
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -79,6 +80,7 @@ func NewGRPCConn() (*grpc.ClientConn, error) {
 
 	addrs := strings.Split(target, ",")
 	opts := []grpc.DialOption{
+		grpcprotocol.ClientOption(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultServiceConfig(serviceConfig),
 	}

--- a/tests/antithesis/workload/internal/pernode.go
+++ b/tests/antithesis/workload/internal/pernode.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/formancehq/ledger/v3/internal/proto/clusterpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
 )
 
 // metadataKeyConsistency mirrors internal/adapter/grpc/consistency.go: the
@@ -109,6 +110,7 @@ func DialPerNode(ctx context.Context) (PerNodeConns, error) {
 	}`
 
 	opts := []grpc.DialOption{
+		grpcprotocol.ClientOption(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultServiceConfig(serviceConfig),
 		grpc.WithUnaryInterceptor(retryUnaryInterceptor(retryMaxAttempts)),

--- a/tests/e2e/cluster/ledgerctl_tls_bearer_test.go
+++ b/tests/e2e/cluster/ledgerctl_tls_bearer_test.go
@@ -21,6 +21,7 @@ import (
 
 	cmdserver "github.com/formancehq/ledger/v3/cmd/server"
 	"github.com/formancehq/ledger/v3/internal/proto/clusterpb"
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
 	"github.com/formancehq/ledger/v3/pkg/testserver"
 	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
 )
@@ -98,6 +99,7 @@ var _ = Describe("ledgerctl TLS bearer against tls-mode=required", Ordered, func
 		}
 		addr := fmt.Sprintf("localhost:%d", ports.GRPC())
 		conn, err := grpc.NewClient(addr,
+			grpcprotocol.ClientOption(),
 			grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg)),
 		)
 		Expect(err).To(Succeed())

--- a/tests/e2e/cluster/protocol_version_test.go
+++ b/tests/e2e/cluster/protocol_version_test.go
@@ -1,0 +1,149 @@
+//go:build e2e
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/formancehq/ledger/v3/internal/proto/clusterpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
+	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func expectProtocolRejection(err error) {
+	GinkgoHelper()
+	Expect(status.Code(err)).To(Equal(codes.FailedPrecondition))
+	Expect(status.Convert(err).Message()).To(ContainSubstring("incompatible Ledger gRPC protocol"))
+}
+
+var _ = Describe("gRPC protocol version", Ordered, func() {
+	var (
+		clusterCtx context.Context
+		ctx        context.Context
+		servers    []*testutil.ServiceWithClient
+		leaderID   *uint64
+		rawConn    *grpc.ClientConn
+		rawClient  servicepb.BucketServiceClient
+		leader     *testutil.ServiceWithClient
+	)
+
+	BeforeAll(func() {
+		clusterCtx, servers, _, leaderID = testutil.SetupMultiNodeCluster(3)
+		leader = servers[*leaderID-1]
+		// Deliberately omit grpcprotocol.ClientOption to represent an old client.
+		var err error
+		rawConn, err = grpc.NewClient(fmt.Sprintf("localhost:%d", leader.GRPCPort),
+			grpc.WithTransportCredentials(insecure.NewCredentials()))
+		Expect(err).To(Succeed())
+		DeferCleanup(func() { Expect(rawConn.Close()).To(Succeed()) })
+		rawClient = servicepb.NewBucketServiceClient(rawConn)
+	})
+
+	AfterAll(func() {
+		// Stop nodes before the helper's deferred directory cleanup runs.
+		testutil.StopServers(context.Background(), servers)
+	})
+
+	BeforeEach(func() {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(clusterCtx, 10*time.Second)
+		DeferCleanup(cancel)
+	})
+
+	DescribeTable("rejects incompatible writes before creating a ledger", func(name string, versions []string) {
+		requestCtx := ctx
+		if versions != nil {
+			requestCtx = metadata.NewOutgoingContext(ctx, metadata.MD{grpcprotocol.MetadataKey: versions})
+		}
+		ledgerName := "protocol-" + name
+		req := servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledgerName, nil))
+		_, err := rawClient.Apply(requestCtx, req)
+		expectProtocolRejection(err)
+
+		// A real, valid write must leave no business effect when refused.
+		_, err = leader.Client.GetLedger(ctx, &servicepb.GetLedgerRequest{Ledger: ledgerName})
+		Expect(status.Code(err)).To(Equal(codes.NotFound))
+
+		// Submit the identical payload with the supported protocol and observe it.
+		resp, err := leader.Client.Apply(ctx, req)
+		Expect(err).To(Succeed())
+		Expect(resp.Logs).To(HaveLen(1))
+		ledgerInfo, err := leader.Client.GetLedger(ctx, &servicepb.GetLedgerRequest{Ledger: ledgerName})
+		Expect(err).To(Succeed())
+		Expect(ledgerInfo.Name).To(Equal(ledgerName))
+	},
+		Entry("without protocol metadata", "missing", []string(nil)),
+		Entry("with a different protocol", "different", []string{"0"}),
+		Entry("with an invalid protocol", "invalid", []string{"dev"}),
+		Entry("with duplicate protocol metadata", "duplicate", []string{grpcprotocol.Version, grpcprotocol.Version}),
+	)
+
+	It("checks each stream and Cluster RPC while allowing diagnostic RPCs", func() {
+		info, err := rawClient.Discovery(ctx, &servicepb.DiscoveryRequest{})
+		Expect(err).To(Succeed())
+		Expect(info.GetServerInfo().GetProtocolVersion()).To(Equal(grpcprotocol.Version))
+		// Health can report NOT_SERVING while projections warm up. The contract
+		// here is that the diagnostic RPC remains callable without a revision.
+		_, err = grpc_health_v1.NewHealthClient(rawConn).Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+		Expect(err).To(Succeed())
+
+		// Successful discovery on this connection does not authorize later RPCs.
+		_, err = clusterpb.NewClusterServiceClient(rawConn).GetClusterState(ctx, &clusterpb.GetClusterStateRequest{})
+		expectProtocolRejection(err)
+		stream, err := rawClient.ListLedgers(ctx, &servicepb.ListLedgersRequest{})
+		if err == nil {
+			_, err = stream.Recv()
+		}
+		expectProtocolRejection(err)
+
+		_, err = leader.Client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction("protocol-stream", nil)))
+		Expect(err).To(Succeed())
+		ledgers, err := actions.ListLedgers(ctx, leader.Client)
+		Expect(err).To(Succeed())
+		Expect(ledgers).To(HaveKey("protocol-stream"))
+		state, err := leader.ClusterClient.GetClusterState(ctx, &clusterpb.GetClusterStateRequest{})
+		Expect(err).To(Succeed())
+		Expect(state.Nodes).To(HaveLen(3))
+	})
+
+	It("forwards an HTTP write from a follower with the server's protocol version", func() {
+		currentLeaderID := *leaderID
+		follower := servers[currentLeaderID%uint64(len(servers))]
+		Expect(uint64(follower.NodeID)).NotTo(Equal(currentLeaderID))
+		state, err := follower.ClusterClient.GetClusterState(ctx, &clusterpb.GetClusterStateRequest{})
+		Expect(err).To(Succeed())
+		Expect(uint64(state.Leader)).To(Equal(currentLeaderID))
+
+		const ledgerName = "protocol-http-forwarding"
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+			fmt.Sprintf("http://localhost:%d/v3/%s", follower.HTTPPort, ledgerName), nil)
+		Expect(err).To(Succeed())
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).To(Succeed())
+		defer func() { Expect(resp.Body.Close()).To(Succeed()) }()
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).To(Succeed())
+		Expect(resp.StatusCode).To(Equal(http.StatusCreated), string(body))
+
+		ledgerInfo, err := servers[currentLeaderID-1].Client.GetLedger(ctx, &servicepb.GetLedgerRequest{Ledger: ledgerName})
+		Expect(err).To(Succeed())
+		Expect(ledgerInfo.Name).To(Equal(ledgerName))
+		state, err = follower.ClusterClient.GetClusterState(ctx, &clusterpb.GetClusterStateRequest{})
+		Expect(err).To(Succeed())
+		Expect(uint64(state.Leader)).To(Equal(currentLeaderID), "the request must have used the follower-to-leader path")
+	})
+})

--- a/tests/e2e/cluster/restore_protocol_version_test.go
+++ b/tests/e2e/cluster/restore_protocol_version_test.go
@@ -1,0 +1,79 @@
+//go:build e2e
+
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	"github.com/formancehq/go-libs/v5/pkg/testing/testservice"
+	cmdserver "github.com/formancehq/ledger/v3/cmd/server"
+	"github.com/formancehq/ledger/v3/internal/proto/restorepb"
+	"github.com/formancehq/ledger/v3/pkg/testserver"
+	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+)
+
+var _ = Describe("Restore gRPC protocol version", func() {
+	It("rejects old unary and streaming clients in restore mode while accepting the supported protocol", func() {
+		ctx, cancel := context.WithTimeout(logging.TestingContext(), 30*time.Second)
+		defer cancel()
+		lease := testserver.AllocateNodeLease()
+		ports := lease.Ports()
+		instruments := testserver.DefaultTestInstruments(testserver.TestNodeConfig{
+			NodeID:    1,
+			ClusterID: "test-cluster",
+			Ports:     ports,
+			WalDir:    GinkgoT().TempDir(),
+			DataDir:   GinkgoT().TempDir(),
+			Debug:     testutil.Debug,
+			Output:    GinkgoWriter,
+		})
+		instruments = append(instruments, testserver.WithRestore())
+		server := lease.NewService(cmdserver.NewRunCommandWithBindings,
+			testservice.WithInstruments(instruments...))
+		Expect(server.Start(ctx)).To(Succeed())
+		DeferCleanup(func() {
+			stopCtx, stopCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer stopCancel()
+			Expect(server.Stop(stopCtx)).To(Succeed())
+		})
+
+		// No discovery handshake or protocol metadata, as with an old ledgerctl.
+		rawConn, err := grpc.NewClient(fmt.Sprintf("localhost:%d", ports.GRPC()),
+			grpc.WithTransportCredentials(insecure.NewCredentials()))
+		Expect(err).To(Succeed())
+		DeferCleanup(func() { Expect(rawConn.Close()).To(Succeed()) })
+		rawClient := restorepb.NewRestoreServiceClient(rawConn)
+
+		_, err = grpc_health_v1.NewHealthClient(rawConn).Check(ctx, &grpc_health_v1.HealthCheckRequest{})
+		Expect(err).To(Succeed())
+		_, err = rawClient.FinalizeRestore(ctx, &restorepb.FinalizeRestoreRequest{})
+		expectProtocolRejection(err)
+		stream, err := rawClient.ValidateRestore(ctx, &restorepb.ValidateRestoreRequest{})
+		if err == nil {
+			_, err = stream.Recv()
+		}
+		expectProtocolRejection(err)
+
+		// The same lookup must reach restore business validation with the current
+		// client; no object store or populated backup is needed to prove routing.
+		req := &restorepb.GetDownloadStatusRequest{JobId: "not-started"}
+		_, err = rawClient.GetDownloadStatus(ctx, req)
+		expectProtocolRejection(err)
+		_, _, matchingConn, err := testutil.NewGRPCClient(ports.GRPC())
+		Expect(err).To(Succeed())
+		DeferCleanup(func() { Expect(matchingConn.Close()).To(Succeed()) })
+		_, err = restorepb.NewRestoreServiceClient(matchingConn).GetDownloadStatus(ctx, req)
+		Expect(status.Code(err)).To(Equal(codes.NotFound))
+		Expect(status.Convert(err).Message()).To(Equal("unknown job id"))
+	})
+})

--- a/tests/e2e/cluster/restore_test.go
+++ b/tests/e2e/cluster/restore_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/restorepb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 	"github.com/formancehq/ledger/v3/pkg/actions"
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
 	"github.com/formancehq/ledger/v3/pkg/testserver"
 	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
 	. "github.com/onsi/ginkgo/v2"
@@ -73,6 +74,7 @@ func readS3Manifest(ctx context.Context, client *s3.Client) (*backup.Manifest, e
 func newRestoreGRPCClient(grpcPort int) (restorepb.RestoreServiceClient, *grpc.ClientConn, error) {
 	conn, err := grpc.NewClient(
 		fmt.Sprintf("localhost:%d", grpcPort),
+		grpcprotocol.ClientOption(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	if err != nil {

--- a/tests/e2e/cluster/tls_test.go
+++ b/tests/e2e/cluster/tls_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 	"github.com/formancehq/ledger/v3/pkg/actions"
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
 	"github.com/formancehq/ledger/v3/pkg/testserver"
 	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
 	. "github.com/onsi/ginkgo/v2"
@@ -46,6 +47,7 @@ func newTLSGRPCClient(grpcPort int, caCertFile string) (servicepb.BucketServiceC
 
 	conn, err := grpc.NewClient(
 		fmt.Sprintf("localhost:%d", grpcPort),
+		grpcprotocol.ClientOption(),
 		grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg)),
 		grpc.WithDefaultServiceConfig(actions.GRPCRetryPolicy),
 	)
@@ -299,6 +301,7 @@ var _ = Describe("TLS", Ordered, func() {
 			// Create an insecure gRPC client (no TLS)
 			conn, err := grpc.NewClient(
 				fmt.Sprintf("localhost:%d", ports.GRPC()),
+				grpcprotocol.ClientOption(),
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 			)
 			Expect(err).To(Succeed())
@@ -318,6 +321,7 @@ var _ = Describe("TLS", Ordered, func() {
 
 			conn, err := grpc.NewClient(
 				fmt.Sprintf("localhost:%d", ports.GRPC()),
+				grpcprotocol.ClientOption(),
 				grpc.WithTransportCredentials(credentials.NewTLS(tlsCfg)),
 			)
 			Expect(err).To(Succeed())

--- a/tests/e2e/testutil/server.go
+++ b/tests/e2e/testutil/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/clusterpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 	"github.com/formancehq/ledger/v3/pkg/actions"
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
 	"github.com/formancehq/ledger/v3/pkg/testserver"
 )
 
@@ -50,6 +51,7 @@ func NewGRPCClient(grpcPort int) (servicepb.BucketServiceClient, clusterpb.Clust
 // NewGRPCClientWithRetry creates a new gRPC client with optional retry policy.
 func NewGRPCClientWithRetry(grpcPort int, withRetry bool, extraDialOptions ...grpc.DialOption) (servicepb.BucketServiceClient, clusterpb.ClusterServiceClient, *grpc.ClientConn, error) {
 	opts := []grpc.DialOption{
+		grpcprotocol.ClientOption(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	}
 

--- a/tests/scenarios/scenariotest/scenariotest.go
+++ b/tests/scenarios/scenariotest/scenariotest.go
@@ -16,6 +16,7 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/clusterpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 	"github.com/formancehq/ledger/v3/pkg/actions"
+	"github.com/formancehq/ledger/v3/pkg/grpcprotocol"
 	"github.com/formancehq/ledger/v3/pkg/testserver"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -91,6 +92,7 @@ func (sc *ScenarioCluster) startServer() {
 
 	conn, err := grpc.NewClient(
 		fmt.Sprintf("localhost:%d", sc.lease.Ports().GRPC()),
+		grpcprotocol.ClientOption(),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 		grpc.WithDefaultServiceConfig(actions.GRPCRetryPolicy),
 	)


### PR DESCRIPTION
## What changed

The service gRPC listener now rejects business RPCs with a missing or different `ledger-protocol-version` using `FailedPrecondition`. The compiled protocol revision starts at `1` and is independent of the release version; repository clients declare it on every unary and streaming RPC.

Discovery, health and reflection remain available for diagnosis. Discovery and `GET /_info` expose the server revision, and `ledgerctl version` displays the local revision offline.

`AGENTS.md` keeps a short mandatory rule: increment the service protocol revision for incompatible changes, including during pre-release, and read the linked maintenance contract. The detailed increment, rebase and PR-reporting rules live in that subsystem document. This detects mismatches without introducing support for older Ledger versions or storage formats.

## Why

[EN-1851](https://formance-team.atlassian.net/browse/EN-1851): an outdated CLI could previously execute requests against an incompatible v3 service contract. A protobuf mismatch can decode successfully with a different meaning, so build metadata alone does not prevent an unsafe operation.

## Product / operational motivation

An incompatible client must be rejected before a business handler executes. The approved policy is blocking with a distinct protocol revision. The durable contract, adoption requirements and revision maintenance rules are in `docs/technical/architecture/subsystems/api/protocol-compatibility.md`.

## Technical decision

Require exactly one matching revision on every business RPC, including streams, restore mode and internal service forwarding. There is no negotiation or bypass. A warning would not enforce rejection; exact commit matching would reject compatible builds; release versions do not describe development protocol compatibility.

Client credentials attach the compiled revision to each call, so retries and backend changes do not rely on a cached handshake. This is a compatibility declaration, not authentication.

## Risk

**MEDIUM** — this intentionally breaks service clients that omit the metadata. Initial deployment must update the server, CLI, SDKs and automation together. Subsequent incompatible wire or semantic changes require a manual protocol revision bump.

## Validation

- [x] `bash scripts/agent-check`.
- [x] Exact-base normalization and lint: zero diagnostics and no unrelated generated changes.
- [x] Targeted adapter, HTTP info, CLI constructor, restore constructor and connection-pool tests.
- [x] Seven focused E2E scenarios: rejected requests have no ledger effect; matching requests succeed; diagnostics remain accessible; HTTP forwarding and restore mode work.
- [x] Mutation check: removing both server interceptor registrations makes the protocol regression test fail; restoring them passes.
- [x] `AI_REVIEW_BASE_SHA=4967afe4b8ab9382d485660290bba61401a3c05a bash scripts/agent-check-pr`: PASS, including full root race tests, business/cluster E2E, financial scenarios and Schemathesis. The conformity runner reported no failures and one recovered transient network error.
- [x] `go test ./...` in `tests/antithesis/workload`: PASS.

The full implementation validation and independent source review above apply to `03e4c06ea52ebd7d2acdc354c6838907f60a851e`, against base `4967afe4b8ab9382d485660290bba61401a3c05a`. Both documentation follow-ups passed their incremental `agent-check-pr` gates (generation, lint, baseline and tooling tests); runtime and protocol revision `1` are unchanged.

Current candidate: `9bb551dd6b3ea28fd9cc3327d4fefb253422c44c`, rebased onto `7994e8c567508ef78ffd43b90824c502d0e90344` (`release/v3.0`). Rebase was conflict-free and `git range-diff` confirms all three patches are identical. Independent review approved this exact candidate with no findings. Exact-base `agent-check-pr` passed generation, lint and baseline, then failed the pre-existing shell-runner fixture `TestRunModelTestRequiresVerifiedOutcome/driver_exits_before_deadline`: it reported `NO VERIFIED MODEL OUTCOMES` instead of the expected early-exit diagnostic. This fixture uses fake executables and does not exercise the gRPC protocol. Its unchanged targeted race rerun passed, followed by a successful complete canonical `agent-check-pr` rerun on the same head and exact base: root race tests, business/cluster E2E, scenarios and Schemathesis all passed. Schemathesis reported zero failures and one recovered transient network error. The initial failure log is retained; no test assertion or timeout was changed. NumaryBot, Shipfox and Paul approved the current head; all applicable GitHub checks passed. Shipfox's test-scaffolding duplication suggestion is explicitly non-blocking.

## Architecture / behavior impact

Admission changes on the service listener only. The separate Raft transport policy, persisted state, audit payloads and deterministic FSM are unchanged. HTTP clients do not send protocol metadata; the server's forwarding client does. OpenAPI and operational/contributor documentation are updated.

## Review focus

Check the diagnostic exemptions, coverage of service client constructors, and the adoption/version-bump contract. Rejection tests exercise unary and streaming handlers with missing, empty, invalid, duplicate and mismatched declarations.

## Known concerns

Servers predating this gate ignore the new metadata; the new CLI has no preflight protection against those servers. Adopt the gate and its clients together. Mixed wire-format rolling upgrades are not supported by this mechanism.

Generated unary gRPC handlers decode before interceptors: malformed protobuf may produce a decoding error before the compatibility diagnostic, but cannot reach a business handler without a matching revision.


[EN-1851]: https://formance-team.atlassian.net/browse/EN-1851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
