### PR TITLE
fix(api)!: redact internal diagnostics and align telemetry (EN-1623)

### DIFF
--- a/cmd/server/otlplogs.go
+++ b/cmd/server/otlplogs.go
@@ -37,6 +37,7 @@ func addOtlpLogsFlags(flags *flag.FlagSet) {
 // Keep go-libs' resource attribute precedence, including explicit overrides of
 // service.name and service.version through --otel-resource-attributes.
 func resourceFromFlags(cmd *cobra.Command, nodeID uint64, info version.Info) (*resource.Resource, error) {
+	// addOtlpLogsFlags registers this flag with its string type before use.
 	serviceName, _ := cmd.Flags().GetString(otlp.OtelServiceNameFlag)
 	if serviceName == "" {
 		serviceName = fmt.Sprintf("ledger-node-%d", nodeID)
@@ -44,6 +45,7 @@ func resourceFromFlags(cmd *cobra.Command, nodeID uint64, info version.Info) (*r
 			return nil, fmt.Errorf("setting default service name: %w", err)
 		}
 	}
+	// addOtlpLogsFlags registers this flag with its string-slice type before use.
 	attributes, _ := cmd.Flags().GetStringSlice(otlp.OtelResourceAttributesFlag)
 
 	return otlp.BuildResource(serviceName, attributes, fmt.Sprintf("%s-%s", info.Version, info.Commit))

--- a/cmd/server/otlplogs.go
+++ b/cmd/server/otlplogs.go
@@ -1,14 +1,18 @@
 package server
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 	flag "github.com/spf13/pflag"
+	"go.opentelemetry.io/otel/sdk/resource"
 
 	otlp "github.com/formancehq/go-libs/v5/pkg/observe"
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 	"github.com/formancehq/go-libs/v5/pkg/service"
 
 	"github.com/formancehq/ledger/v3/internal/infra/monitoring/otlplogs"
+	"github.com/formancehq/ledger/v3/internal/pkg/version"
 )
 
 const (
@@ -29,7 +33,23 @@ func addOtlpLogsFlags(flags *flag.FlagSet) {
 	flags.String(LogLevelFlag, "", "Log level (error|info|debug|trace). Overrides --debug when set. Trace is stdout-only and never exported via OTLP.")
 }
 
-func loggerFromFlags(cmd *cobra.Command, defaultFields map[string]any) (logging.Logger, error) {
+// resourceFromFlags builds the resource shared by logs, traces, and metrics.
+// Keep go-libs' resource attribute precedence, including explicit overrides of
+// service.name and service.version through --otel-resource-attributes.
+func resourceFromFlags(cmd *cobra.Command, nodeID uint64, info version.Info) (*resource.Resource, error) {
+	serviceName, _ := cmd.Flags().GetString(otlp.OtelServiceNameFlag)
+	if serviceName == "" {
+		serviceName = fmt.Sprintf("ledger-node-%d", nodeID)
+		if err := cmd.Flags().Set(otlp.OtelServiceNameFlag, serviceName); err != nil {
+			return nil, fmt.Errorf("setting default service name: %w", err)
+		}
+	}
+	attributes, _ := cmd.Flags().GetStringSlice(otlp.OtelResourceAttributesFlag)
+
+	return otlp.BuildResource(serviceName, attributes, fmt.Sprintf("%s-%s", info.Version, info.Commit))
+}
+
+func loggerFromFlags(cmd *cobra.Command, defaultFields map[string]any, res *resource.Resource) (logging.Logger, error) {
 	exporter, _ := cmd.Flags().GetString(OtelLogsExporterFlag)
 	jsonFormatting, _ := cmd.Flags().GetBool(logging.JsonFormattingLoggerFlag)
 
@@ -40,6 +60,7 @@ func loggerFromFlags(cmd *cobra.Command, defaultFields map[string]any) (logging.
 
 	return otlplogs.Logger(otlplogs.ModuleConfig{
 		Exporter: exporter,
+		Resource: res,
 		OTLPConfig: func() *otlplogs.OTLPConfig {
 			if exporter != otlplogs.OTLPExporter {
 				return nil

--- a/cmd/server/otlplogs_test.go
+++ b/cmd/server/otlplogs_test.go
@@ -7,8 +7,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	otlp "github.com/formancehq/go-libs/v5/pkg/observe"
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 	"github.com/formancehq/go-libs/v5/pkg/service"
+
+	"github.com/formancehq/ledger/v3/internal/pkg/version"
 )
 
 // newCmdWithLogFlags returns a fresh cobra.Command with the --debug and
@@ -96,4 +99,52 @@ func TestResolveLogLevel(t *testing.T) {
 			assert.Equal(t, tc.wantLevel, got)
 		})
 	}
+}
+
+func TestResourceFromFlags(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name        string
+		serviceName string
+		attributes  string
+		wantName    string
+		wantVersion string
+	}{
+		{name: "node default and build metadata", wantName: "ledger-node-42", wantVersion: "v3.0.0-abc123"},
+		{name: "explicit service", serviceName: "ledger-production", wantName: "ledger-production", wantVersion: "v3.0.0-abc123"},
+		{name: "resource overrides", serviceName: "ledger-production", attributes: "service.name=override,service.version=override-build,deployment.environment=regression", wantName: "override", wantVersion: "override-build"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			cmd := &cobra.Command{}
+			otlp.AddFlags(cmd.Flags())
+			require.NoError(t, cmd.Flags().Set(otlp.OtelServiceNameFlag, test.serviceName))
+			if test.attributes != "" {
+				require.NoError(t, cmd.Flags().Set(otlp.OtelResourceAttributesFlag, test.attributes))
+			}
+			res, err := resourceFromFlags(cmd, 42, version.Info{Version: "v3.0.0", Commit: "abc123"})
+			require.NoError(t, err)
+			attributes := res.Set()
+			name, ok := attributes.Value("service.name")
+			require.True(t, ok)
+			require.Equal(t, test.wantName, name.AsString())
+			build, ok := attributes.Value("service.version")
+			require.True(t, ok)
+			require.Equal(t, test.wantVersion, build.AsString())
+			if test.attributes != "" {
+				environment, ok := attributes.Value("deployment.environment")
+				require.True(t, ok)
+				require.Equal(t, "regression", environment.AsString())
+			}
+		})
+	}
+}
+
+func TestResourceFromFlagsRejectsMalformedAttributes(t *testing.T) {
+	t.Parallel()
+	cmd := &cobra.Command{}
+	otlp.AddFlags(cmd.Flags())
+	require.NoError(t, cmd.Flags().Set(otlp.OtelResourceAttributesFlag, "missing-value"))
+	_, err := resourceFromFlags(cmd, 42, version.Info{})
+	require.ErrorContains(t, err, "malformed otlp attribute: missing-value")
 }

--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -272,21 +272,15 @@ func runServer(cmd *cobra.Command, bindings network.Bindings) error {
 		return fmt.Errorf("validating config: %w", err)
 	}
 
-	// Set default service name if not provided via flags
-	serviceName, _ := cmd.Flags().GetString(otlp.OtelServiceNameFlag)
-	if serviceName == "" {
-		// Set default service name based on node ID
-		defaultServiceName := fmt.Sprintf("ledger-node-%d", cfg.RaftConfig.NodeID)
-
-		err := cmd.Flags().Set(otlp.OtelServiceNameFlag, defaultServiceName)
-		if err != nil {
-			return fmt.Errorf("setting default service name: %w", err)
-		}
+	info := version.Get()
+	telemetryResource, err := resourceFromFlags(cmd, cfg.RaftConfig.NodeID, info)
+	if err != nil {
+		return fmt.Errorf("creating telemetry resource: %w", err)
 	}
 
 	logger, err := loggerFromFlags(cmd, map[string]any{
 		"node-id": cfg.RaftConfig.NodeID,
-	})
+	}, telemetryResource)
 	if err != nil {
 		return fmt.Errorf("creating logger: %w", err)
 	}
@@ -335,8 +329,6 @@ func runServer(cmd *cobra.Command, bindings network.Bindings) error {
 		appModule = bootstrap.Module()
 	}
 
-	info := version.Get()
-
 	// Auth (OIDC discovery + JWKS reads, bounded by OIDCDiscoveryTimeout) is built in
 	// bootstrap.buildAuthConfig; there is no auth fx module. The go-libs authnfx JWT
 	// module is intentionally not wired in: nothing in this service consumes its
@@ -350,7 +342,7 @@ func runServer(cmd *cobra.Command, bindings network.Bindings) error {
 		// Provide build metadata for version reporting
 		fx.Supply(info),
 		// Add OpenTelemetry modules from go-libs (using flags)
-		observefx.ResourceModuleFromFlags(cmd, otlp.WithServiceVersion(fmt.Sprintf("%s-%s", info.Version, info.Commit))),
+		fx.Supply(telemetryResource),
 		observefx.TracesModuleFromFlags(cmd),
 		// Decorates the trace.TracerProvider from TracesModule with a
 		// pyroscope.profile.id span attribute (see PyroscopeTracesModule doc

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -1857,7 +1857,7 @@ ledgerctl version
 
 The **server** exposes the same build metadata over two unauthenticated channels:
 
-- **HTTP** — `GET /_info` returns flat JSON (no `data` envelope): `{"version":"…","commit":"…","buildDate":"…","goVersion":"…","protocolVersion":"4"}`.
+- **HTTP** — `GET /_info` returns flat JSON (no `data` envelope): `{"version":"…","commit":"…","buildDate":"…","goVersion":"…","protocolVersion":"5"}`.
 - **gRPC** — the `Discovery` RPC's `DiscoveryResponse` carries a `ServerInfo` message with the same information, including `protocol_version`.
 
 This is useful for monitoring deployed nodes and spotting version skew across a cluster (the per-node `version` is also surfaced on each `NodeInfo` in `GetClusterState`).
@@ -4486,6 +4486,11 @@ the collector as described in [deployment](deployment.md#collector-side-trace-sa
 ### Server OTLP Logs Flags
 
 Configure OpenTelemetry log export.
+
+Logs share `--otel-service-name`, build version metadata, and
+`--otel-resource-attributes` with traces and metrics. See
+[shared telemetry resource](monitoring.md#shared-telemetry-resource) for defaults
+and attribute precedence.
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|

--- a/docs/ops/monitoring.md
+++ b/docs/ops/monitoring.md
@@ -15,6 +15,20 @@ Metrics are organized into several categories:
 
 For a complete reference, see the [Grafana Dashboard](#grafana-dashboards) section.
 
+## Shared telemetry resource
+
+Server OTLP logs, traces, and metrics use the same OpenTelemetry resource.
+`service.name` comes from `--otel-service-name` and defaults to
+`ledger-node-<node ID>`. `service.version` contains the build version and commit,
+joined by a hyphen. `--otel-resource-attributes` applies to all three signals;
+explicit attributes take precedence, including overrides of `service.name`
+and `service.version`.
+
+The resource is built before the server logger starts and is supplied to the
+trace and metric providers. Invalid resource attributes fail startup before
+telemetry providers are created. Console log fields and API error responses
+are independent of these OTLP resource attributes.
+
 ## Naming Convention
 
 Metric names in this document use the **OpenTelemetry dot-notation**

--- a/docs/technical/architecture/subsystems/api/README.md
+++ b/docs/technical/architecture/subsystems/api/README.md
@@ -6,7 +6,7 @@ Client-facing transport layers (`internal/adapter/grpc`, `internal/adapter/http`
 
 | Document | Description |
 |----------|-------------|
-| [grpc-api.md](grpc-api.md) | gRPC service, methods, request/response types, client examples, and restore-mode service lifetime. |
+| [grpc-api.md](grpc-api.md) | gRPC service, methods, request/response types, type-owned public error details, client examples, and restore-mode service lifetime. |
 | [grpc-connections.md](grpc-connections.md) | gRPC connection mechanics, reconnection, and rolling deployment optimizations. |
 | [protocol-compatibility.md](protocol-compatibility.md) | Mandatory service protocol revision, client/server rejection behavior, diagnostics, and revision maintenance (EN-1851). |
 | [http-api.md](http-api.md) | HTTP REST API endpoints, response formats, and error handling. |

--- a/docs/technical/architecture/subsystems/api/grpc-api.md
+++ b/docs/technical/architecture/subsystems/api/grpc-api.md
@@ -548,8 +548,8 @@ Processing errors (insufficient funds, ledger not found, etc.) are wrapped in a 
 Unknown errors, `KindInternal` errors, and recovered panics are logged with a generated `correlation_id`. When the RPC span is recording, the same log also carries `trace_id` and `span_id`, and the span records the correlation ID and error. This applies to both unary and streaming interceptors. Existing wire contracts remain distinct: unknown errors and panics return sanitized messages containing the correlation ID, while recognized `KindInternal` errors retain their status and reason. `INDEX_INCONSISTENT` and `COVERAGE_MISS` use type-owned public messages (`index is inconsistent` and `preload coverage miss`) and empty `ErrorInfo.metadata`; their internal identifiers, storage details, and coverage keys remain in server diagnostics. Other recognized error presentations are unchanged. The adapters consume `domain.PublicErrorDetails`; this optional presentation never changes `Error()` or `Metadata()` used by the authoritative audit projection.
 
 Failures reading the staged restore configuration retain `Internal` but return
-a generic message with a correlation ID. The handler records the underlying cause before constructing the status, so the interceptor's
-existing-status passthrough cannot expose a raw storage error. Validation and
+a generic message with a correlation ID. The handler records the underlying cause
+before constructing the status, so the interceptor's existing-status passthrough cannot expose a raw storage error. Validation and
 other intentionally authored gRPC statuses keep their existing behavior.
 
 Each business error response includes:

--- a/docs/technical/architecture/subsystems/api/grpc-api.md
+++ b/docs/technical/architecture/subsystems/api/grpc-api.md
@@ -545,7 +545,12 @@ See [Idempotency](../admission/idempotency.md) for detailed documentation.
 
 Processing errors (insufficient funds, ledger not found, etc.) are wrapped in a `BusinessError` struct in the FSM layer. The gRPC interceptor converts `BusinessError` instances to proper gRPC status codes with structured `google.rpc.ErrorInfo` details. This allows clients to programmatically identify error types without parsing error messages.
 
-Unknown errors, `KindInternal` errors, and recovered panics are logged with a generated `correlation_id`. When the RPC span is recording, the same log also carries `trace_id` and `span_id`, and the span records the correlation ID and error. This applies to both unary and streaming interceptors. Existing wire contracts remain distinct: unknown errors and panics return sanitized messages containing the correlation ID, while recognized `KindInternal` errors keep their existing status, reason, and message.
+Unknown errors, `KindInternal` errors, and recovered panics are logged with a generated `correlation_id`. When the RPC span is recording, the same log also carries `trace_id` and `span_id`, and the span records the correlation ID and error. This applies to both unary and streaming interceptors. Existing wire contracts remain distinct: unknown errors and panics return sanitized messages containing the correlation ID, while recognized `KindInternal` errors retain their status and reason. `INDEX_INCONSISTENT` and `COVERAGE_MISS` use type-owned public messages (`index is inconsistent` and `preload coverage miss`) and empty `ErrorInfo.metadata`; their internal identifiers, storage details, and coverage keys remain in server diagnostics. Other recognized error presentations are unchanged. The adapters consume `domain.PublicErrorDetails`; this optional presentation never changes `Error()` or `Metadata()` used by the authoritative audit projection.
+
+Failures reading the staged restore configuration retain `Internal` but return
+a generic message with a correlation ID. The handler records the underlying cause before constructing the status, so the interceptor's
+existing-status passthrough cannot expose a raw storage error. Validation and
+other intentionally authored gRPC statuses keep their existing behavior.
 
 Each business error response includes:
 - A **gRPC status code** (e.g., `NOT_FOUND`, `ALREADY_EXISTS`, `FAILED_PRECONDITION`)

--- a/docs/technical/architecture/subsystems/api/http-api.md
+++ b/docs/technical/architecture/subsystems/api/http-api.md
@@ -97,7 +97,9 @@ Three paths need correlated server-side diagnostics because the raw value can co
 
 1. **Panic recovery** (`jsonRecoverer`) — a panic in any handler.
 2. **Unmapped errors** (`handleError` fallthrough → `writeInternalServerError`) — any error that is not a domain `Describable` or a known sentinel.
-3. **`KindInternal` domain errors** — recognized internal failures whose existing status, reason, and response message contract is preserved.
+3. **`KindInternal` domain errors** — recognized internal failures whose status and reason are preserved. `INDEX_INCONSISTENT` and `COVERAGE_MISS` supply public messages (`index is inconsistent` and `preload coverage miss`) that omit internal identifiers and storage details, including when wrapped. Other recognized error presentations are unchanged.
+
+Type-owned public details are selected through `domain.PublicErrorDetails` at the response boundary. Diagnostic `Error()` and `Metadata()` values remain unchanged, including the coverage failure context in the authoritative audit chain.
 
 Every path logs the raw cause **server-side** with a `correlation_id` field. When the request span is recording, the log also carries `trace_id` and `span_id`, and the span records both the correlation ID and the error. Panic spans additionally carry the panic value and stack. Unmapped errors and panics remain sanitized identically to the gRPC adapter, so the client receives only a generic body:
 
@@ -336,6 +338,15 @@ Content-Type: application/json
 
 **Query Parameters**:
 - `continueOnFailure=true`: When the request is accepted, keep processing subsequent elements after a per-element **business** failure (validation / not-found / conflict / precondition / permission) instead of aborting. Business failures surface as `errorCode` on each element and the overall status stays `200`. Request-level failures (malformed body, missing scope, oversized) and processing-time infra/retryable failures (`ErrNoLeader`, cache-horizon exceeded, `KindInternal`, `KindResourceExhausted`, `KindUnavailable`) still surface as non-2xx (`4xx`, `429`, `503`, `500`) regardless of this flag — see the `POST /v3/{ledgerName}/bulk` operation in `openapi.yml` for the full status matrix.
+
+Bulk internal failures are logged and stamped on the recording request span
+with a validated correlation ID, including sequential and atomic apply failures.
+Unknown errors expose only `internal server error (correlation ID: <id>)` in
+`errorDescription`; the existing `ERROR` code and bulk envelope stay unchanged.
+Typed internal failures keep their reason and use their type-owned public
+presentation when provided; actionable Numscript diagnostics remain visible.
+The `continueOnFailure` rollup and retry semantics are unaffected.
+
 - `atomic=true`: Execute atomically (all or nothing) - not yet supported
 
 ### Account Metadata

--- a/docs/technical/architecture/subsystems/api/protocol-compatibility.md
+++ b/docs/technical/architecture/subsystems/api/protocol-compatibility.md
@@ -20,7 +20,7 @@ compatibility of development revisions.
 ## Wire contract and failure behavior
 
 `pkg/grpcprotocol.Version` is the compiled service protocol revision, currently
-`"4"`. `pkg/grpcprotocol.MetadataKey` is `ledger-protocol-version`. Clients send
+`"5"`. `pkg/grpcprotocol.MetadataKey` is `ledger-protocol-version`. Clients send
 exactly one value for this metadata key on every RPC. The Go
 `grpcprotocol.ClientOption()` dial option supplies the local revision for unary
 and streaming calls. Local `dev` builds carry the same constant without release
@@ -49,6 +49,12 @@ Restore mode does not register Discovery: its service gate provides the
 compatibility error without requiring a preliminary Discovery call, while
 health and reflection remain exempt.
 
+Revision 5 (EN-1623) removes internal index/coverage details from public
+error messages and ErrorInfo metadata while retaining their reasons and status
+codes. Internal read failures in restore validation retain `Internal` with a sanitized
+correlation message. AuditFailure records
+retain their original diagnostic message and context.
+
 ## Client and deployment scope
 
 Enforcement starts with servers implementing EN-1851: they reject old clients
@@ -61,10 +67,10 @@ servers or support for mixed wire-format upgrades.
 
 Every consumer of the service gRPC endpoint must declare its protocol,
 including SDKs, automation, `grpcurl`, and internal requests forwarded to a
-leader. For example, with a schema implementing revision 4:
+leader. For example, with a schema implementing revision 5:
 
 ```bash
-grpcurl -plaintext -H 'ledger-protocol-version: 4' \
+grpcurl -plaintext -H 'ledger-protocol-version: 5' \
   localhost:8888 cluster.ClusterService.GetClusterState
 ```
 

--- a/docs/technical/architecture/subsystems/api/protocol-compatibility.md
+++ b/docs/technical/architecture/subsystems/api/protocol-compatibility.md
@@ -51,9 +51,9 @@ health and reflection remain exempt.
 
 Revision 5 (EN-1623) removes internal index/coverage details from public
 error messages and ErrorInfo metadata while retaining their reasons and status
-codes. Internal read failures in restore validation retain `Internal` with a sanitized
-correlation message. AuditFailure records
-retain their original diagnostic message and context.
+codes. Internal read failures in restore validation retain `Internal` with a
+sanitized correlation message. AuditFailure records retain their original
+diagnostic message and context.
 
 ## Client and deployment scope
 

--- a/docs/technical/architecture/subsystems/fsm/coverage-gate.md
+++ b/docs/technical/architecture/subsystems/fsm/coverage-gate.md
@@ -84,10 +84,10 @@ A coverage miss is an admission bug, not an infrastructure fault, and it is labe
 | Hash-chained `AuditFailure.Reason` | `ERROR_REASON_COVERAGE_MISS` |
 | `AuditFailure.Context` | `attribute`, `canonicalHex`, `idHex`, `raftIndex` |
 | Frozen idempotency outcome | **not applicable** — `KindInternal` failures are deliberately never frozen (`IsFreezableFailure`, `internal/domain/errors.go:152-158`), so a coverage miss leaves no idempotency record and the request stays retryable |
-| gRPC / HTTP `ErrorInfo.reason` | `COVERAGE_MISS` (status `INTERNAL` — both reasons are `KindInternal`) |
+| gRPC / HTTP error reason | `COVERAGE_MISS` (gRPC `INTERNAL` / HTTP 500), public message `preload coverage miss`, no gRPC error metadata |
 | Node-local log + OTel counter | `scope.go:374-378` (see [Metrics](#metrics)) |
 
-The `Metadata()` keys are camelCase, matching every other `Describable` and the repo-wide wire convention. The structured log emitted alongside keeps snake_case field names — that is a log, not a wire payload.
+The `Metadata()` keys are camelCase and remain part of the diagnostic and authoritative audit contract. The API adapters use the separate, type-owned `PublicDetails()` presentation through `domain.PublicErrorDetails`: it hides the attribute, canonical key, hashed identifier, and Raft index from error responses without changing `Error()`, `Metadata()`, or the audit hash pre-image. This response-only redaction does not change FSM execution, persisted state, or incremental restore behavior. The structured log emitted alongside keeps snake_case field names — that is a log, not a wire payload.
 
 The idempotency row is worth stating explicitly because the non-freezing is a design point, not an oversight: `recordIdempotencyFailure` returns early (`machine.go:1729`) for any non-freezable kind, and `KindForReason` classifies `ERROR_REASON_COVERAGE_MISS` as `KindInternal` (`internal/domain/reason.go:124`). Freezing would pin a server bug against the caller's key for the whole TTL. This was equally true before EN-1379 — `ERROR_REASON_STORAGE_OPERATION_FAILED` sits in the same `KindInternal` arm — so the idempotency outcome is not one of the surfaces the fix repairs.
 

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -830,7 +830,7 @@ Note that `POST /v3/{ledgerName}/bulk` shares this classifier but can only expre
 
 ### gRPC Error Mapping
 
-Business errors from the processing layer are mapped to gRPC status codes with structured `ErrorInfo` details via the `Describable` contract in `internal/domain`. This allows clients to programmatically identify error types without parsing error messages. See `internal/domain/errors.go` for the canonical list — the `Reason()` method on each typed error returns the constant below, and `Metadata()` returns the keys listed.
+Business errors from the processing layer are mapped to gRPC status codes with structured `ErrorInfo` details via the `Describable` contract in `internal/domain`. This allows clients to programmatically identify error types without parsing error messages. See `internal/domain/errors.go` for the canonical list — the `Reason()` method on each typed error returns the constant below, and `Metadata()` supplies the diagnostic context. The optional `domain.PublicErrorDetails` presentation supplies the public message and metadata for types whose diagnostic values are not safe to expose; the keys listed below describe the public response.
 
 Each error response includes a `google.rpc.ErrorInfo` detail with:
 - **`reason`**: Machine-readable error reason constant (e.g., `LEDGER_ALREADY_EXISTS`)
@@ -881,7 +881,7 @@ Each error response includes a `google.rpc.ErrorInfo` detail with:
 | Filter compilation error | `INVALID_ARGUMENT` | `FILTER_COMPILATION_ERROR` | `detail` |
 | Index not found | `FAILED_PRECONDITION` | `INDEX_NOT_FOUND` | `index` |
 | Index building | `FAILED_PRECONDITION` | `INDEX_BUILDING` | `index` |
-| Index inconsistent | `INTERNAL` | `INDEX_INCONSISTENT` | `index`, `detail` |
+| Index inconsistent | `INTERNAL` | `INDEX_INCONSISTENT` | *(none — internal index/storage details remain server-side)* |
 | Account not matching type | `FAILED_PRECONDITION` | `ACCOUNT_NOT_MATCHING_TYPE` | `address` |
 | Account type not found | `NOT_FOUND` | `ACCOUNT_TYPE_NOT_FOUND` | `name` |
 | Account type already exists | `ALREADY_EXISTS` | `ACCOUNT_TYPE_ALREADY_EXISTS` | `name` |
@@ -895,7 +895,7 @@ Each error response includes a `google.rpc.ErrorInfo` detail with:
 | Invalid order type (protocol mismatch) | `INTERNAL` | `INVALID_ORDER_TYPE` | `typeName` |
 | Invalid apply type (protocol mismatch) | `INTERNAL` | `INVALID_APPLY_TYPE` | `typeName` |
 | Storage operation failed | `INTERNAL` | `STORAGE_OPERATION_FAILED` | `operation` |
-| Preload coverage miss (admission contract violation) | `INTERNAL` | `COVERAGE_MISS` | `attribute`, `canonicalHex`, `idHex`, `raftIndex` |
+| Preload coverage miss (admission contract violation) | `INTERNAL` | `COVERAGE_MISS` | *(none — coverage context remains in diagnostics and audit)* |
 | Checkpoint ID required | `INVALID_ARGUMENT` | `CHECKPOINT_ID_REQUIRED` | *(none)* |
 
 ### REST/HTTP Error Mapping

--- a/go.mod
+++ b/go.mod
@@ -88,6 +88,8 @@ require (
 	google.golang.org/protobuf v1.36.11
 )
 
+require go.opentelemetry.io/proto/otlp v1.10.0
+
 require (
 	al.essio.dev/pkg/shellescape v1.5.1 // indirect
 	atomicgo.dev/cursor v0.2.0 // indirect
@@ -299,7 +301,6 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.41.0 // indirect
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.41.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/dig v1.19.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect

--- a/internal/adapter/grpc/errors.go
+++ b/internal/adapter/grpc/errors.go
@@ -63,15 +63,16 @@ func kindToGRPCCode(k domain.ErrorKind) codes.Code {
 
 // describableToGRPCStatus converts a Describable to a gRPC status with the
 // ErrorInfo detail clients pattern-match on. The Kind selects the status
-// code via the exhaustive switch above; the Reason and Metadata carry the
-// per-type wire contract.
+// code via the exhaustive switch above; the Reason and type-owned public
+// presentation carry the wire contract without exposing diagnostic context.
 func describableToGRPCStatus(d domain.Describable) *status.Status {
-	st := status.New(kindToGRPCCode(domain.Kind(d)), d.Error())
+	message, metadata, _ := domain.PublicErrorDetails(d)
+	st := status.New(kindToGRPCCode(domain.Kind(d)), message)
 
 	detailed, err := st.WithDetails(&errdetails.ErrorInfo{
 		Reason:   d.Reason(),
 		Domain:   errorDomain,
-		Metadata: d.Metadata(),
+		Metadata: metadata,
 	})
 	if err != nil {
 		return st

--- a/internal/adapter/grpc/internal_diagnostics_test.go
+++ b/internal/adapter/grpc/internal_diagnostics_test.go
@@ -1,0 +1,64 @@
+package grpc
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/proto/restorepb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+// Exercise the real reads with malformed persisted protobuf data, rather than
+// handing a fabricated status directly to the conversion interceptor.
+func TestInternalReadFailuresAreSanitized(t *testing.T) {
+	t.Parallel()
+
+	t.Run("staged-config", func(t *testing.T) {
+		t.Parallel()
+		var logs bytes.Buffer
+		logger := logging.NewDefaultLogger(&logs, false, false, false)
+		recorder := tracetest.NewSpanRecorder()
+		provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+		t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+		ctx, span := provider.Tracer("test").Start(context.Background(), "staged-config")
+		ctx = logging.ContextWithLogger(ctx, logger)
+		server := NewRestoreServiceServer(t.TempDir(), "test-cluster", 1, logger)
+		store, err := dal.OpenDirect(server.stagingDir(), logger)
+		require.NoError(t, err)
+		server.stagingStore = store
+		server.downloaded = true
+		t.Cleanup(server.Shutdown)
+		batch := store.OpenWriteSession()
+		require.NoError(t, batch.SetBytes([]byte{dal.ZoneGlobal, dal.SubGlobPersistedConfig}, []byte{0xff}))
+		require.NoError(t, batch.Commit())
+		stream := NewMockServerStreamingServer[restorepb.ValidateRestoreEvent](gomock.NewController(t))
+		stream.EXPECT().Context().Return(ctx).AnyTimes()
+		err = server.ValidateRestore(&restorepb.ValidateRestoreRequest{}, stream)
+		diagnostic := "reading staged backup config"
+		err = convertToGRPCErrorWithContext(ctx, err, logger)
+		span.End()
+		st := status.Convert(err)
+		require.Equal(t, codes.Internal, st.Code())
+		require.Regexp(t, `^internal server error \(correlation ID: [0-9a-f]+\)$`, st.Message())
+		id := strings.TrimSuffix(strings.TrimPrefix(st.Message(), "internal server error (correlation ID: "), ")")
+		require.Contains(t, logs.String(), id)
+		require.NotContains(t, st.Message(), diagnostic)
+		require.Empty(t, st.Details())
+		require.Contains(t, logs.String(), diagnostic)
+		require.Contains(t, logs.String(), "correlation_id")
+		require.Contains(t, logs.String(), span.SpanContext().TraceID().String())
+		require.Equal(t, id, grpcSpanAttribute(recorder.Ended()[0], "correlation_id"))
+		require.NotEmpty(t, recorder.Ended()[0].Events())
+	})
+}

--- a/internal/adapter/grpc/protocol_interceptor_test.go
+++ b/internal/adapter/grpc/protocol_interceptor_test.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"context"
 	"net"
+	"strconv"
 	"testing"
 	"time"
 
@@ -26,6 +27,10 @@ import (
 // a distinct status when reached; rejected calls must never reach them.
 func TestServiceServerProtocolVersion(t *testing.T) {
 	t.Parallel()
+
+	currentRevision, err := strconv.Atoi(grpcprotocol.Version)
+	require.NoError(t, err)
+	require.Positive(t, currentRevision)
 
 	listener, err := net.Listen("tcp4", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -94,7 +99,8 @@ func TestServiceServerProtocolVersion(t *testing.T) {
 				{"missing", nil},
 				{"empty", []string{""}},
 				{"older", []string{"0"}},
-				{"newer", []string{"5"}},
+				{"previous", []string{strconv.Itoa(currentRevision - 1)}},
+				{"newer", []string{strconv.Itoa(currentRevision + 1)}},
 				{"invalid", []string{"dev"}},
 				{"duplicate", []string{grpcprotocol.Version, grpcprotocol.Version}},
 				{"conflicting", []string{grpcprotocol.Version, "0"}},

--- a/internal/adapter/grpc/public_errors_test.go
+++ b/internal/adapter/grpc/public_errors_test.go
@@ -1,0 +1,60 @@
+package grpc
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/infra/state"
+)
+
+func TestGRPCPublicInternalDetails(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		err     domain.Describable
+		message string
+	}{
+		{"index", &domain.ErrIndexInconsistent{Index: "private-index", Detail: "reading /private/pebble: secret failure"}, "index is inconsistent"},
+		{"coverage", &state.ErrCoverageMiss{Attribute: "private-attribute", CanonicalHex: "deadbeef", IDHex: "0102", RaftIndex: 42}, "preload coverage miss"},
+	} {
+		for _, wrapped := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/wrapped=%t", tc.name, wrapped), func(t *testing.T) {
+				t.Parallel()
+				var err error = tc.err
+				if wrapped {
+					err = fmt.Errorf("private wrapper: %w", &domain.BusinessError{Err: tc.err})
+				}
+				var logs bytes.Buffer
+				st := status.Convert(convertToGRPCError(err, logging.NewDefaultLogger(&logs, false, false, false)))
+				require.Equal(t, codes.Internal, st.Code())
+				require.Equal(t, tc.message, st.Message())
+				info := extractErrorInfo(t, st)
+				require.Equal(t, tc.err.Reason(), info.GetReason())
+				require.Equal(t, errorDomain, info.GetDomain())
+				require.Empty(t, info.GetMetadata())
+				require.Contains(t, logs.String(), tc.err.Error())
+				require.Contains(t, logs.String(), "correlation_id")
+			})
+		}
+	}
+}
+
+func TestGRPCPublicDetailsPreserveNumscriptDiagnostics(t *testing.T) {
+	t.Parallel()
+	err := &domain.ErrNumscriptRuntime{Detail: "negative posting amount"}
+	st := status.Convert(convertToGRPCError(&domain.BusinessError{Err: err}, logging.Testing()))
+	require.Equal(t, codes.Internal, st.Code())
+	require.Equal(t, err.Error(), st.Message())
+	info := extractErrorInfo(t, st)
+	require.Equal(t, domain.ErrReasonNumscriptRuntime, info.GetReason())
+	require.Equal(t, map[string]string{"detail": "negative posting amount"}, info.GetMetadata())
+}

--- a/internal/adapter/grpc/server.go
+++ b/internal/adapter/grpc/server.go
@@ -708,6 +708,14 @@ func convertToGRPCErrorWithContext(ctx context.Context, err error, logger loggin
 	return status.Errorf(codes.Unknown, "unknown server error (correlation ID: %s)", correlationID)
 }
 
+// internalGRPCError sanitizes a known internal read failure at its source while
+// retaining Internal (the unmapped-error boundary deliberately uses Unknown).
+func internalGRPCError(ctx context.Context, logger logging.Logger, err error) error {
+	correlationID := recordGRPCInternalError(ctx, logger, err)
+
+	return status.Errorf(codes.Internal, "internal server error (correlation ID: %s)", correlationID)
+}
+
 func recordGRPCInternalError(ctx context.Context, logger logging.Logger, err error) string {
 	correlationID := newCorrelationID()
 	fields := apitrace.Fields(ctx)

--- a/internal/adapter/grpc/server_restore.go
+++ b/internal/adapter/grpc/server_restore.go
@@ -287,7 +287,7 @@ func (s *RestoreServiceServerImpl) ValidateRestore(_ *restorepb.ValidateRestoreR
 	// the source cluster's key.
 	persisted, err := query.ReadPersistedConfig(store)
 	if err != nil {
-		return status.Errorf(codes.Internal, "reading staged backup config: %v", err)
+		return internalGRPCError(stream.Context(), s.logger, fmt.Errorf("reading staged backup config: %w", err))
 	}
 
 	if persisted == nil {

--- a/internal/adapter/http/error_handler.go
+++ b/internal/adapter/http/error_handler.go
@@ -106,6 +106,9 @@ func handleError(w http.ResponseWriter, r *http.Request, err error) {
 		if httpStatus == http.StatusInternalServerError {
 			recordHTTPInternalError(r, correlationID(r), err)
 		}
+		if message, _, overridden := domain.PublicErrorDetails(d); overridden {
+			err = errors.New(message)
+		}
 
 		writeErrorResponse(w, httpStatus, d.Reason(), err)
 

--- a/internal/adapter/http/handlers_bulk.go
+++ b/internal/adapter/http/handlers_bulk.go
@@ -102,7 +102,7 @@ func (s *Server) serveBulk(w http.ResponseWriter, r *http.Request) {
 	results := s.runBulk(r.Context(), ledgerName, elements, opts)
 
 	// Write response
-	writeBulkResponse(w, elements, results, opts.continueOnFailure)
+	writeBulkResponse(w, r, elements, results, opts.continueOnFailure)
 }
 
 // bulkOptions contains options for bulk processing.
@@ -231,7 +231,7 @@ func (s *Server) runBulkSequential(ctx context.Context, requests []*servicepb.Re
 //
 // Any 5xx/429 status from infra/retryable/rate-limit errors always surfaces,
 // with `Retry-After: 1` on 503 to match handleError.
-func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement, results []bulkResult, continueOnFailure bool) {
+func writeBulkResponse(w http.ResponseWriter, r *http.Request, elements []*servicepb.BulkElement, results []bulkResult, continueOnFailure bool) {
 	worstBusiness := 0 // highest 4xx from a per-element business failure
 	worstInfra := 0    // highest ≥429 from a retryable/infra/rate-limit error
 	apiResults := make([]bulkAPIResult, len(results))
@@ -265,7 +265,7 @@ func writeBulkResponse(w http.ResponseWriter, elements []*servicepb.BulkElement,
 			apiResults[i] = bulkAPIResult{
 				ResponseType:     "ERROR",
 				ErrorCode:        bulkErrorCode(result.err),
-				ErrorDescription: result.err.Error(),
+				ErrorDescription: bulkErrorDescription(r, result.err),
 			}
 
 			continue
@@ -343,6 +343,26 @@ func perElementStatus(err error) int {
 
 	// Unknown error: 500. Can't be masked as 200 under continueOnFailure.
 	return http.StatusInternalServerError
+}
+
+// bulkErrorDescription applies the same diagnostics and public presentation as
+// single-request errors while preserving the bulk envelope, reasons and rollup.
+func bulkErrorDescription(r *http.Request, err error) string {
+	message := err.Error()
+	if perElementStatus(err) != http.StatusInternalServerError {
+		return message
+	}
+	id := correlationID(r)
+	recordHTTPInternalError(r, id, err)
+	if d, ok := errors.AsType[domain.Describable](err); ok {
+		if public, _, overridden := domain.PublicErrorDetails(d); overridden {
+			return public
+		}
+
+		return message
+	}
+
+	return fmt.Sprintf("internal server error (correlation ID: %s)", id)
 }
 
 // bulkErrorCode returns a machine-readable code for a per-element bulk failure.

--- a/internal/adapter/http/handlers_bulk_diagnostics_test.go
+++ b/internal/adapter/http/handlers_bulk_diagnostics_test.go
@@ -1,0 +1,80 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.uber.org/mock/gomock"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+)
+
+func TestHandleBulkInternalDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	for _, atomic := range []bool{false, true} {
+		for _, tc := range []struct {
+			name    string
+			err     error
+			cause   string
+			code    string
+			message string
+		}{
+			{"unknown", errors.New("pebble: /private/ledger/000123.sst broken"), "pebble: /private/ledger/000123.sst broken", "ERROR", "internal server error (correlation ID: bulk-diagnostics)"},
+			{"missing-log", nil, "no log returned from apply", "ERROR", "internal server error (correlation ID: bulk-diagnostics)"},
+			{"private-typed", &domain.BusinessError{Err: &domain.ErrIndexInconsistent{Index: "ledger-index", Detail: "/private/index.sst broken"}}, "index ledger-index is inconsistent: /private/index.sst broken", domain.ErrReasonIndexInconsistent, "index is inconsistent"},
+			{"numscript", &domain.ErrNumscriptRuntime{Detail: "negative posting amount"}, "numscript runtime error: negative posting amount", domain.ErrReasonNumscriptRuntime, "numscript runtime error: negative posting amount"},
+			{"typed-internal", &domain.ErrStorageOperation{Operation: "reading ledger", Cause: errors.New("private")}, "storage operation failed: reading ledger", domain.ErrReasonStorageOperation, "storage operation failed: reading ledger"},
+		} {
+			if atomic && tc.err == nil {
+				continue
+			} // The empty-log sentinel belongs to sequential apply.
+			t.Run(tc.name+map[bool]string{false: "/sequential", true: "/atomic"}[atomic], func(t *testing.T) {
+				t.Parallel()
+				for _, continueOnFailure := range []string{"false", "true"} {
+					backend := NewMockBackend(gomock.NewController(t))
+					backend.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, tc.err)
+					srv := newTestServer(t, backend)
+					var logs bytes.Buffer
+					recorder := tracetest.NewSpanRecorder()
+					provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+					t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+					r := newRequest(t, http.MethodPost, "/ledger1/bulk", strings.NewReader(bulkWriteBody), map[string]string{"ledgerName": "ledger1"})
+					ctx, span := provider.Tracer("test").Start(r.Context(), "bulk")
+					ctx = logging.ContextWithLogger(ctx, logging.NewDefaultLogger(&logs, false, false, false))
+					ctx = context.WithValue(ctx, middleware.RequestIDKey, "bulk-diagnostics")
+					url := "/ledger1/bulk?continueOnFailure=" + continueOnFailure
+					if atomic {
+						url += "&atomic=true"
+					}
+					r = r.WithContext(ctx)
+					r.URL.RawQuery = strings.SplitN(url, "?", 2)[1]
+					w := httptest.NewRecorder()
+					srv.handleBulk(w, r)
+					span.End()
+					require.Equal(t, http.StatusInternalServerError, w.Code)
+					response := decodeResponse[bulkResponse](t, w)
+					require.Len(t, response.Data, 1)
+					require.Equal(t, tc.code, response.Data[0].ErrorCode)
+					require.Equal(t, tc.message, response.Data[0].ErrorDescription)
+					require.Contains(t, logs.String(), tc.cause)
+					require.Contains(t, logs.String(), "bulk-diagnostics")
+					require.Contains(t, logs.String(), span.SpanContext().TraceID().String())
+					require.Equal(t, "bulk-diagnostics", httpSpanAttribute(recorder.Ended()[0], "correlation_id"))
+					require.NotEmpty(t, recorder.Ended()[0].Events())
+				}
+			})
+		}
+	}
+}

--- a/internal/adapter/http/handlers_coverage_test.go
+++ b/internal/adapter/http/handlers_coverage_test.go
@@ -964,7 +964,7 @@ func TestWriteBulkResponse_WithErrors(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	writeBulkResponse(w, elements, results, false)
+	writeBulkResponse(w, httptest.NewRequest(http.MethodPost, "/ledger1/bulk", nil), elements, results, false)
 
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
@@ -1004,7 +1004,7 @@ func TestWriteBulkResponse_KindDispatch(t *testing.T) {
 			}}}
 
 			w := httptest.NewRecorder()
-			writeBulkResponse(w, elements, []bulkResult{{err: tc.err}}, true)
+			writeBulkResponse(w, httptest.NewRequest(http.MethodPost, "/ledger1/bulk", nil), elements, []bulkResult{{err: tc.err}}, true)
 
 			require.Equal(t, tc.wantStatus, w.Code, "unexpected top-level status for %q", tc.name)
 
@@ -1051,7 +1051,7 @@ func TestWriteBulkResponse_ContinueOnFailure(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	writeBulkResponse(w, elements, results, true)
+	writeBulkResponse(w, httptest.NewRequest(http.MethodPost, "/ledger1/bulk", nil), elements, results, true)
 
 	require.Equal(t, http.StatusOK, w.Code)
 }
@@ -1083,7 +1083,7 @@ func TestWriteBulkResponse_AllSuccess(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	writeBulkResponse(w, elements, results, false)
+	writeBulkResponse(w, httptest.NewRequest(http.MethodPost, "/ledger1/bulk", nil), elements, results, false)
 
 	require.Equal(t, http.StatusOK, w.Code)
 }
@@ -1102,7 +1102,7 @@ func TestWriteBulkResponse_NilLog(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	writeBulkResponse(w, elements, results, false)
+	writeBulkResponse(w, httptest.NewRequest(http.MethodPost, "/ledger1/bulk", nil), elements, results, false)
 
 	require.Equal(t, http.StatusOK, w.Code)
 }
@@ -1240,7 +1240,7 @@ func TestWriteBulkResponse_AbortedElementsDontEscalate(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	writeBulkResponse(w, elements, results, false)
+	writeBulkResponse(w, httptest.NewRequest(http.MethodPost, "/ledger1/bulk", nil), elements, results, false)
 
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
@@ -1459,7 +1459,7 @@ func TestWriteBulkResponse_LogWithCreatedTransaction(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	writeBulkResponse(w, elements, results, false)
+	writeBulkResponse(w, httptest.NewRequest(http.MethodPost, "/ledger1/bulk", nil), elements, results, false)
 
 	require.Equal(t, http.StatusOK, w.Code)
 	require.Contains(t, w.Body.String(), "CREATE_TRANSACTION")
@@ -1484,7 +1484,7 @@ func TestWriteBulkResponse_LogWithoutData(t *testing.T) {
 	}
 
 	w := httptest.NewRecorder()
-	writeBulkResponse(w, elements, results, false)
+	writeBulkResponse(w, httptest.NewRequest(http.MethodPost, "/ledger1/bulk", nil), elements, results, false)
 
 	require.Equal(t, http.StatusOK, w.Code)
 }

--- a/internal/adapter/http/public_errors_test.go
+++ b/internal/adapter/http/public_errors_test.go
@@ -1,0 +1,70 @@
+package http
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/infra/state"
+)
+
+func TestHTTPPublicInternalDetails(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		err     domain.Describable
+		message string
+	}{
+		{"index", &domain.ErrIndexInconsistent{Index: "private-index", Detail: "reading /private/pebble: secret failure"}, "index is inconsistent"},
+		{"coverage", &state.ErrCoverageMiss{Attribute: "private-attribute", CanonicalHex: "deadbeef", IDHex: "0102", RaftIndex: 42}, "preload coverage miss"},
+	} {
+		for _, wrapped := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/wrapped=%t", tc.name, wrapped), func(t *testing.T) {
+				t.Parallel()
+				var err error = tc.err
+				if wrapped {
+					err = fmt.Errorf("private wrapper: %w", &domain.BusinessError{Err: tc.err})
+				}
+				var logs bytes.Buffer
+				ctx := logging.ContextWithLogger(context.Background(), logging.NewDefaultLogger(&logs, false, false, false))
+				w := httptest.NewRecorder()
+				handleError(w, httptest.NewRequest(http.MethodGet, "/", nil).WithContext(ctx), err)
+				require.Equal(t, http.StatusInternalServerError, w.Code)
+				response := decodeResponse[ErrorResponse](t, w)
+				require.Equal(t, tc.err.Reason(), response.ErrorCode)
+				require.Equal(t, tc.message, response.ErrorMessage)
+				require.Contains(t, logs.String(), tc.err.Error())
+				require.Contains(t, logs.String(), "correlation_id")
+			})
+		}
+	}
+}
+
+func TestHTTPPublicDetailsPreserveOtherWrappedErrors(t *testing.T) {
+	t.Parallel()
+	err := fmt.Errorf("existing context: %w", &domain.BusinessError{Err: &domain.ErrLedgerNotFound{Name: "test"}})
+	w := httptest.NewRecorder()
+	handleError(w, httptest.NewRequest(http.MethodGet, "/", nil), err)
+	require.Equal(t, http.StatusNotFound, w.Code)
+	require.Equal(t, err.Error(), decodeResponse[ErrorResponse](t, w).ErrorMessage)
+}
+
+func TestHTTPPublicDetailsPreserveNumscriptDiagnostics(t *testing.T) {
+	t.Parallel()
+	err := fmt.Errorf("existing context: %w", &domain.BusinessError{Err: &domain.ErrNumscriptRuntime{Detail: "negative posting amount"}})
+	w := httptest.NewRecorder()
+	handleError(w, httptest.NewRequest(http.MethodPost, "/", nil), err)
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+	response := decodeResponse[ErrorResponse](t, w)
+	require.Equal(t, domain.ErrReasonNumscriptRuntime, response.ErrorCode)
+	require.Equal(t, err.Error(), response.ErrorMessage)
+}

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -108,8 +108,10 @@ func (k ErrorKind) String() string {
 // Describable is the contract every domain business error must satisfy.
 // Adapters derive a transport status code from domain.Kind(d) — a function of
 // Reason — read Reason() for the stable client-facing identifier, and
-// Metadata() for the structured error-info payload (field values that let the
-// client format a precise user message — names, IDs, etc.).
+// Metadata() for diagnostic context. API adapters use PublicErrorDetails for
+// the message and structured payload, allowing types with sensitive diagnostic
+// context to provide a separate presentation. Audit projections always consume
+// Error() and Metadata() directly.
 //
 // The interface embeds `error` so `errors.As(err, &target Describable)` works
 // transparently from any chain. Implementations should be value-comparable
@@ -124,10 +126,29 @@ type Describable interface {
 	// kind is derived from it via domain.Kind / KindForReason.
 	Reason() string
 
-	// Metadata returns structured context the client uses to format a
-	// user-facing message (e.g. {"name": "default"}). Return nil when
-	// there is no per-occurrence context.
+	// Metadata returns structured diagnostic context. It is also the default
+	// public context unless PublicDetails overrides the presentation.
+	// Return nil when there is no per-occurrence context.
 	Metadata() map[string]string
+}
+
+// PublicErrorDetails selects the optional public presentation owned by an
+// error type. Error() and Metadata() remain the diagnostic and audit identity;
+// this helper is only for API responses, never persisted failure projections.
+// The override flag lets adapters preserve their existing outer error text
+// when the type has not opted into a separate public presentation.
+//
+// Only the selected Describable is consulted: a nested cause must not replace
+// the presentation of an unrelated outer reason. Transparent BusinessError
+// wrappers explicitly delegate their presentation to the contained error.
+func PublicErrorDetails(d Describable) (message string, metadata map[string]string, overridden bool) {
+	if public, ok := d.(interface {
+		PublicDetails() (string, map[string]string, bool)
+	}); ok {
+		return public.PublicDetails()
+	}
+
+	return d.Error(), d.Metadata(), false
 }
 
 // ReplayedFailure is a Describable reconstructed from a stored idempotency
@@ -271,6 +292,10 @@ func (e *BusinessError) Error() string               { return e.Err.Error() }
 func (e *BusinessError) Unwrap() error               { return e.Err }
 func (e *BusinessError) Reason() string              { return e.Err.Reason() }
 func (e *BusinessError) Metadata() map[string]string { return e.Err.Metadata() }
+
+func (e *BusinessError) PublicDetails() (string, map[string]string, bool) {
+	return PublicErrorDetails(e.Err)
+}
 
 // WrapCompileError propagates errors returned by query.Compile through to the
 // caller. Typed BusinessErrors (ErrIndexNotFound from missing-index paths,
@@ -981,6 +1006,12 @@ func (e *ErrIndexInconsistent) Error() string {
 func (*ErrIndexInconsistent) Reason() string { return ErrReasonIndexInconsistent }
 func (e *ErrIndexInconsistent) Metadata() map[string]string {
 	return map[string]string{"index": e.Index, "detail": e.Detail}
+}
+
+// PublicDetails omits the index identity and raw storage diagnostics while
+// retaining Error() and Metadata() for operator diagnostics.
+func (*ErrIndexInconsistent) PublicDetails() (string, map[string]string, bool) {
+	return "index is inconsistent", nil, true
 }
 
 // ErrNumscriptNotFound — referenced numscript does not exist in the library.

--- a/internal/domain/public_errors_test.go
+++ b/internal/domain/public_errors_test.go
@@ -1,0 +1,42 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublicErrorDetails(t *testing.T) {
+	t.Parallel()
+
+	private := &ErrIndexInconsistent{Index: "private-index", Detail: "private storage detail"}
+	ordinary := &ErrLedgerNotFound{Name: "caller-ledger"}
+	outer := &ErrStorageOperation{Operation: "loading index", Cause: private}
+	for _, tc := range []struct {
+		name       string
+		err        Describable
+		overridden bool
+	}{
+		{"private", private, true},
+		{"business private", &BusinessError{Err: private}, true},
+		{"nested business private", &BusinessError{Err: &BusinessError{Err: private}}, true},
+		{"ordinary", ordinary, false},
+		{"business ordinary", &BusinessError{Err: ordinary}, false},
+		{"distinct outer reason", outer, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			message, metadata, overridden := PublicErrorDetails(tc.err)
+			require.Equal(t, tc.overridden, overridden)
+			if overridden {
+				require.Equal(t, "index is inconsistent", message)
+				require.Empty(t, metadata)
+				require.Equal(t, "index private-index is inconsistent: private storage detail", tc.err.Error())
+				require.Equal(t, map[string]string{"index": "private-index", "detail": "private storage detail"}, tc.err.Metadata())
+			} else {
+				require.Equal(t, tc.err.Error(), message)
+				require.Equal(t, tc.err.Metadata(), metadata)
+			}
+		})
+	}
+}

--- a/internal/infra/monitoring/otlplogs/module.go
+++ b/internal/infra/monitoring/otlplogs/module.go
@@ -2,13 +2,11 @@ package otlplogs
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"runtime/debug"
 
 	prettyconsole "github.com/thessem/zap-prettyconsole"
 	"go.opentelemetry.io/contrib/bridges/otelzap"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc"
 	"go.opentelemetry.io/otel/log/global"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
@@ -33,6 +31,8 @@ const (
 type ModuleConfig struct {
 	Exporter   string
 	OTLPConfig *OTLPConfig
+	// Resource is the server resource shared with traces and metrics.
+	Resource   *resource.Resource
 	Output     io.Writer
 	Level      logging.Level
 	FormatJSON bool
@@ -84,21 +84,11 @@ func Logger(cfg ModuleConfig) (logging.Logger, error) {
 		exporter = NewNoOpExporter()
 	}
 
-	defaultResource := resource.Default()
-	attributes := make([]attribute.KeyValue, 0)
-	attributes = append(attributes, attribute.String("service.name", "ledger-exp"))
-	attributes = append(attributes, attribute.String("service.version", "0.1.0"))
-
-	resource, err := resource.Merge(defaultResource, resource.NewSchemaless(attributes...))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create resource: %w", err)
-	}
-
 	loggerProvider := sdklog.NewLoggerProvider(
 		sdklog.WithProcessor(
 			sdklog.NewBatchProcessor(exporter),
 		),
-		sdklog.WithResource(resource),
+		sdklog.WithResource(cfg.Resource),
 	)
 
 	global.SetLoggerProvider(loggerProvider)

--- a/internal/infra/monitoring/otlplogs/resource_test.go
+++ b/internal/infra/monitoring/otlplogs/resource_test.go
@@ -1,0 +1,100 @@
+package otlplogs
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/log/global"
+	sdklog "go.opentelemetry.io/otel/sdk/log"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	collector "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	"google.golang.org/grpc"
+
+	"github.com/formancehq/go-libs/v5/pkg/observe"
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+type resourceLogReceiver struct {
+	collector.UnimplementedLogsServiceServer
+
+	received chan *collector.ExportLogsServiceRequest
+}
+
+func (r *resourceLogReceiver) Export(ctx context.Context, request *collector.ExportLogsServiceRequest) (*collector.ExportLogsServiceResponse, error) {
+	select {
+	case r.received <- request:
+		return &collector.ExportLogsServiceResponse{}, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// Logger changes the global log provider, so this collector test runs serially.
+func TestLoggerExportsSharedTraceResource(t *testing.T) {
+	previousProvider := global.GetLoggerProvider()
+	t.Cleanup(func() { global.SetLoggerProvider(previousProvider) })
+
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+	server := grpc.NewServer()
+	receiver := &resourceLogReceiver{received: make(chan *collector.ExportLogsServiceRequest, 1)}
+	collector.RegisterLogsServiceServer(server, receiver)
+	served := make(chan error, 1)
+	go func() { served <- server.Serve(listener) }()
+	t.Cleanup(func() {
+		server.Stop()
+		require.NoError(t, <-served)
+	})
+
+	sharedResource, err := observe.BuildResource("ledger-node-42", []string{
+		"service.name=ledger-custom", "service.version=overridden-build", "deployment.environment=regression",
+	}, "3.0.0-build")
+	require.NoError(t, err)
+	spanExporter := tracetest.NewInMemoryExporter()
+	traceProvider := sdktrace.NewTracerProvider(sdktrace.WithResource(sharedResource), sdktrace.WithSyncer(spanExporter))
+	t.Cleanup(func() { require.NoError(t, traceProvider.Shutdown(context.Background())) })
+	_, span := traceProvider.Tracer("resource-regression").Start(t.Context(), "request")
+	span.End()
+	spans := spanExporter.GetSpans()
+	require.Len(t, spans, 1)
+
+	logger, err := Logger(ModuleConfig{
+		Exporter:   OTLPExporter,
+		OTLPConfig: &OTLPConfig{Mode: "grpc", Endpoint: listener.Addr().String(), Insecure: true},
+		Resource:   sharedResource, Output: io.Discard, Level: logging.InfoLevel,
+	})
+	require.NoError(t, err)
+	provider, ok := global.GetLoggerProvider().(*sdklog.LoggerProvider)
+	require.True(t, ok)
+	t.Cleanup(func() { require.NoError(t, provider.Shutdown(context.Background())) })
+
+	logger.Info("shared-resource-regression")
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, provider.ForceFlush(ctx))
+	select {
+	case request := <-receiver.received:
+		require.Len(t, request.GetResourceLogs(), 1)
+		exported := request.GetResourceLogs()[0]
+		got := make(map[string]string)
+		for _, attribute := range exported.GetResource().GetAttributes() {
+			got[attribute.GetKey()] = attribute.GetValue().GetStringValue()
+		}
+		want := make(map[string]string)
+		for _, attribute := range spans[0].Resource.Attributes() {
+			want[string(attribute.Key)] = attribute.Value.AsString()
+		}
+		require.Equal(t, want, got, "logs and actual exported spans must share all resource attributes")
+		require.Equal(t, spans[0].Resource.SchemaURL(), exported.GetSchemaUrl())
+		require.Len(t, exported.GetScopeLogs(), 1)
+		require.Len(t, exported.GetScopeLogs()[0].GetLogRecords(), 1)
+		require.Equal(t, "shared-resource-regression", exported.GetScopeLogs()[0].GetLogRecords()[0].GetBody().GetStringValue())
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+}

--- a/internal/infra/state/delete_ledger_cascade_test.go
+++ b/internal/infra/state/delete_ledger_cascade_test.go
@@ -99,6 +99,17 @@ func TestDeleteLedger_MissingBoundaryCoverageSurfacesCoverageMiss(t *testing.T) 
 	require.ErrorAs(t, result.Results[0].Error, &miss, "the gated boundary delete must surface *ErrCoverageMiss")
 	require.Equal(t, "boundaries", miss.Attribute)
 
+	// The real FSM result retains the diagnostic key for audit and operators,
+	// while its public presentation must not expose that key to the caller.
+	var described domain.Describable
+	require.ErrorAs(t, result.Results[0].Error, &described)
+	message, metadata, overridden := domain.PublicErrorDetails(described)
+	require.True(t, overridden)
+	require.Equal(t, "preload coverage miss", message)
+	require.Empty(t, metadata)
+	require.NotEmpty(t, miss.CanonicalHex)
+	require.NotEmpty(t, miss.Metadata()["canonicalHex"])
+
 	// The ledger row is untouched (the proposal was rejected as a unit).
 	info, _, err := fsm.Registry.Ledgers.GetKey(domain.LedgerKey{Name: ledgerName})
 	require.NoError(t, err)

--- a/internal/infra/state/public_error_audit_test.go
+++ b/internal/infra/state/public_error_audit_test.go
@@ -1,0 +1,47 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+)
+
+// API redaction must not erase the diagnostic identity hashed into audit
+// failures. Pin literal messages as well as context to catch accidental edits
+// to Error() (the general projection table intentionally derives its message).
+func TestPublicErrorAuditIdentityUnchanged(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		err      domain.Describable
+		message  string
+		metadata map[string]string
+	}{
+		{
+			name:     "coverage",
+			err:      &ErrCoverageMiss{Attribute: "volumes", CanonicalHex: "deadbeef", IDHex: "0102", RaftIndex: 42},
+			message:  "preload coverage miss (kind=volumes id=0102 raftIndex=42)",
+			metadata: map[string]string{"attribute": "volumes", "canonicalHex": "deadbeef", "idHex": "0102", "raftIndex": "42"},
+		},
+		{
+			name:     "index",
+			err:      &domain.ErrIndexInconsistent{Index: "private-index", Detail: "reading /private/pebble: secret failure"},
+			message:  "index private-index is inconsistent: reading /private/pebble: secret failure",
+			metadata: map[string]string{"index": "private-index", "detail": "reading /private/pebble: secret failure"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, metadata, overridden := domain.PublicErrorDetails(tc.err)
+			require.True(t, overridden)
+			require.Empty(t, metadata)
+			failure := buildAuditFailure(tc.err)
+			require.Equal(t, tc.message, failure.GetMessage())
+			require.Equal(t, tc.metadata, failure.GetContext())
+			require.Equal(t, tc.err.Reason(), domain.ReasonString(failure.GetReason()))
+		})
+	}
+}

--- a/internal/infra/state/scope.go
+++ b/internal/infra/state/scope.go
@@ -56,7 +56,8 @@ func (*ErrCoverageMiss) Reason() string { return domain.ErrReasonCoverageMiss }
 //     AuditFailure.Context. The snake_case keys were already in the audit.
 //   - planInvariantDescribable returns the bare miss to applyProposal, which
 //     surfaces it as a domain.BusinessError whose Metadata() delegates through
-//     to the gRPC/HTTP ErrorInfo.
+//     to the miss. That metadata used to reach the gRPC ErrorInfo; API error
+//     responses now use PublicDetails while the audit identity stays intact.
 //
 // So operator tooling keyed on canonical_hex / id_hex / raft_index stops
 // matching at this deploy, and audit entries for this failure class carry
@@ -76,6 +77,13 @@ func (e *ErrCoverageMiss) Metadata() map[string]string {
 		"idHex":        e.IDHex,
 		"raftIndex":    strconv.FormatUint(e.RaftIndex, 10),
 	}
+}
+
+// PublicDetails hides cache keys and Raft position from API error responses.
+// Error() and Metadata() must retain their diagnostic values: both are copied
+// into the authoritative, hash-chained AuditFailure by buildAuditFailure.
+func (*ErrCoverageMiss) PublicDetails() (string, map[string]string, bool) {
+	return "preload coverage miss", nil, true
 }
 
 // gatedScope decorates an embedded *WriteSet (the raw engine) with the

--- a/internal/query/log_inconsistency_test.go
+++ b/internal/query/log_inconsistency_test.go
@@ -3,6 +3,7 @@ package query
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"io"
 	"testing"
 
@@ -134,6 +135,29 @@ func TestReadLedgerLogsCompiled_IndexGetError(t *testing.T) {
 	var inc *domain.ErrIndexInconsistent
 	require.ErrorAs(t, err, &inc)
 	require.Contains(t, inc.Detail, "logID=99")
+}
+
+// An actual read-index IO failure can contain an internal filesystem path.
+// Keep its diagnostic detail while the type supplies a safe API presentation.
+func TestReadLedgerLogsCompiled_IndexGetErrorPublicDetails(t *testing.T) {
+	t.Parallel()
+
+	const cause = "open /private/ledger/index/000123.sst: permission denied"
+	_, err := ReadLedgerLogsCompiled(
+		context.Background(), nil, newGetterAlwaysErr(t, errors.New(cause)),
+		"test", [][]byte{logID8(99)},
+	)
+	var inc *domain.ErrIndexInconsistent
+	require.ErrorAs(t, err, &inc)
+	require.Equal(t, "reading per-ledger log index for logID=99: "+cause, inc.Detail)
+	require.Contains(t, inc.Error(), cause)
+
+	message, metadata, overridden := domain.PublicErrorDetails(inc)
+	require.True(t, overridden)
+	require.Equal(t, "index is inconsistent", message)
+	require.Empty(t, metadata)
+	require.Equal(t, domain.ErrReasonIndexInconsistent, inc.Reason())
+	require.Equal(t, domain.KindInternal, domain.Kind(inc))
 }
 
 // TestReadLedgerLogsCompiled_MalformedIndexValue asserts that an index entry

--- a/openapi.yml
+++ b/openapi.yml
@@ -3567,7 +3567,11 @@ components:
           description: Error code (present only on error)
         errorDescription:
           type: string
-          description: Error description (present only on error)
+          description: |
+            Client-facing error description (present only on error). Unknown
+            internal failures carry a generic message with a correlation ID;
+            internal index/coverage details are omitted. Machine-readable
+            error codes and the bulk response shape are preserved.
         data:
           description: |
             Operation result data. Shape depends on the originating action:
@@ -5438,7 +5442,10 @@ components:
           description: Error code identifier
         errorMessage:
           type: string
-          description: Human-readable error message
+          description: |
+            Human-readable, client-facing error message. INDEX_INCONSISTENT
+            and COVERAGE_MISS omit internal index, cache-key and Raft
+            details; other domain errors retain their documented diagnostics.
 
     AuditEntry:
       type: object

--- a/pkg/grpcprotocol/protocol.go
+++ b/pkg/grpcprotocol/protocol.go
@@ -12,7 +12,7 @@ const (
 	// Version must change when the client-facing wire format or semantics break.
 	// See docs/technical/architecture/subsystems/api/protocol-compatibility.md.
 	// A compiled constant also identifies local builds without release ldflags.
-	Version = "4"
+	Version = "5"
 	// MetadataKey carries the protocol version, not authentication credentials.
 	MetadataKey = "ledger-protocol-version"
 )


### PR DESCRIPTION
## What changed

Internal index and coverage failures now expose type-owned public messages and omit private ErrorInfo metadata. Their original messages and context remain available to server diagnostics and the authoritative audit chain.

Bulk internal failures gain correlated logs and spans; unknown errors expose a generic correlation message. Restore-config read failures retain gRPC `Internal` with sanitized messages. Logs, traces and metrics now share the configured OpenTelemetry resource.

## Why

Completes the confirmed Ledger-local remainder of [EN-1623](https://formance-team.atlassian.net/browse/EN-1623) after #1935. The original Jira investigation explicitly retained these source-disclosure and resource-alignment fixes. No duplicate second-slice task or PR was found; #1939 / EN-1980 address received-error reconstruction separately.

## Product / operational motivation

Need: diagnose failed requests without sending storage paths, cache identifiers or Raft positions to callers.
Current limitation: bulk and the explicit restore-config read-error status bypassed correlated sanitization; index/coverage error messages and metadata carried private diagnostics; OTLP logs used `ledger-exp`/`0.1.0` regardless of trace configuration.
Requirement: preserve status, stable reasons, bulk rollup, Numscript diagnostics and audit identity while correcting disclosure.
Evidence: failing-before/passing-after HTTP/gRPC tests, real malformed-store reads, a real FSM coverage rejection and index I/O fault, plus a local OTLP receiver comparing log resources against an exported span.
Durable repository evidence: API error sections, `coverage-gate.md`, `protocol-compatibility.md`, and `docs/ops/monitoring.md`.

## Technical decision

Types opt into a public presentation; adapters consume it without altering diagnostic `Error()`/`Metadata()`. Transparent business wrappers delegate it. Blanket sanitization of all `KindInternal` errors would discard actionable Numscript feedback. Redacting the original metadata would alter hash-bound audit failures. Both are avoided by separating presentation from audit identity.

The server builds one resource using existing go-libs flag precedence and supplies it to all telemetry providers.

## Risk

**MEDIUM** — deliberate public error-contract narrowing across adapters. The coverage trigger is an admitted malformed plan; this PR does not claim or fix an ordinary frontend producer exploit.

## Validation

Current candidate: `760517651c2ce7c6b0167dc7dc1b87d5684f824f`, rebased onto live target `658dfacacafd6a14b074c7ab2ddb484630178c56` (refreshed after validation).

- [x] Rebase and final diff/whitespace review: all three commits retain identical range-diffs
- [x] `GOMAXPROCS=4 GOFLAGS=-p=4 bash scripts/agent-check`
- [x] `GOMAXPROCS=4 GOFLAGS=-p=4 AI_REVIEW_BASE_SHA=658dfacacafd6a14b074c7ab2ddb484630178c56 bash scripts/agent-check-pr`: normalization/lints, all root-module race tests, Schemathesis
- [x] Schemathesis: 62 endpoints, no failed or errored endpoints; two transient network errors recovered by the harness
- [x] Fresh native exact-candidate review: APPROVE, zero findings, residual risk LOW; primary checkout unchanged; final target refresh unchanged
- [x] CI Tests rerun and complete workflow: SUCCESS; current HEAD approved by paul-nicolas; PR ready for review

The first pass on the preceding local base hit four unchanged 15-second shell-fixture deadlines in `TestRunModelTestRequiresVerifiedOutcome`. The same test then passed three isolated repetitions with identical CPU/package caps and race detection; the fresh complete canonical pass also passed the whole Antithesis package. No timeout, assertion or test was changed. Logs are retained in `build/en-1623/` locally.

The preceding native workflow approved an older candidate, then correctly stopped on target advancement. That approval is historical evidence, not the verdict for this exact candidate.

DISCOVERY: PARTIAL_FIX — #1935 addressed the first correlation slice; this PR fixes EN-1623's reproduced Ledger-local remainder.
BEFORE_FIX: BUG_REPRODUCED — public index/coverage disclosure, missing bulk and explicit gRPC read diagnostics, and mismatched exported OTLP resources failed focused tests before the fixes.
AFTER_FIX: PASS — fresh baseline and exact-base canonical validation pass on the current candidate; native exact review is APPROVE with zero findings.

## Target synchronization and review feedback

The latest rebase includes #1950 and #1951 without changing any EN-1623 patch. Their files do not overlap this PR. The query/readstore integration is covered by the fresh complete race suite; public error, audit presentation, telemetry resource and revision contracts remain unchanged.

The new base removed the public minimum-log-sequence contract and its filtered-audit wait path in #1881. This PR preserves that removal: its obsolete audit-head correction and the corresponding tests are dropped. The staged-config regression remains and now creates a restore service with the lifecycle introduced by #1908. The target already uses protocol revision 4, so EN-1623 advances it to 5. Other EN-1623 changes retain their scope.

Shipfox feedback was checked against current source:
- The raw `Unavailable` audit-head status is obsolete with the entire removed path.
- Comments now justify the two registered, correctly typed resource flag lookups.
- Telemetry wiring is confirmed in pinned go-libs v5.7.2: `observefx/traces.go` supplies `tracesdk.WithResource`, and `observefx/metrics.go` supplies `sdkmetric.WithResource`; both consume the resource supplied by `runServer`. The collector regression proves logs versus an exported span, not a full application metrics export.
- Extracting the repeated correlation-message literal is optional maintenance; no current divergence or runtime defect was demonstrated.

## Architecture / behavior impact

Service gRPC revision **4 → 5**: `INDEX_INCONSISTENT` and `COVERAGE_MISS` retain their codes/reasons but deliberately remove private messages/metadata. Restore-config read failures keep `Internal` with correlation messages. Rebuild communicating service clients and servers together.

No persisted state, audit identity, FSM application, restore semantics, protobuf layout or dependency version changes. An existing indirect OTLP module becomes direct for the collector test. HTTP bulk response structure and codes are unchanged.

## Review focus

Public versus audit presentation, wrapper behavior, real exceptional-path coverage, unchanged retry/status policy, and shared resource configuration.

## Known concerns

The first CI Tests job on this HEAD hit a pre-existing timing assertion in `TestSendPagedToStream_ProfilePhaseAttribution` (8.366327 ms against a 6 ms bound). The helper, test and duration accounting are unchanged by EN-1623. Twenty isolated repetitions with race detection passed, as did both complete local validations. Only the failed CI job was rerun; it and the complete workflow are now green. No assertion or timing threshold was changed.

[EN-1981](https://formance-team.atlassian.net/browse/EN-1981) owns the separate native OTLP context/exporter integration: pinned go-libs `ZapLogger.WithContext` still drops context, although explicit string trace/span fields export. It also records the advertised HTTP exporter-mode behavior for dedicated reproduction and correction.

Old remainder classification: gRPC logger injection is already fixed and tested (#1806); malformed protojson payloads produced static schema diagnostics only and remain defensive hardening; `ErrIdempotencyCheckFailed` has no production construction sites; mirror-v2 errors are outside direct HTTP conversion. Caller metadata and trace-response/CLI conventions are deferred hardening/product work. This PR does not merge automatically.


[EN-1623]: https://formance-team.atlassian.net/browse/EN-1623?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EN-1981]: https://formance-team.atlassian.net/browse/EN-1981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ