### PR TITLE
fix(EN-1980): preserve forwarded errors across API boundaries

### DIFF
--- a/docs/technical/architecture/subsystems/api/README.md
+++ b/docs/technical/architecture/subsystems/api/README.md
@@ -12,6 +12,10 @@ Client-facing transport layers (`internal/adapter/grpc`, `internal/adapter/http`
 | [http-api.md](http-api.md) | HTTP REST API endpoints, response formats, error handling, and the `apierr`/`grpcerr` error boundary crossed by a forwarded write. |
 | [auth.md](auth.md) | Client JWT authentication (OIDC + Ed25519), scope-based authorization, and the Raft inter-node cluster-secret auth layer. |
 
+Decoded leader errors retain their exact gRPC status through routing wrappers
+and streaming cursors. See [forwarding and cancellation](http-api.md#forwarded-writes-and-the-transport-seam)
+for the distinction between a decoded rejection and raw transport cancellation.
+
 ## Related
 
 - [Admission](../admission/) — what every write request enters next.

--- a/docs/technical/architecture/subsystems/api/grpc-api.md
+++ b/docs/technical/architecture/subsystems/api/grpc-api.md
@@ -562,6 +562,13 @@ Each business error response includes:
 
 ### gRPC Status Codes
 
+Forwarded decoded errors are re-emitted from `grpcerr.OriginalStatus` before
+generic status conversion, so outer routing context cannot replace the public
+message. All status details are preserved, including details beyond `ErrorInfo`.
+Streaming cursors also preserve these decoded statuses before interpreting raw
+`Canceled` as EOF or a retryable transport failure. An unknown Ledger reason
+carried by `Canceled` remains an error with its original details.
+
 | Code | Condition |
 |------|-----------|
 | `OK` | Request succeeded |

--- a/docs/technical/architecture/subsystems/api/http-api.md
+++ b/docs/technical/architecture/subsystems/api/http-api.md
@@ -97,7 +97,7 @@ Three paths need correlated server-side diagnostics because the raw value can co
 
 1. **Panic recovery** (`jsonRecoverer`) — a panic in any handler.
 2. **Unmapped errors** (`handleError` fallthrough → `writeInternalServerError`) — any error that is not a domain `Describable` or a known sentinel.
-3. **`KindInternal` domain errors** — recognized internal failures whose status and reason are preserved. `INDEX_INCONSISTENT` and `COVERAGE_MISS` supply public messages (`index is inconsistent` and `preload coverage miss`) that omit internal identifiers and storage details, including when wrapped. Other recognized error presentations are unchanged.
+3. **`KindInternal` domain errors** — recognized internal failures whose status and reason are preserved. `INDEX_INCONSISTENT` and `COVERAGE_MISS` supply public messages (`index is inconsistent` and `preload coverage miss`) that omit internal identifiers and storage details, including when wrapped. Other recognized errors retain their type-owned message, with outer diagnostic prefixes omitted.
 
 Type-owned public details are selected through `domain.PublicErrorDetails` at the response boundary. Diagnostic `Error()` and `Metadata()` values remain unchanged, including the coverage failure context in the authoritative audit chain.
 
@@ -216,13 +216,15 @@ kind would yield `KindInternal` and answer `500` for what the sender classified
 as a caller error.
 
 `Message` and `Metadata` are the client-safe presentation, not the diagnostic
-identity: a locally raised failure is read through `domain.PublicErrorDetails`,
-so a type that owns a separate public presentation (EN-1623) reaches a surface
-redacted, and `Descriptor.PublicOverride` tells the surface to render `Message`
-in place of the wrapped chain that presentation exists to withhold. A decoded
-failure needs no such selection — the sender applied it before serialising — so
-`PublicOverride` is false for an `*apierr.Remote` and the consumer keeps
-rendering its own outer context, exactly as it did before the hop.
+identity. A locally raised failure uses `domain.PublicErrorDetails` when its
+type owns a separate public presentation (EN-1623); otherwise its describable
+message is used. A decoded failure already contains the sender's selection.
+Both unitary and bulk HTTP responses render the descriptor's message rather
+than outer routing or Raft context, so local and forwarded failures have the
+same public text. `Descriptor.PublicOverride` still identifies a separate
+type-owned public presentation. Recognized internal failures retain their
+status and reason; unmapped errors, invalid wire pairs and panics retain the
+generic correlation-ID response.
 
 `apierr` imports `internal/domain` and nothing else, so HTTP reads a decoded
 failure without linking any gRPC detail. The reverse direction is a layering

--- a/docs/technical/architecture/subsystems/api/http-api.md
+++ b/docs/technical/architecture/subsystems/api/http-api.md
@@ -146,13 +146,15 @@ of excluded codes: **everything else passes through unchanged**. That covers
 three groups.
 
 - A **bare** `codes.Canceled`, because the cursor layer keys end-of-stream
-  detection off it and normalises it to `io.EOF`. The ledger `ErrorInfo` is
+  detection off it: caller cancellation becomes `io.EOF`, while a live caller
+  sees `Unavailable` for a failed transfer. The ledger `ErrorInfo` is
   still decoded first: no `ErrorKind` maps to `codes.Canceled`, so a reason
   this build knows arriving under it is a contradiction, and answering the
   status before the decode would exempt the one code with no legitimate reason
   from the mismatch policy below and hand the peer's message to the client.
-  Pagination is unaffected either way — a reconstructed value keeps answering
-  `GRPCStatus()` with the received `Canceled` status.
+  A decoded unknown reason carried by `Canceled` retains its full status through
+  both cursor implementations, even after caller teardown. `grpcerr.OriginalStatus`
+  identifies that decoded failure before the raw cancellation policy runs.
 - A **bare** status of any code — no ledger `ErrorInfo`, so no reason to
   recover. A bare `codes.Unavailable` already reaches the right outcome
   (`handleError` answers that code with `503` + `Retry-After` on its own);
@@ -175,6 +177,13 @@ The HTTP layer needs no status-code branch of its own: both mappers read the
 failure through `apierr.Describe`, which answers identically for a locally
 raised error and a decoded one, so a follower answers with the same status and
 `errorCode` as the leader and the bulk path is repaired by the same change.
+
+At a subsequent gRPC hop, the server uses `grpcerr.OriginalStatus` before generic
+status conversion. This preserves the sender's message and all status details
+even when routing has wrapped the error with diagnostic context. The helper
+recognizes only this decoder's reconstructed errors; invalid pairs and foreign
+or raw transport statuses retain their existing handling. The originating
+server's `PublicErrorDetails` selection is preserved rather than re-created.
 
 The decorator wraps the connection rather than the generated client's 37
 methods (11 of them server-streaming), because six of the `BucketGrpcClient`

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -946,6 +946,9 @@ original code, public message, and every status detail survive the hop; raw
 transport cancellation still follows the caller-context policy. Regression
 tests cover both production cursor types, wrapped repeated hops, exact REST/bulk
 message parity, and complete gRPC status parity between leader and followers.
+Unitary and bulk HTTP responses use the descriptor message for recognized
+public errors, omitting outer routing or Raft prefixes on both local and
+forwarded paths; internal-error sanitization remains in force.
 
 **Client-side usage (Go):**
 

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -940,7 +940,15 @@ The decoded representation lives at the adapter boundary by design, not in `inte
 
 **Mismatch policy.** A reason ledger knows is a reason whose legitimate wire codes it knows: `CodeForKind(KindForReason(reason))`, today exactly one code, since every enum reason is encoded through `describableToGRPCStatus` and nothing else. Validation stays reason-keyed rather than kind-keyed so a reason that must travel under a second code can be widened alone. A known reason arriving under a code outside that set is a protocol fault, not a business outcome: every consumer branches on `apierr.InvalidWire` and answers its own internal-error representation — `500 INTERNAL_ERROR` + correlation ID on REST (unitary *and* per bulk element), `codes.Unknown` + correlation ID on gRPC, the invalid-pair message on `ledgerctl` — so the received message and metadata are dropped rather than echoed as trusted business information. An unknown reason cannot be validated and is preserved verbatim — reason, message, metadata and exact status.
 
+On internal forwarding hops, `grpcerr.OriginalStatus` preserves decoded statuses
+through outer error wrappers and before cursor cancellation normalization. The
+original code, public message, and every status detail survive the hop; raw
+transport cancellation still follows the caller-context policy. Regression
+tests cover both production cursor types, wrapped repeated hops, exact REST/bulk
+message parity, and complete gRPC status parity between leader and followers.
+
 **Client-side usage (Go):**
+
 ```go
 import (
     "google.golang.org/genproto/googleapis/rpc/errdetails"

--- a/internal/adapter/apierr/apierr.go
+++ b/internal/adapter/apierr/apierr.go
@@ -168,8 +168,8 @@ func InvalidWire(err error) (*InvalidWireError, bool) {
 // reaches a surface through this contract with the diagnostic one. A decoded
 // remote failure needs no such selection: the sender already applied it before
 // serialising (internal/adapter/grpc.describableToGRPCStatus), so what arrived
-// is the public presentation and PublicOverride stays false — a consumer keeps
-// rendering its own outer context for it, exactly as it did before the hop.
+// is the public presentation and PublicOverride stays false. Consumers render
+// Message on public paths so outer routing context cannot change the response.
 func Describe(err error) (Descriptor, bool) {
 	if remote, ok := errors.AsType[*Remote](err); ok {
 		return Descriptor{

--- a/internal/adapter/apierr/apierr_test.go
+++ b/internal/adapter/apierr/apierr_test.go
@@ -188,8 +188,8 @@ func TestDescribe_LocalDescribableUsesItsPublicPresentation(t *testing.T) {
 }
 
 // TestDescribe_LocalDescribableWithoutPublicPresentation: the common case is
-// unchanged — Error() and Metadata() are the client-facing values, and the
-// consumer keeps rendering its own outer context.
+// unchanged — the describable Error() and Metadata() are the client-facing
+// values, without an explicit public presentation override.
 func TestDescribe_LocalDescribableWithoutPublicPresentation(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapter/grpc/cursor.go
+++ b/internal/adapter/grpc/cursor.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/formancehq/ledger/v3/internal/adapter/grpcerr"
 	"github.com/formancehq/ledger/v3/internal/pkg/cursor"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
@@ -33,7 +34,7 @@ func (c GRPCStreamCursor[Res, To]) Next() (To, error) {
 	return c.mapper(next)
 }
 
-// normalizeStreamEnd maps a Canceled Recv error to io.EOF ONLY when the
+// normalizeStreamEnd maps a raw Canceled Recv error to io.EOF ONLY when the
 // cancellation is the consumer's own — the caller-supplied context is done
 // because the consumer stopped reading and tore the stream down, so the
 // results gathered so far form a complete answer for it. A Canceled status
@@ -49,6 +50,10 @@ func (c GRPCStreamCursor[Res, To]) Next() (To, error) {
 // into the retry path (gRPC clients retry it; HTTP serves 503 with
 // Retry-After).
 //
+// A decoded Ledger failure retains its original status, including Canceled
+// carried by an unknown reason. Neither caller teardown nor the raw transport
+// retry policy may discard that failure's message and details.
+//
 // The ours/not-ours verdict MUST come from the caller-supplied context,
 // never from ClientStream.Context(): gRPC derives the stream context with
 // WithCancel and cancels it in finish() on EVERY stream termination, so by
@@ -56,6 +61,9 @@ func (c GRPCStreamCursor[Res, To]) Next() (To, error) {
 // gates nothing.
 func normalizeStreamEnd(ctx context.Context, err error) error {
 	if status.Code(err) != codes.Canceled {
+		return err
+	}
+	if grpcerr.OriginalStatus(err) != nil {
 		return err
 	}
 

--- a/internal/adapter/grpc/cursor_error_boundary_test.go
+++ b/internal/adapter/grpc/cursor_error_boundary_test.go
@@ -1,0 +1,124 @@
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	ggrpc "google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/formancehq/ledger/v3/internal/adapter/apierr"
+	"github.com/formancehq/ledger/v3/internal/adapter/grpcerr"
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/pkg/cursor"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+)
+
+func TestForwardedCursorPreservesCanceledLedgerStatus(t *testing.T) {
+	t.Parallel()
+
+	constructors := []struct {
+		name string
+		new  func(context.Context, ggrpc.ServerStreamingClient[commonpb.Account]) cursor.Cursor[*commonpb.Account]
+	}{
+		{"upstream peek", NewUpstreamPeekCursor[commonpb.Account]},
+		{"generic identity", NewGRPCIdentityCursor[commonpb.Account]},
+	}
+	for _, constructor := range constructors {
+		for _, structured := range []bool{true, false} {
+			t.Run(fmt.Sprintf("%s/ledger=%t", constructor.name, structured), func(t *testing.T) {
+				t.Parallel()
+				const reason = "FUTURE_LEDGER_CANCELED_REASON"
+				const message = "upstream operation canceled"
+				metadata := map[string]string{"request": "retained-upstream-context"}
+				upstream := status.New(codes.Canceled, message)
+				if structured {
+					var err error
+					upstream, err = upstream.WithDetails(
+						&errdetails.ErrorInfo{Domain: "ledger", Reason: reason, Metadata: metadata},
+						&errdetails.RetryInfo{RetryDelay: durationpb.New(7 * time.Second)},
+					)
+					require.NoError(t, err)
+				}
+				client := dialCursorBoundaryServer(t, &endingBucketServer{rows: 2, endErr: upstream.Err()})
+				ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
+				t.Cleanup(cancel)
+				stream, err := client.ListAccounts(ctx, &servicepb.ListAccountsRequest{Ledger: "ledger"})
+				require.NoError(t, err)
+				cur := constructor.new(ctx, stream)
+				t.Cleanup(func() { require.NoError(t, cur.Close()) })
+				for i := range 2 {
+					row, err := cur.Next()
+					require.NoError(t, err)
+					require.Equal(t, fmt.Sprintf("acc-%d", i), row.GetAddress())
+				}
+				_, terminal := cur.Next()
+				require.Error(t, terminal)
+				require.NoError(t, ctx.Err(), "the caller is still reading when the upstream status arrives")
+
+				if !structured {
+					// Genuine transport cancellation keeps its existing behavior.
+					_, described := apierr.Describe(terminal)
+					require.False(t, described)
+					require.Equal(t, codes.Unavailable, status.Code(terminal))
+					require.Contains(t, status.Convert(terminal).Message(), message)
+					require.Empty(t, status.Convert(terminal).Details())
+
+					return
+				}
+
+				want := apierr.Descriptor{Kind: domain.KindInternal, Reason: reason, Message: message, Metadata: metadata}
+				// Once the actual wire failure has arrived, caller teardown
+				// must not turn the already-decoded business failure into EOF.
+				cancel()
+				require.ErrorIs(t, ctx.Err(), context.Canceled)
+				require.Same(t, terminal, normalizeStreamEnd(ctx, terminal))
+				for hop := range 2 {
+					descriptor, described := apierr.Describe(terminal)
+					require.True(t, described, "cursor must preserve the decoded Ledger failure, hop %d", hop)
+					require.Equal(t, want, descriptor)
+					require.True(t, proto.Equal(upstream.Proto(), status.Convert(terminal).Proto()),
+						"cursor and second hop must retain the entire upstream status, hop %d: %v", hop, terminal)
+					terminal = convertToGRPCError(fmt.Errorf("follower forwarding context: %w", terminal), testLogger())
+					require.True(t, proto.Equal(upstream.Proto(), status.Convert(terminal).Proto()),
+						"the real server encoder must preserve all details and the safe message, hop %d", hop)
+					terminal = grpcerr.FromStatusError(terminal)
+				}
+			})
+		}
+	}
+}
+
+func dialCursorBoundaryServer(t *testing.T, srv servicepb.BucketServiceServer) servicepb.BucketServiceClient {
+	t.Helper()
+	listener := bufconn.Listen(1 << 20)
+	server := ggrpc.NewServer()
+	servicepb.RegisterBucketServiceServer(server, srv)
+	serveErr := make(chan error, 1)
+	go func() { serveErr <- server.Serve(listener) }()
+	t.Cleanup(func() {
+		server.Stop()
+		require.NoError(t, <-serveErr)
+	})
+	conn, err := ggrpc.NewClient("passthrough:///cursor-boundary",
+		ggrpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+			return listener.DialContext(ctx)
+		}),
+		ggrpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, conn.Close()) })
+
+	return servicepb.NewBucketServiceClient(grpcerr.NewConn(conn))
+}

--- a/internal/adapter/grpc/forwarded_status_test.go
+++ b/internal/adapter/grpc/forwarded_status_test.go
@@ -1,0 +1,53 @@
+package grpc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/formancehq/ledger/v3/internal/adapter/grpcerr"
+)
+
+func TestForwardedStatusPreservedThroughWrappers(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name   string
+		code   codes.Code
+		reason string
+	}{
+		{"conflict", codes.FailedPrecondition, "LEDGER_DELETED"},
+		{"public internal", codes.Internal, "COVERAGE_MISS"},
+		{"unknown aborted", codes.Aborted, "FUTURE_REASON"},
+		{"unknown canceled", codes.Canceled, "FUTURE_REASON"},
+		{"bare not found", codes.NotFound, ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			upstream, err := status.New(tt.code, "safe upstream message").WithDetails(
+				&errdetails.RetryInfo{RetryDelay: &durationpb.Duration{Seconds: 7}},
+			)
+			require.NoError(t, err)
+			if tt.reason != "" {
+				upstream, err = upstream.WithDetails(&errdetails.ErrorInfo{
+					Domain: "ledger", Reason: tt.reason,
+				})
+				require.NoError(t, err)
+			}
+			wire := upstream
+			for hop := range 2 {
+				decoded := grpcerr.FromStatusError(wire.Err())
+				wrapped := fmt.Errorf("private routing context: %w", decoded)
+				wire = status.Convert(convertToGRPCError(wrapped, testLogger()))
+				require.True(t, proto.Equal(upstream.Proto(), wire.Proto()),
+					"hop %d changed upstream status: want %v, got %v", hop, upstream.Proto(), wire.Proto())
+			}
+		})
+	}
+}

--- a/internal/adapter/grpc/server.go
+++ b/internal/adapter/grpc/server.go
@@ -31,6 +31,7 @@ import (
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
 	"github.com/formancehq/ledger/v3/internal/adapter/apitrace"
+	"github.com/formancehq/ledger/v3/internal/adapter/grpcerr"
 	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/domain/crypto/signing"
 	"github.com/formancehq/ledger/v3/internal/infra/backup"
@@ -515,6 +516,12 @@ func convertToGRPCError(err error, logger logging.Logger) error {
 }
 
 func convertToGRPCErrorWithContext(ctx context.Context, err error, logger logging.Logger) error {
+	// Re-emit decoded statuses verbatim: outer routing context is diagnostic,
+	// not part of the upstream public message.
+	if st := grpcerr.OriginalStatus(err); st != nil {
+		return st.Err()
+	}
+
 	// Already a gRPC status error, return as-is
 	if _, ok := status.FromError(err); ok {
 		return err

--- a/internal/adapter/grpcerr/conn.go
+++ b/internal/adapter/grpcerr/conn.go
@@ -58,8 +58,9 @@ type clientStream struct {
 }
 
 // RecvMsg converts the receive error. io.EOF (a normal stream end) is not a
-// status and passes through untouched, as does the codes.Canceled that
-// internal/adapter/grpc/cursor.go normalises into io.EOF.
+// status and passes through untouched. Bare Canceled statuses also remain raw
+// for the cursor's caller-cancellation policy; decoded Ledger failures retain
+// their original status through that policy.
 func (s *clientStream) RecvMsg(m any) error {
 	return FromStatusError(s.ClientStream.RecvMsg(m))
 }

--- a/internal/adapter/grpcerr/errors.go
+++ b/internal/adapter/grpcerr/errors.go
@@ -38,8 +38,9 @@
 //     reason this build knows arriving under it is a contradiction, and
 //     letting the passthrough run first would hand the client the untrusted
 //     message of a pair the validation exists to reject. A reconstructed
-//     value keeps answering GRPCStatus() with the received Canceled status,
-//     so cursor termination is unaffected either way.
+//     value keeps answering GRPCStatus() with the received Canceled status;
+//     cursors preserve that decoded failure before applying raw transport
+//     cancellation policy.
 //   - A *bare* status of any code — no ledger ErrorInfo to decode, and no
 //     reason to recover. Bare codes.Unavailable (no leader yet, peer missing
 //     from the pool, stream torn down) already reaches the right outcome:
@@ -245,10 +246,21 @@ func (e *reconstructedError) Unwrap() error { return e.inner }
 
 // GRPCStatus keeps the original status reachable through status.FromError, so
 // the code survives reconstruction unchanged — the transport axis is preserved
-// exactly as received, independently of the semantic kind. cursor.go's
-// end-of-stream check and convertToGRPCError's "already a status, return
-// as-is" shortcut both depend on it.
+// exactly as received, independently of the semantic kind. Forwarding uses
+// OriginalStatus below so outer wrappers cannot replace its public message.
 func (e *reconstructedError) GRPCStatus() *status.Status { return e.st }
+
+// OriginalStatus returns the status retained by this decoder, even through
+// additional error wrappers. Unlike status.FromError, it does not replace the
+// upstream message with the outer error's diagnostic text. Raw transport
+// statuses and rejected wire pairs have no reconstructed status here.
+func OriginalStatus(err error) *status.Status {
+	if reconstructed, ok := errors.AsType[*reconstructedError](err); ok {
+		return reconstructed.st
+	}
+
+	return nil
+}
 
 // Decode reads the boundary view out of a gRPC status error. It returns:
 //

--- a/internal/adapter/http/error_handler.go
+++ b/internal/adapter/http/error_handler.go
@@ -123,11 +123,9 @@ func handleError(w http.ResponseWriter, r *http.Request, err error) {
 		if httpStatus == http.StatusInternalServerError {
 			recordHTTPInternalError(r, correlationID(r), err)
 		}
-		if d.PublicOverride {
-			err = errors.New(d.Message)
-		}
-
-		writeErrorResponse(w, httpStatus, d.Reason, err)
+		// Render the same public message selected by the originating gRPC
+		// encoder; routing wrappers belong to diagnostics, not the response.
+		writeErrorResponse(w, httpStatus, d.Reason, errors.New(d.Message))
 
 		return
 	}

--- a/internal/adapter/http/error_message_parity_test.go
+++ b/internal/adapter/http/error_message_parity_test.go
@@ -1,0 +1,72 @@
+package http
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/adapter/grpcerr"
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+)
+
+func TestErrorMessageParityThroughRoutingWrappers(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		err     domain.Describable
+		status  int
+		message string
+	}{
+		{"metadata", &domain.ErrMetadataFieldNotInSchema{Target: "TARGET_TYPE_ACCOUNT", Key: "never-declared"}, http.StatusBadRequest, "metadata field not declared in schema: TARGET_TYPE_ACCOUNT/never-declared"},
+		{"not found", &domain.ErrLedgerNotFound{Name: "test"}, http.StatusNotFound, "ledger does not exist: test"},
+		{"public internal", &domain.ErrIndexInconsistent{Index: "private-index", Detail: "private-storage-failure"}, http.StatusInternalServerError, "index is inconsistent"},
+		{"numscript", &domain.ErrNumscriptRuntime{Detail: "negative posting amount"}, http.StatusInternalServerError, "numscript runtime error: negative posting amount"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			message, metadata, _ := domain.PublicErrorDetails(tc.err)
+			wire := leaderStatusWithMetadata(t, grpcerr.CodeForKind(domain.Kind(tc.err)), message, tc.err.Reason(), metadata)
+			for _, origin := range []struct {
+				name string
+				err  error
+			}{
+				{"local", &domain.BusinessError{Err: tc.err}},
+				{"forwarded", grpcerr.FromStatusError(wire)},
+			} {
+				t.Run(origin.name, func(t *testing.T) {
+					t.Parallel()
+					wrapped := fmt.Errorf("applying raft requests: %w", origin.err)
+					diagnostic := wrapped.Error()
+					t.Run("unitary", func(t *testing.T) {
+						w := httptest.NewRecorder()
+						handleError(w, httptest.NewRequest(http.MethodPost, "/", nil), wrapped)
+						require.Equal(t, tc.status, w.Code)
+						response := decodeResponse[ErrorResponse](t, w)
+						require.Equal(t, tc.err.Reason(), response.ErrorCode)
+						require.Equal(t, tc.message, response.ErrorMessage)
+					})
+
+					t.Run("bulk", func(t *testing.T) {
+						elements := []*servicepb.BulkElement{{Action: &servicepb.LedgerAction{
+							Data: &servicepb.LedgerAction_CreateTransaction{CreateTransaction: &servicepb.CreateTransactionPayload{}},
+						}}}
+						w := httptest.NewRecorder()
+						writeBulkResponse(w, testBulkRequest(), elements, []bulkResult{{err: wrapped}}, false)
+						require.Equal(t, tc.status, w.Code)
+						bulk := decodeResponse[bulkResponse](t, w)
+						require.Len(t, bulk.Data, 1)
+						require.Equal(t, "ERROR", bulk.Data[0].ResponseType)
+						require.Equal(t, tc.err.Reason(), bulk.Data[0].ErrorCode)
+						require.Equal(t, tc.message, bulk.Data[0].ErrorDescription)
+					})
+					require.Equal(t, diagnostic, wrapped.Error(), "rendering must preserve the diagnostic error")
+				})
+			}
+		})
+	}
+}

--- a/internal/adapter/http/handlers_bulk.go
+++ b/internal/adapter/http/handlers_bulk.go
@@ -368,21 +368,20 @@ func perElementStatus(err error) int {
 // bulkErrorDescription applies the same diagnostics and public presentation as
 // single-request errors while preserving the bulk envelope, reasons and rollup.
 func bulkErrorDescription(r *http.Request, err error) string {
-	message := err.Error()
-	if perElementStatus(err) != http.StatusInternalServerError {
-		return message
+	internal := perElementStatus(err) == http.StatusInternalServerError
+	var id string
+	if internal {
+		id = correlationID(r)
+		recordHTTPInternalError(r, id, err)
 	}
-	id := correlationID(r)
-	recordHTTPInternalError(r, id, err)
 	if d, ok := apierr.Describe(err); ok {
-		if d.PublicOverride {
-			return d.Message
-		}
-
-		return message
+		return d.Message
+	}
+	if internal {
+		return fmt.Sprintf("internal server error (correlation ID: %s)", id)
 	}
 
-	return fmt.Sprintf("internal server error (correlation ID: %s)", id)
+	return err.Error()
 }
 
 // bulkErrorCode returns a machine-readable code for a per-element bulk failure.

--- a/internal/adapter/http/public_errors_test.go
+++ b/internal/adapter/http/public_errors_test.go
@@ -55,7 +55,7 @@ func TestHTTPPublicDetailsPreserveOtherWrappedErrors(t *testing.T) {
 	w := httptest.NewRecorder()
 	handleError(w, httptest.NewRequest(http.MethodGet, "/", nil), err)
 	require.Equal(t, http.StatusNotFound, w.Code)
-	require.Equal(t, err.Error(), decodeResponse[ErrorResponse](t, w).ErrorMessage)
+	require.Equal(t, "ledger does not exist: test", decodeResponse[ErrorResponse](t, w).ErrorMessage)
 }
 
 func TestHTTPPublicDetailsPreserveNumscriptDiagnostics(t *testing.T) {
@@ -66,5 +66,5 @@ func TestHTTPPublicDetailsPreserveNumscriptDiagnostics(t *testing.T) {
 	require.Equal(t, http.StatusInternalServerError, w.Code)
 	response := decodeResponse[ErrorResponse](t, w)
 	require.Equal(t, domain.ErrReasonNumscriptRuntime, response.ErrorCode)
-	require.Equal(t, err.Error(), response.ErrorMessage)
+	require.Equal(t, "numscript runtime error: negative posting amount", response.ErrorMessage)
 }

--- a/tests/e2e/cluster/rest_error_parity_test.go
+++ b/tests/e2e/cluster/rest_error_parity_test.go
@@ -16,6 +16,10 @@ import (
 	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 // restOutcome is the client-visible part of a REST error: what a caller
@@ -45,8 +49,8 @@ type restOutcome struct {
 // wrongly, which a leader-only expectation would miss.
 //
 // Only writes are covered here, deliberately. Reads are served locally behind a
-// ReadIndex barrier and forward to the leader only while a node is syncing,
-// which is not reachable deterministically in a healthy cluster; the HTTP
+// ReadIndex barrier and forward on syncing or an in-flight leadership change,
+// which are not deterministic routes in a healthy cluster; the HTTP
 // surface exposes no consistency header to force it. The forwarded-read and
 // list-stream paths run through the same seam and are covered at the unit level
 // by internal/adapter/grpcerr (TestConn_StreamErrorIsReconstructed).
@@ -135,7 +139,8 @@ var _ = Describe("REST error parity across cluster nodes (EN-1636)", Ordered, fu
 	}
 
 	// expectParity sends the same rejected request to the leader and to every
-	// follower and asserts they answer identically, with the expected outcome.
+	// follower and asserts all public REST error fields are identical. REST does
+	// not expose structured metadata; the gRPC spec below checks that separately.
 	expectParity := func(path, body string, wantStatus int, wantCode string) {
 		GinkgoHelper()
 
@@ -147,6 +152,7 @@ var _ = Describe("REST error parity across cluster nodes (EN-1636)", Ordered, fu
 
 		Expect(onLeader.StatusCode).To(Equal(wantStatus), "leader body: %s", onLeader.ErrorMessage)
 		Expect(onLeader.ErrorCode).To(Equal(wantCode))
+		Expect(onLeader.ErrorMessage).NotTo(BeEmpty())
 
 		for _, follower := range followers {
 			onFollower := post(follower, path, body)
@@ -157,6 +163,9 @@ var _ = Describe("REST error parity across cluster nodes (EN-1636)", Ordered, fu
 			Expect(onFollower.ErrorCode).To(Equal(wantCode),
 				"node %d answered errorCode %q where the leader answered %q",
 				follower.NodeID, onFollower.ErrorCode, onLeader.ErrorCode)
+			Expect(onFollower.ErrorMessage).To(Equal(onLeader.ErrorMessage),
+				"node %d changed the leader's safe error message: got %q, want %q",
+				follower.NodeID, onFollower.ErrorMessage, onLeader.ErrorMessage)
 
 			// The sanitizer's fingerprints. Asserted separately from the
 			// equality above so a failure says which contract broke.
@@ -183,6 +192,36 @@ var _ = Describe("REST error parity across cluster nodes (EN-1636)", Ordered, fu
 		// here for the errorCode half of the contract: before the fix a follower
 		// dropped LEDGER_ALREADY_EXISTS entirely.
 		expectParity("/"+ledgerName, `{}`, http.StatusConflict, "LEDGER_ALREADY_EXISTS")
+	})
+
+	It("preserves the gRPC reason, safe message, and metadata through a follower (EN-1980)", func() {
+		leader, followers := splitByRole()
+		apply := func(node *testutil.ServiceWithClient) *status.Status {
+			GinkgoHelper()
+			_, err := node.Client.Apply(ctx,
+				servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledgerName, nil)))
+			Expect(err).To(HaveOccurred())
+			st, ok := status.FromError(err)
+			Expect(ok).To(BeTrue())
+			return st
+		}
+
+		onLeader := apply(leader)
+		Expect(onLeader.Code()).To(Equal(codes.AlreadyExists))
+		Expect(onLeader.Message()).To(Equal("ledger already exists: " + ledgerName))
+		Expect(onLeader.Details()).To(HaveLen(1))
+		info, ok := onLeader.Details()[0].(*errdetails.ErrorInfo)
+		Expect(ok).To(BeTrue())
+		Expect(info.Reason).To(Equal("LEDGER_ALREADY_EXISTS"))
+		Expect(info.Domain).To(Equal("ledger"))
+		Expect(info.Metadata).To(Equal(map[string]string{"name": ledgerName}))
+
+		for _, follower := range followers {
+			onFollower := apply(follower)
+			Expect(proto.Equal(onFollower.Proto(), onLeader.Proto())).To(BeTrue(),
+				"node %d changed the leader's gRPC error: got %v, want %v",
+				follower.NodeID, onFollower.Proto(), onLeader.Proto())
+		}
 	})
 
 	It("returns the same 409 and errorCode on every node for a write to a deleted ledger", func() {
@@ -215,7 +254,7 @@ var _ = Describe("REST error parity across cluster nodes (EN-1636)", Ordered, fu
 		expectParity("/"+deletedLedger, `{}`, http.StatusConflict, "LEDGER_DELETED")
 	})
 
-	It("returns the same per-element errorCode on every node for a failing bulk element", func() {
+	It("returns the same per-element reason and safe message on every node for a failing bulk element", func() {
 		// Bulk has its own error mapper (perElementStatus / bulkErrorCode), which
 		// dispatches on the same Describable contract. Before the fix it lacked
 		// even the InvalidArgument consolation the single-request path had, so
@@ -225,7 +264,7 @@ var _ = Describe("REST error parity across cluster nodes (EN-1636)", Ordered, fu
 
 		leader, followers := splitByRole()
 
-		elementCode := func(node *testutil.ServiceWithClient) string {
+		elementOutcome := func(node *testutil.ServiceWithClient) restOutcome {
 			GinkgoHelper()
 
 			url := fmt.Sprintf("http://localhost:%d/v3/%s/bulk", node.HTTPPort, ledgerName)
@@ -244,7 +283,9 @@ var _ = Describe("REST error parity across cluster nodes (EN-1636)", Ordered, fu
 			var decoded struct {
 				ErrorCode string `json:"errorCode"`
 				Data      []struct {
-					ErrorCode string `json:"errorCode"`
+					ErrorCode        string `json:"errorCode"`
+					ErrorDescription string `json:"errorDescription"`
+					ResponseType     string `json:"responseType"`
 				} `json:"data"`
 			}
 			Expect(json.Unmarshal(raw, &decoded)).To(Succeed(), "unparseable bulk body: %s", raw)
@@ -260,21 +301,29 @@ var _ = Describe("REST error parity across cluster nodes (EN-1636)", Ordered, fu
 			Expect(decoded.Data).To(HaveLen(1),
 				"the rejection must be per-element, not request-level; top-level errorCode was %q, body: %s",
 				decoded.ErrorCode, raw)
+			Expect(decoded.ErrorCode).To(BeEmpty())
+			Expect(decoded.Data[0].ResponseType).To(Equal("ERROR"))
 
-			return decoded.Data[0].ErrorCode
+			return restOutcome{
+				StatusCode:   resp.StatusCode,
+				ErrorCode:    decoded.Data[0].ErrorCode,
+				ErrorMessage: decoded.Data[0].ErrorDescription,
+			}
 		}
 
 		// The posting's source is an account with no balance, so admission
 		// rejects the single element with INSUFFICIENT_FUNDS (KindPrecondition,
 		// 400). Pinning the expected code rather than only "non-empty and equal"
 		// means the spec fails if the element stops reaching the FSM at all.
-		onLeader := elementCode(leader)
-		Expect(onLeader).To(Equal("INSUFFICIENT_FUNDS"),
+		onLeader := elementOutcome(leader)
+		Expect(onLeader.ErrorCode).To(Equal("INSUFFICIENT_FUNDS"),
 			"the leader must name the business reason of the element rejection")
+		Expect(onLeader.StatusCode).To(Equal(http.StatusBadRequest))
+		Expect(onLeader.ErrorMessage).NotTo(BeEmpty())
 
 		for _, follower := range followers {
-			Expect(elementCode(follower)).To(Equal(onLeader),
-				"node %d reported a different per-element errorCode than the leader", follower.NodeID)
+			Expect(elementOutcome(follower)).To(Equal(onLeader),
+				"node %d reported a different per-element error than the leader", follower.NodeID)
 		}
 	})
 })


### PR DESCRIPTION
## What changed

Preserve decoded leader statuses through streaming cursors and outer routing wrappers. Unknown Ledger reasons carried by `Canceled` remain errors with their original code, message and details; generic transport cancellation retains its existing EOF/Unavailable behavior. Render the boundary descriptor message in unitary and bulk HTTP responses so local Raft wrappers do not appear only on the leader. Add exact REST/bulk message parity and complete gRPC status parity checks across cluster nodes.

## Why

Complete the forwarding contract from merged #1939 and [EN-1980](https://formance-team.atlassian.net/browse/EN-1980). A stream can return rows and then a structured rejection: converting that rejection into EOF hides the failure, while recoding it loses its status details. Wrapping a decoded error must not add internal routing text to its public message.

## Product / operational motivation

A caller must observe the leader's rejection faithfully regardless of the receiving node or number of forwarding hops. Regression tests reproduce lost cursor details and prefixed messages against merged #1939. The API forwarding documentation records the distinction between decoded failures and raw cancellation.

## Technical decision

Reuse #1939's private reconstructed error and expose its retained status through `grpcerr.OriginalStatus`. The server and cursor consult that helper before their generic status/cancellation policy. HTTP responses use the descriptor message on public paths while retaining internal-error sanitization. Re-encoding from semantic kind is lossy; `status.FromError` also changes the message when an outer wrapper is present.

The merged descriptor, `PublicErrorDetails`, invalid-pair sanitization, UNSPECIFIED rejection and business-core import guard remain unchanged.

## Risk

**MEDIUM** — changes terminal-error handling on forwarded streams. Raw cancellation siblings, both production cursor constructors and repeated wrapped hops have dedicated regressions.

## Validation

DISCOVERY: PARTIAL_FIX — #1939 supplies the boundary decoder; cursor normalization and wrapped re-emission still lose the original rejection.
BEFORE_FIX: BUG_REPRODUCED — both structured cursor cases and five wrapped-status cases fail against merge commit `8d38782c44b012101961cfb732322729a5163208`; raw cancellation siblings pass. The first cluster CI and native run additionally reproduce a leader-only `applying raft requests` message prefix; the additive HTTP unitary/bulk regression also fails before the HTTP rendering fix.
AFTER_FIX: PASS — full `internal/adapter/grpc`, `internal/adapter/grpcerr`, and `internal/adapter/http` race suites pass after the guards and HTTP presentation fix, including public-error, invalid-pair and raw-cancellation coverage.

- Exact candidate `94e2e0c4373a7eb82758db102326ecfa7363d827`, base `8d38782c44b012101961cfb732322729a5163208`: canonical `agent-check-pr` PASS, including normalization, `agent-check`, race suites for `apierr`, `grpc`, `grpcerr`, `http`, business e2e (85.523s), cluster e2e (351.202s), and Schemathesis (62 endpoints, zero failed/errored; one recovered transient network event).
- Native exact-head review: **APPROVE**, zero actionable findings, zero unresolved GitHub findings, residual risk LOW. Root guard PASS, clean worktree, final live base recheck unchanged. Workflow result: **READY_FOR_HUMAN_REVIEW**.
- All GitHub CI checks PASS on this candidate, including cluster e2e and Schemathesis; NumaryBot reports no findings.

## Architecture / behavior impact

No domain, persisted-state, audit, HTTP response shape, or protobuf change. Recognized public HTTP error messages omit outer diagnostic prefixes to match the originating business message on every node. Service protocol stays at revision 5: the fix restores the existing forwarding contract and preserves the originating server's public presentation, with no new reason/code mapping or schema. The previous independent EN-1980 implementation has been replaced by this focused supplement to #1939.

## Review focus

- Only decoder-owned statuses bypass raw cancellation normalization; invalid and foreign statuses retain existing handling.
- Original messages and all details survive wrappers, multiple hops, and caller teardown after a terminal rejection.
- Existing public-error redaction and additive parity coverage remain intact.

## Known concerns

An earlier local cluster run timed out while starting its third node, before the follower-loss scenario. The trace contains pending ConfChange retries and an out-of-bounds WAL snapshot index. The isolated scenario and REST parity tests pass at the same seed (21.901s), and the subsequent complete canonical run and CI pass. The startup root cause is not established; the trace is retained separately from this API fix. Local ENOSPC also interrupted intermediate runs; the final run completed after capacity recovery.


[EN-1980]: https://formance-team.atlassian.net/browse/EN-1980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ