### PR TITLE
refactor(query): unify the query compiler across directions (EN-1966)

### DIFF
--- a/internal/query/leaves.go
+++ b/internal/query/leaves.go
@@ -1,0 +1,152 @@
+package query
+
+import (
+	"github.com/formancehq/ledger/v3/internal/pkg/bitset"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+// leaves builds the leaf iterators whose PHYSICAL traversal depends on the
+// direction of the page being served — a Pebble cursor driven
+// First/Next versus Last/Prev, a bitset word walked from its lowest set bit
+// versus its highest, an event group resolved forwards versus backwards.
+//
+// It exists so that everything else about compiling a filter — predicate
+// resolution, schema validation, index-readiness gating, bound computation,
+// boolean composition, error wrapping, resource cleanup and profile-tree
+// construction — is written ONCE, in one recursion, and cannot be correct
+// ascending while being wrong or missing descending (EN-1966).
+//
+// Deliberately absent: the materializing range leaves. Draining a scan into a
+// sorted slice is direction-free, so the shared recursion builds the
+// ascending range scan and hands the one sorted result to Slice[D]. A
+// descending page over a materialized range therefore costs no second
+// collection.
+type leaves[D readstore.Direction] interface {
+	// accountUniverse is every account in the ledger.
+	accountUniverse(ctx *compileCtx) (readstore.Iterator[D], error)
+	// txUniverse is every transaction in the ledger.
+	txUniverse(ctx *compileCtx) (readstore.Iterator[D], error)
+	// logUniverse is every log in the ledger.
+	logUniverse(ctx *compileCtx) (readstore.Iterator[D], error)
+
+	// accountPrefix is every account under a chart-of-accounts prefix.
+	accountPrefix(ctx *compileCtx, addrPrefix string) (readstore.Iterator[D], error)
+	// addressTx is the account→transaction union for the accounts produced by
+	// accounts. The union is order-insensitive, so accounts may travel in
+	// either direction.
+	addressTx(ctx *compileCtx, accounts readstore.Iterator[D], rolePrefix byte) readstore.Iterator[D]
+
+	// eventResolve resolves the latest metadata event at or below the
+	// reader's pin for every entity under prefix.
+	eventResolve(ctx *compileCtx, prefix []byte) (readstore.Iterator[D], error)
+
+	// prefixScan is an entity-ordered scan of one index prefix.
+	prefixScan(ctx *compileCtx, prefix []byte, entityOffset, entityLen int) (readstore.Iterator[D], error)
+	// stampGatedPrefix is prefixScan with the fold-sequence gate armed at the
+	// reader's pin. The gate MUST be present in both directions: a row
+	// written past the pin that one direction hides and the other admits is a
+	// direction-dependent visibility bug, and a whole-set parity test cannot
+	// see it, because both directions are compared against the same pinned
+	// view.
+	stampGatedPrefix(ctx *compileCtx, prefix []byte, entityOffset, entityLen int) (readstore.Iterator[D], error)
+
+	// txRange is the transaction universe restricted to [lower, upper) on the
+	// transaction id. A nil bound is open on that side.
+	txRange(ctx *compileCtx, lower, upper []byte) (readstore.Iterator[D], error)
+
+	// bitset walks the set bits of bs as 8-byte big-endian transaction ids.
+	bitset(bs *bitset.Bitset) readstore.Iterator[D]
+}
+
+// ascLeaves builds the ascending leaves.
+type ascLeaves struct{}
+
+func (ascLeaves) accountUniverse(ctx *compileCtx) (readstore.Iterator[readstore.Asc], error) {
+	return readstore.NewPebbleAccountIterator(ctx.pebbleReader, ctx.ledgerName)
+}
+
+func (ascLeaves) txUniverse(ctx *compileCtx) (readstore.Iterator[readstore.Asc], error) {
+	return readstore.NewPebbleTxIterator(ctx.pebbleReader, ctx.ledgerName)
+}
+
+func (ascLeaves) logUniverse(ctx *compileCtx) (readstore.Iterator[readstore.Asc], error) {
+	return readstore.NewLedgerLogIterator(ctx.indexReader, ctx.kb, ctx.ledgerName)
+}
+
+func (ascLeaves) accountPrefix(ctx *compileCtx, addrPrefix string) (readstore.Iterator[readstore.Asc], error) {
+	return readstore.NewPebbleAccountPrefixIterator(ctx.pebbleReader, ctx.ledgerName, addrPrefix)
+}
+
+func (ascLeaves) addressTx(ctx *compileCtx, accounts readstore.Iterator[readstore.Asc], rolePrefix byte) readstore.Iterator[readstore.Asc] {
+	return readstore.NewAddressTxIterator(ctx.indexReader, ctx.kb, ctx.ledgerName, accounts, rolePrefix)
+}
+
+func (ascLeaves) eventResolve(ctx *compileCtx, prefix []byte) (readstore.Iterator[readstore.Asc], error) {
+	return readstore.NewEventResolveIterator(ctx.indexReader, prefix, ctx.pin)
+}
+
+func (ascLeaves) prefixScan(ctx *compileCtx, prefix []byte, entityOffset, entityLen int) (readstore.Iterator[readstore.Asc], error) {
+	return readstore.NewPrefixIterator(ctx.indexReader, prefix, entityOffset, entityLen)
+}
+
+func (ascLeaves) stampGatedPrefix(ctx *compileCtx, prefix []byte, entityOffset, entityLen int) (readstore.Iterator[readstore.Asc], error) {
+	return readstore.NewStampGatedPrefixIterator(ctx.indexReader, prefix, entityOffset, entityLen, ctx.pin)
+}
+
+func (ascLeaves) txRange(ctx *compileCtx, lower, upper []byte) (readstore.Iterator[readstore.Asc], error) {
+	return readstore.NewPebbleTxRangeIterator(ctx.pebbleReader, ctx.ledgerName, lower, upper)
+}
+
+func (ascLeaves) bitset(bs *bitset.Bitset) readstore.Iterator[readstore.Asc] {
+	return readstore.NewBitsetIterator(bs)
+}
+
+// descLeaves builds the descending leaves. Every method is the physical
+// mirror of its ascending twin; nothing about what the filter MEANS lives
+// here.
+type descLeaves struct{}
+
+func (descLeaves) accountUniverse(ctx *compileCtx) (readstore.Iterator[readstore.Desc], error) {
+	return readstore.NewPebbleReverseAccountIterator(ctx.pebbleReader, ctx.ledgerName)
+}
+
+func (descLeaves) txUniverse(ctx *compileCtx) (readstore.Iterator[readstore.Desc], error) {
+	return readstore.NewPebbleReverseTxIterator(ctx.pebbleReader, ctx.ledgerName)
+}
+
+func (descLeaves) logUniverse(ctx *compileCtx) (readstore.Iterator[readstore.Desc], error) {
+	return readstore.NewReverseLedgerLogIterator(ctx.indexReader, ctx.kb, ctx.ledgerName)
+}
+
+func (descLeaves) accountPrefix(ctx *compileCtx, addrPrefix string) (readstore.Iterator[readstore.Desc], error) {
+	return readstore.NewPebbleReverseAccountPrefixIterator(ctx.pebbleReader, ctx.ledgerName, addrPrefix)
+}
+
+func (descLeaves) addressTx(ctx *compileCtx, accounts readstore.Iterator[readstore.Desc], rolePrefix byte) readstore.Iterator[readstore.Desc] {
+	return readstore.NewReverseAddressTxIterator(ctx.indexReader, ctx.kb, ctx.ledgerName, accounts, rolePrefix)
+}
+
+func (descLeaves) eventResolve(ctx *compileCtx, prefix []byte) (readstore.Iterator[readstore.Desc], error) {
+	return readstore.NewReverseEventResolveIterator(ctx.indexReader, prefix, ctx.pin)
+}
+
+func (descLeaves) prefixScan(ctx *compileCtx, prefix []byte, entityOffset, entityLen int) (readstore.Iterator[readstore.Desc], error) {
+	return readstore.NewReversePrefixIterator(ctx.indexReader, prefix, entityOffset, entityLen)
+}
+
+func (descLeaves) stampGatedPrefix(ctx *compileCtx, prefix []byte, entityOffset, entityLen int) (readstore.Iterator[readstore.Desc], error) {
+	return readstore.NewStampGatedReversePrefixIterator(ctx.indexReader, prefix, entityOffset, entityLen, ctx.pin)
+}
+
+func (descLeaves) txRange(ctx *compileCtx, lower, upper []byte) (readstore.Iterator[readstore.Desc], error) {
+	return readstore.NewPebbleReverseTxRangeIterator(ctx.pebbleReader, ctx.ledgerName, lower, upper)
+}
+
+func (descLeaves) bitset(bs *bitset.Bitset) readstore.Iterator[readstore.Desc] {
+	return readstore.NewReverseBitsetIterator(bs)
+}
+
+var (
+	_ leaves[readstore.Asc]  = ascLeaves{}
+	_ leaves[readstore.Desc] = descLeaves{}
+)

--- a/internal/storage/readstore/combinator_and.go
+++ b/internal/storage/readstore/combinator_and.go
@@ -177,6 +177,14 @@ func (it *AndIterator[D]) converge() bool {
 	}
 }
 
+// And creates an AND over children travelling in D's direction. It is the
+// entry point the direction-generic query compiler uses; NewAndIterator and
+// NewReverseAndIterator are the non-generic spellings for callers that know
+// their direction statically.
+func And[D Direction](children []Iterator[D]) *AndIterator[D] {
+	return newAndIterator(children)
+}
+
 // Direction is the compile-time direction witness; see Iterator.Direction.
 func (it *AndIterator[D]) Direction() (d D) { return }
 

--- a/internal/storage/readstore/combinator_filter.go
+++ b/internal/storage/readstore/combinator_filter.go
@@ -86,6 +86,12 @@ func (it *FilterIterator[D]) Err() error {
 // future wrapper acquires of its own.
 func (it *FilterIterator[D]) Close() { it.inner.Close() }
 
+// Filter wraps inner so only entities admitted by keep surface, in inner's
+// direction. See And for why both a generic and a named spelling exist.
+func Filter[D Direction](inner Iterator[D], keep func(entity []byte) (bool, error)) *FilterIterator[D] {
+	return &FilterIterator[D]{inner: inner, keep: keep}
+}
+
 // Direction is the compile-time direction witness; see Iterator.Direction.
 func (it *FilterIterator[D]) Direction() (d D) { return }
 

--- a/internal/storage/readstore/combinator_not.go
+++ b/internal/storage/readstore/combinator_not.go
@@ -147,6 +147,12 @@ func (it *NotIterator[D]) Close() {
 	it.child.Close()
 }
 
+// Not creates a NOT over operands travelling in D's direction. See And for
+// why both a generic and a named spelling exist.
+func Not[D Direction](universe, child Iterator[D]) *NotIterator[D] {
+	return newNotIterator[D](universe, child)
+}
+
 // Direction is the compile-time direction witness; see Iterator.Direction.
 func (it *NotIterator[D]) Direction() (d D) { return }
 

--- a/internal/storage/readstore/combinator_or.go
+++ b/internal/storage/readstore/combinator_or.go
@@ -138,6 +138,12 @@ func (it *OrIterator[D]) advanceToLeader() bool {
 	return true
 }
 
+// Or creates an OR over children travelling in D's direction. See And for why
+// both a generic and a named spelling exist.
+func Or[D Direction](children []Iterator[D]) *OrIterator[D] {
+	return newOrIterator(children)
+}
+
 // Direction is the compile-time direction witness; see Iterator.Direction.
 func (it *OrIterator[D]) Direction() (d D) { return }
 

--- a/internal/storage/readstore/combinator_slice.go
+++ b/internal/storage/readstore/combinator_slice.go
@@ -27,20 +27,20 @@ type SliceIterator[D Direction] struct {
 	current   []byte
 }
 
-func newSliceIterator[D Direction](entities [][]byte, step int) *SliceIterator[D] {
-	return &SliceIterator[D]{entities: entities, cmp: comparator[D](), step: step}
+func newSliceIterator[D Direction](entities [][]byte) *SliceIterator[D] {
+	return &SliceIterator[D]{entities: entities, cmp: comparator[D](), step: travelStep[D]()}
 }
 
 // NewSliceIterator borrows entities (ascending, sorted) and walks them low to
 // high. A nil slice yields an empty iterator.
 func NewSliceIterator(entities [][]byte) *SliceIterator[Asc] {
-	return newSliceIterator[Asc](entities, 1)
+	return newSliceIterator[Asc](entities)
 }
 
 // NewReverseSliceIterator borrows entities (ascending, sorted) and walks them
 // high to low.
 func NewReverseSliceIterator(entities [][]byte) *SliceIterator[Desc] {
-	return newSliceIterator[Desc](entities, -1)
+	return newSliceIterator[Desc](entities)
 }
 
 // at maps a travel position onto a slice index. Travel position 0 is the
@@ -109,6 +109,23 @@ func (it *SliceIterator[D]) Seek(target []byte) bool {
 func (it *SliceIterator[D]) Err() error { return nil }
 
 func (it *SliceIterator[D]) Close() {}
+
+// Slice borrows entities (ascending, sorted) and walks them in D's direction.
+// See And for why both a generic and a named spelling exist.
+func Slice[D Direction](entities [][]byte) *SliceIterator[D] {
+	return newSliceIterator[D](entities)
+}
+
+// travelStep is +1 ascending and -1 descending: the increment over slice
+// indices that moves along the direction of travel.
+func travelStep[D Direction]() int {
+	var d D
+	if d.compare([]byte{0}, []byte{1}) < 0 {
+		return 1
+	}
+
+	return -1
+}
 
 // Direction is the compile-time direction witness; see Iterator.Direction.
 func (it *SliceIterator[D]) Direction() (d D) { return }

--- a/internal/storage/readstore/iterator_address.go
+++ b/internal/storage/readstore/iterator_address.go
@@ -4,126 +4,68 @@ import (
 	"bytes"
 	"encoding/binary"
 	"slices"
-	"sort"
 
 	"github.com/cockroachdb/pebble/v2"
 
 	"github.com/formancehq/ledger/v3/internal/storage/dal"
 )
 
-// AddressTxIterator translates an address match on the TRANSACTIONS target into
-// a sorted iterator of transaction IDs. It works by:
+// entitySource is an entity producer whose ORDER IS IRRELEVANT to the
+// consumer. addressTxUnion takes one because it builds a set: it drains every
+// entity, deduplicates, and sorts the result itself, so an ascending and a
+// descending account scan produce the same union. Both Iterator[Asc] and
+// Iterator[Desc] satisfy it, which is why the union needs no direction of its
+// own (EN-1966).
+type entitySource interface {
+	Next() bool
+	Current() []byte
+	Err() error
+	Close()
+}
+
+// addressTxUnion is the account→transaction union underlying an address match
+// on the TRANSACTIONS target. It works by:
 //  1. Scanning the existence index for matching account addresses
 //  2. For each matching account, scanning the account→tx mapping
-//  3. Unioning all transaction ID sets into a single sorted output
+//  3. Unioning all transaction ID sets into a single sorted slice
 //
-// The union is built by appending each unseen ID and sorting the completed
-// slice once, so the order during materialization is unspecified; nothing
-// outside materialize may observe it. Every positioning call goes through
+// Members come from N per-account scans, each ascending but collectively
+// unordered, so "the next transaction after X" is undefined until the whole
+// union is known. The union is therefore materialized in full on first use
+// and kept for the iterator's lifetime — this is the one materializing leaf
+// on the address path, and it is materializing in BOTH directions for the
+// same reason.
+//
+// The slice is built by appending each unseen ID and sorting once at the end,
+// so the order during materialization is unspecified; nothing outside
+// materialize may observe it. Every positioning call goes through
 // ensureMaterialized, which returns only after the slice is sorted.
-//
-// The union is materialized in full on first use and kept for the iterator's
-// lifetime; Next and Seek are cursor moves over the stable sorted slice, so
-// Seek is a true absolute reposition — seekable backwards, repeatable, and
-// well-defined after exhaustion — as the EntityIterator contract requires.
-type AddressTxIterator struct {
+type addressTxUnion struct {
 	reader     dal.PebbleReader
 	kb         *dal.KeyBuilder
 	ledgerName string
-	prefix     byte           // which account→tx prefix to scan
-	addrIter   EntityIterator // iterates over matching account addresses
-	current    []byte         // current txID (8 bytes)
-	err        error          // first I/O error from materialize / addrIter
+	prefix     byte         // which account→tx prefix to scan
+	addrIter   entitySource // produces the matching account addresses
+	err        error        // first I/O error from materialize / addrIter
 
 	materialized bool
-	txns         [][]byte // all matching txIDs, sorted and deduplicated
-	pos          int      // index into txns of the entry the next Next() yields
-}
-
-// NewAddressTxIterator creates an iterator that, for each address matching
-// addrIter, looks up all associated transaction IDs in the specified
-// account→tx prefix and produces them in sorted order.
-func NewAddressTxIterator(
-	reader dal.PebbleReader,
-	kb *dal.KeyBuilder,
-	ledgerName string,
-	addrIter EntityIterator,
-	prefix byte,
-) *AddressTxIterator {
-	return &AddressTxIterator{
-		reader:     reader,
-		kb:         kb,
-		ledgerName: ledgerName,
-		prefix:     prefix,
-		addrIter:   addrIter,
-	}
-}
-
-func (it *AddressTxIterator) Next() bool {
-	if !it.ensureMaterialized() {
-		return false
-	}
-
-	if it.pos >= len(it.txns) {
-		return false
-	}
-
-	it.current = it.txns[it.pos]
-	it.pos++
-
-	return true
-}
-
-func (it *AddressTxIterator) Current() []byte {
-	return it.current
-}
-
-func (it *AddressTxIterator) Seek(target []byte) bool {
-	if !it.ensureMaterialized() {
-		return false
-	}
-
-	idx := sort.Search(len(it.txns), func(i int) bool {
-		return bytes.Compare(it.txns[i], target) >= 0
-	})
-	if idx >= len(it.txns) {
-		it.pos = len(it.txns)
-
-		return false
-	}
-
-	it.current = it.txns[idx]
-	it.pos = idx + 1
-
-	return true
-}
-
-func (it *AddressTxIterator) Err() error {
-	if it.err != nil {
-		return it.err
-	}
-
-	return it.addrIter.Err()
-}
-
-func (it *AddressTxIterator) Close() {
-	it.addrIter.Close()
+	txns         [][]byte // all matching txIDs, sorted ascending and deduplicated
 }
 
 // ensureMaterialized runs the one-time materialization, latching any I/O error
 // (an error is permanent — positioning calls after it always return false).
-func (it *AddressTxIterator) ensureMaterialized() bool {
-	if it.err != nil {
+func (u *addressTxUnion) ensureMaterialized() bool {
+	if u.err != nil {
 		return false
 	}
 
-	if it.materialized {
+	if u.materialized {
 		return true
 	}
 
-	it.materialized = true
-	if err := it.materialize(); err != nil {
-		it.err = err
+	u.materialized = true
+	if err := u.materialize(); err != nil {
+		u.err = err
 
 		return false
 	}
@@ -137,17 +79,16 @@ func (it *AddressTxIterator) ensureMaterialized() bool {
 // once. Sorting on each insertion instead (a binary search plus a tail shift)
 // moves O(U^2) elements for U unique IDs when account histories interleave,
 // because most new IDs land near the front. Surfaces I/O errors from the
-// underlying Pebble iterators and from the addrIter through addrIter.Err()
-// (checked by the caller via it.Err()).
-func (it *AddressTxIterator) materialize() error {
+// underlying Pebble iterators and from the addrIter through addrIter.Err().
+func (u *addressTxUnion) materialize() error {
 	txSeen := make(map[uint64]struct{})
 
-	for it.addrIter.Next() {
-		account := string(it.addrIter.Current())
-		prefix := AccountTxPrefix(it.kb, it.prefix, it.ledgerName, account)
+	for u.addrIter.Next() {
+		account := string(u.addrIter.Current())
+		prefix := AccountTxPrefix(u.kb, u.prefix, u.ledgerName, account)
 		upper := IncrementBytes(prefix)
 
-		iter, err := it.reader.NewIter(&pebble.IterOptions{
+		iter, err := u.reader.NewIter(&pebble.IterOptions{
 			LowerBound: prefix,
 			UpperBound: upper,
 		})
@@ -173,7 +114,7 @@ func (it *AddressTxIterator) materialize() error {
 
 			txCopy := make([]byte, 8)
 			copy(txCopy, txIDBytes)
-			it.txns = append(it.txns, txCopy)
+			u.txns = append(u.txns, txCopy)
 		}
 
 		iterErr := iter.Error()
@@ -188,10 +129,121 @@ func (it *AddressTxIterator) materialize() error {
 	// slice. IDs are unique after txSeen, so no tie can be reordered and an
 	// unstable sort is safe. bytes.Compare on the 8-byte big-endian IDs is the
 	// numeric ID order (see ReadStoreComparer).
-	slices.SortFunc(it.txns, bytes.Compare)
+	slices.SortFunc(u.txns, bytes.Compare)
 
-	return it.addrIter.Err()
+	return u.addrIter.Err()
+}
+
+// AddressTxIterator walks the account→transaction union in D's direction.
+//
+// Direction costs nothing here: the union is order-insensitive and its result
+// is a single ascending sorted slice, so both directions are a
+// SliceIterator[D] over that one slice — the descending page needs no second
+// collection. Next and Seek are cursor moves over a slice that is stable for
+// the iterator's lifetime, so Seek is a true absolute reposition — seekable
+// backwards, repeatable, and well-defined after exhaustion — as the Iterator
+// contract requires.
+type AddressTxIterator[D Direction] struct {
+	union *addressTxUnion
+	view  *SliceIterator[D]
+}
+
+func newAddressTxIterator[D Direction](
+	reader dal.PebbleReader,
+	kb *dal.KeyBuilder,
+	ledgerName string,
+	addrIter entitySource,
+	prefix byte,
+) *AddressTxIterator[D] {
+	return &AddressTxIterator[D]{
+		union: &addressTxUnion{
+			reader:     reader,
+			kb:         kb,
+			ledgerName: ledgerName,
+			prefix:     prefix,
+			addrIter:   addrIter,
+		},
+	}
+}
+
+// NewAddressTxIterator creates an iterator that, for each address produced by
+// addrIter, looks up all associated transaction IDs in the specified
+// account→tx prefix and produces them in ascending order.
+func NewAddressTxIterator(
+	reader dal.PebbleReader,
+	kb *dal.KeyBuilder,
+	ledgerName string,
+	addrIter entitySource,
+	prefix byte,
+) *AddressTxIterator[Asc] {
+	return newAddressTxIterator[Asc](reader, kb, ledgerName, addrIter, prefix)
+}
+
+// NewReverseAddressTxIterator is NewAddressTxIterator in descending order,
+// over the same union.
+func NewReverseAddressTxIterator(
+	reader dal.PebbleReader,
+	kb *dal.KeyBuilder,
+	ledgerName string,
+	addrIter entitySource,
+	prefix byte,
+) *AddressTxIterator[Desc] {
+	return newAddressTxIterator[Desc](reader, kb, ledgerName, addrIter, prefix)
+}
+
+// ensureView materializes the union and, on success, borrows its sorted slice.
+func (it *AddressTxIterator[D]) ensureView() bool {
+	if !it.union.ensureMaterialized() {
+		return false
+	}
+
+	if it.view == nil {
+		it.view = newSliceIterator[D](it.union.txns)
+	}
+
+	return true
+}
+
+func (it *AddressTxIterator[D]) Next() bool {
+	if !it.ensureView() {
+		return false
+	}
+
+	return it.view.Next()
+}
+
+func (it *AddressTxIterator[D]) Current() []byte {
+	if it.view == nil {
+		return nil
+	}
+
+	return it.view.Current()
+}
+
+func (it *AddressTxIterator[D]) Seek(target []byte) bool {
+	if !it.ensureView() {
+		return false
+	}
+
+	return it.view.Seek(target)
+}
+
+func (it *AddressTxIterator[D]) Err() error {
+	if it.union.err != nil {
+		return it.union.err
+	}
+
+	return it.union.addrIter.Err()
+}
+
+func (it *AddressTxIterator[D]) Close() {
+	it.union.addrIter.Close()
 }
 
 // Direction is the compile-time direction witness; see Iterator.Direction.
-func (it *AddressTxIterator) Direction() (d Asc) { return }
+func (it *AddressTxIterator[D]) Direction() (d D) { return }
+
+var (
+	_ EntityIterator  = (*AddressTxIterator[Asc])(nil)
+	_ ReverseIterator = (*AddressTxIterator[Desc])(nil)
+)

--- a/internal/storage/readstore/iterator_address_test.go
+++ b/internal/storage/readstore/iterator_address_test.go
@@ -19,7 +19,7 @@ func txIDBytes(id uint64) []byte {
 
 // newAddressTxFixture writes account→tx rows in the any-role bucket and
 // returns an AddressTxIterator over the given addresses.
-func newAddressTxFixture(t *testing.T, txsByAccount map[string][]uint64, addrs ...string) *AddressTxIterator {
+func newAddressTxFixture(t *testing.T, txsByAccount map[string][]uint64, addrs ...string) *AddressTxIterator[Asc] {
 	t.Helper()
 
 	return newAddressTxFixtureForPrefix(t, PrefixAccountTx, txsByAccount, addrs...)
@@ -33,7 +33,7 @@ func newAddressTxFixtureForPrefix(
 	prefix byte,
 	txsByAccount map[string][]uint64,
 	addrs ...string,
-) *AddressTxIterator {
+) *AddressTxIterator[Asc] {
 	tb.Helper()
 
 	s := newTestStore(tb)
@@ -49,7 +49,7 @@ func newAddressTxFixtureForPrefix(
 }
 
 // drainIDs consumes the iterator and returns the decoded transaction IDs.
-func drainIDs(tb testing.TB, it *AddressTxIterator) []uint64 {
+func drainIDs(tb testing.TB, it *AddressTxIterator[Asc]) []uint64 {
 	tb.Helper()
 
 	var got []uint64

--- a/internal/storage/readstore/iterator_admission.go
+++ b/internal/storage/readstore/iterator_admission.go
@@ -1,0 +1,23 @@
+package readstore
+
+import (
+	"encoding/binary"
+	"fmt"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+// admitFoldStamp applies the same visibility predicate in both scan directions.
+// Callers latch malformed-value errors and exhaust their iterator.
+func admitFoldStamp(iter *pebble.Iterator, pin uint64) (bool, error) {
+	if pin == 0 {
+		return true, nil
+	}
+
+	value := iter.Value()
+	if len(value) != 8 {
+		return false, fmt.Errorf("stamp-gated scan: row %x carries a %d-byte value (want an 8-byte fold sequence)", iter.Key(), len(value))
+	}
+
+	return binary.BigEndian.Uint64(value) <= pin, nil
+}

--- a/internal/storage/readstore/iterator_event_key.go
+++ b/internal/storage/readstore/iterator_event_key.go
@@ -1,0 +1,20 @@
+package readstore
+
+import "encoding/binary"
+
+// parseEventKey splits an event key into (group, seq, op) independently of
+// scan direction. The fixed suffix locates the terminator from the right.
+// Unknown operations and malformed keys must fail the caller's scan loudly.
+func parseEventKey(key []byte, prefixLen int) (group []byte, seq uint64, op byte, ok bool) {
+	rest := key[prefixLen:]
+	tpos := len(rest) - metadataEventSuffixLen - 1
+	if tpos < 0 || rest[tpos] != metadataEventTerminator {
+		return nil, 0, 0, false
+	}
+
+	if op := rest[tpos+9]; !validEventOp(op) {
+		return nil, 0, 0, false
+	}
+
+	return rest[:tpos], binary.BigEndian.Uint64(rest[tpos+1 : tpos+9]), rest[tpos+9], true
+}

--- a/internal/storage/readstore/iterator_event_resolve.go
+++ b/internal/storage/readstore/iterator_event_resolve.go
@@ -2,7 +2,6 @@ package readstore
 
 import (
 	"bytes"
-	"encoding/binary"
 	"errors"
 	"fmt"
 
@@ -85,25 +84,6 @@ func NewEventResolveRangeIterator(reader dal.PebbleReader, lower, upper []byte, 
 	return &EventResolveIterator{iter: iter, prefixLen: prefixLen, emitOffset: emitOffset, pin: pin, rangeMode: true}, nil
 }
 
-// parse splits an event key into (group, seq, op). The terminator position
-// is computed from the right — the fixed suffix makes it unambiguous. ok is
-// false for anything this package would not have written, unknown ops
-// included: the caller turns that into a loud error rather than resolving a
-// group from bytes it cannot read.
-func (it *EventResolveIterator) parse(key []byte) (group []byte, seq uint64, op byte, ok bool) {
-	rest := key[it.prefixLen:]
-	tpos := len(rest) - metadataEventSuffixLen - 1
-	if tpos < 0 || rest[tpos] != metadataEventTerminator {
-		return nil, 0, 0, false
-	}
-
-	if op := rest[tpos+9]; !validEventOp(op) {
-		return nil, 0, 0, false
-	}
-
-	return rest[:tpos], binary.BigEndian.Uint64(rest[tpos+1 : tpos+9]), rest[tpos+9], true
-}
-
 // settle resolves consecutive groups starting at the raw iterator's current
 // position until one is live at the pin, leaving the raw iterator at the
 // following group.
@@ -122,7 +102,7 @@ func (it *EventResolveIterator) settleFrom(seekTarget []byte) bool {
 
 func (it *EventResolveIterator) settle() bool {
 	for it.iter.Valid() {
-		g, _, _, ok := it.parse(it.iter.Key())
+		g, _, _, ok := parseEventKey(it.iter.Key(), it.prefixLen)
 		if !ok {
 			it.err = fmt.Errorf("malformed metadata event key %x", it.iter.Key())
 
@@ -133,7 +113,7 @@ func (it *EventResolveIterator) settle() bool {
 		live := false
 
 		for it.iter.Valid() {
-			g, seq, op, ok := it.parse(it.iter.Key())
+			g, seq, op, ok := parseEventKey(it.iter.Key(), it.prefixLen)
 			if !ok {
 				it.err = fmt.Errorf("malformed metadata event key %x", it.iter.Key())
 

--- a/internal/storage/readstore/iterator_event_resolve_reverse.go
+++ b/internal/storage/readstore/iterator_event_resolve_reverse.go
@@ -1,0 +1,225 @@
+package readstore
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/cockroachdb/pebble/v2"
+
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+// ReverseEventResolveIterator is the descending twin of
+// EventResolveIterator's POINT form: it reads a metadata / exists index event
+// range at a pinned raft sequence and yields, in descending key order, every
+// group whose latest event at or below the pin is an ADD (see event_keys.go).
+//
+// Direction changes only how a group is resolved, never the verdict. Events of
+// one group are key-adjacent and seq-ASCENDING, so walking the group backwards
+// visits them seq-descending and the FIRST event with seq <= pin is the latest
+// one at or below the pin — exactly the event the forward pass keeps last.
+// The scan still walks the group to its first key before moving on, because
+// that is what positions the raw iterator on the preceding group.
+//
+// The range form is deliberately absent. Its groups are (encodedValue, entity)
+// pairs that do not surface in entity order, so every construction site
+// materializes it and serves both directions from the sorted slice — see
+// ReverseSliceIterator and query.materializeIterator.
+type ReverseEventResolveIterator struct {
+	iter       *pebble.Iterator
+	seekPrefix []byte // the scan prefix, prepended to seek targets
+	prefixLen  int    // key bytes before the group identity
+	pin        uint64
+
+	current   []byte
+	started   bool
+	exhausted bool
+	ceil      seekCeil
+	err       error
+}
+
+// NewReverseEventResolveIterator scans the event range under prefix (built by
+// MetadataIndexEventValuePrefixV or an EntityExists*PrefixV) as of pin,
+// descending.
+func NewReverseEventResolveIterator(reader dal.PebbleReader, prefix []byte, pin uint64) (*ReverseEventResolveIterator, error) {
+	iter, err := reader.NewIter(&pebble.IterOptions{
+		LowerBound: prefix,
+		UpperBound: IncrementBytes(prefix),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &ReverseEventResolveIterator{iter: iter, seekPrefix: prefix, prefixLen: len(prefix), pin: pin}, nil
+}
+
+// parse splits an event key into (group, seq, op) — identical to
+// EventResolveIterator.parse; the layout does not depend on direction.
+func (it *ReverseEventResolveIterator) parse(key []byte) (group []byte, seq uint64, op byte, ok bool) {
+	rest := key[it.prefixLen:]
+
+	tpos := len(rest) - metadataEventSuffixLen - 1
+	if tpos < 0 || rest[tpos] != metadataEventTerminator {
+		return nil, 0, 0, false
+	}
+
+	if op := rest[tpos+9]; !validEventOp(op) {
+		return nil, 0, 0, false
+	}
+
+	return rest[:tpos], binary.BigEndian.Uint64(rest[tpos+1 : tpos+9]), rest[tpos+9], true
+}
+
+// settleFrom resolves groups backwards from the raw iterator's position until
+// one is live at the pin. seekTarget is the target of the seek that led here,
+// or nil when advancing through Next: a scan that runs out while seeking
+// proves no live group at or below that target, which the ceil memoises.
+func (it *ReverseEventResolveIterator) settleFrom(seekTarget []byte) bool {
+	live := it.settle()
+	if !live && seekTarget != nil && it.err == nil {
+		it.ceil.fail(seekTarget, it.iter.Error())
+	}
+
+	return live
+}
+
+// settle walks groups from high to low. Within a group it walks events from
+// high seq to low, and the first event at or below the pin decides; the walk
+// then continues to the group's first key so the raw iterator lands on the
+// preceding group.
+func (it *ReverseEventResolveIterator) settle() bool {
+	for it.iter.Valid() {
+		g, _, _, ok := it.parse(it.iter.Key())
+		if !ok {
+			it.err = fmt.Errorf("malformed metadata event key %x", it.iter.Key())
+
+			return false
+		}
+
+		group := append([]byte(nil), g...)
+		live := false
+		decided := false
+
+		for it.iter.Valid() {
+			g, seq, op, ok := it.parse(it.iter.Key())
+			if !ok {
+				it.err = fmt.Errorf("malformed metadata event key %x", it.iter.Key())
+
+				return false
+			}
+
+			if !bytes.Equal(g, group) {
+				break
+			}
+
+			// Walking backwards, the first event at or below the pin is the
+			// LATEST such event — the one the forward pass settles on.
+			if !decided && seq <= it.pin {
+				live = op == MetadataEventAdd
+				decided = true
+			}
+
+			if !it.iter.Prev() {
+				break
+			}
+		}
+
+		if live {
+			it.current = group
+
+			return true
+		}
+	}
+
+	it.exhausted = true
+
+	return false
+}
+
+func (it *ReverseEventResolveIterator) Next() bool {
+	if it.err != nil || it.exhausted {
+		return false
+	}
+
+	if !it.started {
+		it.started = true
+		if !it.iter.Last() {
+			it.exhausted = true
+
+			return false
+		}
+	}
+
+	// After a successful settle the raw iterator already rests on the
+	// preceding group's last key.
+	return it.settleFrom(nil)
+}
+
+func (it *ReverseEventResolveIterator) Current() []byte { return it.current }
+
+// Seek positions at the largest live group <= target.
+//
+// The seek bound is prefix+target+(terminator+1): every event key of group
+// `target` is prefix+target+terminator+seq+op, so all of them sort below that
+// bound, and any longer group starting with `target` sorts above it — entity
+// bytes can never be NUL or 0x01 (account addresses are [a-zA-Z0-9:_-]+;
+// transaction IDs are fixed-width, so no group is a strict prefix of another).
+// SeekGE to that bound then Prev() therefore lands on the LAST event of group
+// `target`, or on the last event of the largest group below it.
+func (it *ReverseEventResolveIterator) Seek(target []byte) bool {
+	if it.err != nil {
+		return false
+	}
+
+	// A prior failed seek at or above target proves this one empty too.
+	if it.ceil.covers(target) {
+		it.exhausted = true
+
+		return false
+	}
+
+	// Absolute reposition: clear the exhausted latch so a re-seek after
+	// exhaustion still finds groups (the body re-seeks from target).
+	it.exhausted = false
+	it.started = true
+
+	seekKey := make([]byte, 0, len(it.seekPrefix)+len(target)+1)
+	seekKey = append(seekKey, it.seekPrefix...)
+	seekKey = append(seekKey, target...)
+	seekKey = append(seekKey, metadataEventTerminator+1)
+
+	if it.iter.SeekGE(seekKey) {
+		if !it.iter.Prev() {
+			it.exhausted = true
+			it.ceil.fail(target, it.iter.Error())
+
+			return false
+		}
+	} else if !it.iter.Last() {
+		// Nothing at or above the bound and the range is empty.
+		it.exhausted = true
+		it.ceil.fail(target, it.iter.Error())
+
+		return false
+	}
+
+	return it.settleFrom(target)
+}
+
+func (it *ReverseEventResolveIterator) Err() error {
+	if it.err != nil {
+		return it.err
+	}
+
+	return it.iter.Error()
+}
+
+func (it *ReverseEventResolveIterator) Close() {
+	_ = it.iter.Close()
+}
+
+// Direction is the compile-time direction witness; see Iterator.Direction.
+func (it *ReverseEventResolveIterator) Direction() (d Desc) { return }
+
+var _ ReverseIterator = (*ReverseEventResolveIterator)(nil)

--- a/internal/storage/readstore/iterator_event_resolve_reverse.go
+++ b/internal/storage/readstore/iterator_event_resolve_reverse.go
@@ -2,7 +2,6 @@ package readstore
 
 import (
 	"bytes"
-	"encoding/binary"
 	"fmt"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -54,23 +53,6 @@ func NewReverseEventResolveIterator(reader dal.PebbleReader, prefix []byte, pin 
 	return &ReverseEventResolveIterator{iter: iter, seekPrefix: prefix, prefixLen: len(prefix), pin: pin}, nil
 }
 
-// parse splits an event key into (group, seq, op) — identical to
-// EventResolveIterator.parse; the layout does not depend on direction.
-func (it *ReverseEventResolveIterator) parse(key []byte) (group []byte, seq uint64, op byte, ok bool) {
-	rest := key[it.prefixLen:]
-
-	tpos := len(rest) - metadataEventSuffixLen - 1
-	if tpos < 0 || rest[tpos] != metadataEventTerminator {
-		return nil, 0, 0, false
-	}
-
-	if op := rest[tpos+9]; !validEventOp(op) {
-		return nil, 0, 0, false
-	}
-
-	return rest[:tpos], binary.BigEndian.Uint64(rest[tpos+1 : tpos+9]), rest[tpos+9], true
-}
-
 // settleFrom resolves groups backwards from the raw iterator's position until
 // one is live at the pin. seekTarget is the target of the seek that led here,
 // or nil when advancing through Next: a scan that runs out while seeking
@@ -90,7 +72,7 @@ func (it *ReverseEventResolveIterator) settleFrom(seekTarget []byte) bool {
 // preceding group.
 func (it *ReverseEventResolveIterator) settle() bool {
 	for it.iter.Valid() {
-		g, _, _, ok := it.parse(it.iter.Key())
+		g, _, _, ok := parseEventKey(it.iter.Key(), it.prefixLen)
 		if !ok {
 			it.err = fmt.Errorf("malformed metadata event key %x", it.iter.Key())
 
@@ -102,7 +84,7 @@ func (it *ReverseEventResolveIterator) settle() bool {
 		decided := false
 
 		for it.iter.Valid() {
-			g, seq, op, ok := it.parse(it.iter.Key())
+			g, seq, op, ok := parseEventKey(it.iter.Key(), it.prefixLen)
 			if !ok {
 				it.err = fmt.Errorf("malformed metadata event key %x", it.iter.Key())
 

--- a/internal/storage/readstore/iterator_event_resolve_reverse_test.go
+++ b/internal/storage/readstore/iterator_event_resolve_reverse_test.go
@@ -1,0 +1,123 @@
+package readstore
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+func TestReverseEventResolveIterator_PinnedHistories(t *testing.T) {
+	t.Parallel()
+	s, prefix := eventFixture(t, "v",
+		ev{"a", 10, MetadataEventAdd}, ev{"a", 20, MetadataEventDel}, ev{"a", 30, MetadataEventAdd},
+		ev{"ab", 10, MetadataEventAdd}, ev{"ab", 20, MetadataEventDel},
+		ev{"b", 20, MetadataEventDel}, ev{"b", 20, MetadataEventAdd},
+		ev{"z", 40, MetadataEventAdd},
+	)
+	for _, tc := range []struct {
+		pin  uint64
+		want []string
+	}{
+		{0, nil}, {10, []string{"ab", "a"}}, {20, []string{"b"}}, {30, []string{"b", "a"}}, {40, []string{"z", "b", "a"}},
+	} {
+		t.Run(strconv.FormatUint(tc.pin, 10), func(t *testing.T) {
+			it, err := NewReverseEventResolveIterator(s.DB(), prefix, tc.pin)
+			require.NoError(t, err)
+			defer it.Close()
+			var got []string
+			for it.Next() {
+				got = append(got, string(it.Current()))
+			}
+			require.Equal(t, tc.want, got)
+			require.NoError(t, it.Err())
+			require.False(t, it.Next())
+		})
+	}
+}
+
+func TestReverseEventResolveIterator_AbsoluteSeek(t *testing.T) {
+	t.Parallel()
+	s, prefix := eventFixture(t, "v", ev{"a", 10, MetadataEventAdd}, ev{"ab", 10, MetadataEventAdd},
+		ev{"b", 10, MetadataEventAdd}, ev{"b", 20, MetadataEventDel}, ev{"c", 10, MetadataEventAdd})
+	it, err := NewReverseEventResolveIterator(s.DB(), prefix, 25)
+	require.NoError(t, err)
+	defer it.Close()
+	for _, tc := range []struct{ target, want string }{{"z", "c"}, {"b", "ab"}, {"b", "ab"}, {"a", "a"}} {
+		require.True(t, it.Seek([]byte(tc.target)))
+		require.Equal(t, tc.want, string(it.Current()))
+	}
+	require.False(t, it.Next())
+	require.True(t, it.Seek([]byte("c")), "reposition after Next exhaustion")
+	require.Equal(t, "c", string(it.Current()))
+	require.True(t, it.Next())
+	require.Equal(t, "ab", string(it.Current()))
+	require.False(t, it.Seek([]byte("0")))
+	require.False(t, it.Next())
+	require.False(t, it.Seek(nil), "a lower target remains empty")
+	require.True(t, it.Seek([]byte("a")), "failed seek must not hide larger targets")
+	require.Equal(t, "a", string(it.Current()))
+	require.NoError(t, it.Err())
+}
+
+func TestReverseEventResolveIterator_Empty(t *testing.T) {
+	t.Parallel()
+	s, prefix := eventFixture(t, "v")
+	it, err := NewReverseEventResolveIterator(s.DB(), prefix, 25)
+	require.NoError(t, err)
+	defer it.Close()
+	require.False(t, it.Next())
+	require.False(t, it.Seek([]byte("z")))
+	require.False(t, it.Seek([]byte("zz")))
+	require.False(t, it.Next())
+	require.NoError(t, it.Err())
+}
+
+func TestReverseEventResolveIterator_MalformedKeys(t *testing.T) {
+	t.Parallel()
+	for _, corruption := range []string{"unknown operation", "truncated tail", "missing terminator"} {
+		for _, seek := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/seek=%t", corruption, seek), func(t *testing.T) {
+				t.Parallel()
+				s, prefix := eventFixture(t, "v", ev{"a", 10, MetadataEventAdd})
+				key := append([]byte(nil), MetadataIndexEventKeyV(dal.NewKeyBuilder(), "l", NamespaceAccount, "k", 1, []byte("v"), []byte("z"), 20, MetadataEventAdd)...)
+				switch corruption {
+				case "unknown operation":
+					key[len(key)-1] = 0x7f
+				case "truncated tail":
+					key = key[:len(key)-3]
+				case "missing terminator":
+					key[len(key)-metadataEventSuffixLen-1] = 2
+				}
+				require.NoError(t, s.DB().Set(key, nil, pebble.NoSync))
+				it, err := NewReverseEventResolveIterator(s.DB(), prefix, 25)
+				require.NoError(t, err)
+				defer it.Close()
+				if seek {
+					require.False(t, it.Seek([]byte("zz")))
+				} else {
+					require.False(t, it.Next())
+				}
+				require.EqualError(t, it.Err(), fmt.Sprintf("malformed metadata event key %x", key))
+				require.False(t, it.Next())
+				require.False(t, it.Seek([]byte("a")), "malformed event errors remain sticky")
+			})
+		}
+	}
+}
+
+func TestReverseEventResolveIterator_MalformedEarlierEvent(t *testing.T) {
+	t.Parallel()
+	s, prefix := eventFixture(t, "v", ev{"a", 10, MetadataEventAdd}, ev{"z", 30, MetadataEventAdd})
+	key := append([]byte(nil), MetadataIndexEventKeyV(dal.NewKeyBuilder(), "l", NamespaceAccount, "k", 1, []byte("v"), []byte("z"), 20, 0x7f)...)
+	require.NoError(t, s.DB().Set(key, nil, pebble.NoSync))
+	it, err := NewReverseEventResolveIterator(s.DB(), prefix, 30)
+	require.NoError(t, err)
+	defer it.Close()
+	require.False(t, it.Next(), "an already decided ADD cannot hide corruption earlier in its group")
+	require.EqualError(t, it.Err(), fmt.Sprintf("malformed metadata event key %x", key))
+}

--- a/internal/storage/readstore/iterator_floor_test.go
+++ b/internal/storage/readstore/iterator_floor_test.go
@@ -273,7 +273,7 @@ func TestPebbleReverseAccountIterator_SeekRepositioning(t *testing.T) {
 		require.NoError(t, s.DB().Set(key, nil, pebble.NoSync))
 	}
 
-	it, err := newSingleTypeReverseAccountIterator(s.DB(), dal.SubAttrVolume, "l")
+	it, err := newSingleTypeReverseAccountIterator(s.DB(), dal.SubAttrVolume, "l", "")
 	require.NoError(t, err)
 	defer it.Close()
 
@@ -292,7 +292,7 @@ func TestPebbleReverseAccountIterator_SeekRepositioning(t *testing.T) {
 
 	// Last()-fails branch: an empty view records the ceil on the first seek,
 	// covering every later target below it.
-	empty, err := newSingleTypeReverseAccountIterator(s.DB(), dal.SubAttrVolume, "empty")
+	empty, err := newSingleTypeReverseAccountIterator(s.DB(), dal.SubAttrVolume, "empty", "")
 	require.NoError(t, err)
 	defer empty.Close()
 

--- a/internal/storage/readstore/iterator_leaf.go
+++ b/internal/storage/readstore/iterator_leaf.go
@@ -1,9 +1,7 @@
 package readstore
 
 import (
-	"encoding/binary"
 	"errors"
-	"fmt"
 
 	"github.com/cockroachdb/pebble/v2"
 
@@ -82,19 +80,13 @@ func NewStampGatedPrefixIterator(
 // malformed value latches an error and exhausts the iterator: refusing per
 // invariant #7 beats silently folding an unreadable row into the page.
 func (it *PrefixIterator) admitStamp() bool {
-	if it.stampPin == 0 {
-		return true
-	}
-
-	v := it.iter.Value()
-	if len(v) != 8 {
-		it.stampErr = fmt.Errorf("stamp-gated scan: row %x carries a %d-byte value (want an 8-byte fold sequence)", it.iter.Key(), len(v))
+	admitted, err := admitFoldStamp(it.iter, it.stampPin)
+	if err != nil {
+		it.stampErr = err
 		it.exhausted = true
-
-		return false
 	}
 
-	return binary.BigEndian.Uint64(v) <= it.stampPin
+	return admitted
 }
 
 func (it *PrefixIterator) Next() bool {
@@ -301,19 +293,13 @@ func NewStampGatedRangeIterator(
 
 // admitStamp — see PrefixIterator.admitStamp.
 func (it *RangeIterator) admitStamp() bool {
-	if it.stampPin == 0 {
-		return true
-	}
-
-	v := it.iter.Value()
-	if len(v) != 8 {
-		it.stampErr = fmt.Errorf("stamp-gated scan: row %x carries a %d-byte value (want an 8-byte fold sequence)", it.iter.Key(), len(v))
+	admitted, err := admitFoldStamp(it.iter, it.stampPin)
+	if err != nil {
+		it.stampErr = err
 		it.exhausted = true
-
-		return false
 	}
 
-	return binary.BigEndian.Uint64(v) <= it.stampPin
+	return admitted
 }
 
 func (it *RangeIterator) Next() bool {

--- a/internal/storage/readstore/iterator_pebble.go
+++ b/internal/storage/readstore/iterator_pebble.go
@@ -830,6 +830,15 @@ type PebbleTxRangeIterator struct {
 }
 
 // NewPebbleTxRangeIterator creates a bounded transaction iterator for range queries.
+// NewReverseLedgerLogIterator is the descending twin of NewLedgerLogIterator:
+// log ids under the ledger's log prefix, high to low. Logs are entity-ordered
+// in the index, so the scan streams in both directions (EN-1966).
+func NewReverseLedgerLogIterator(reader dal.PebbleReader, kb *dal.KeyBuilder, ledgerName string) (*ReversePrefixIterator, error) {
+	prefix := LedgerLogPrefix(kb, ledgerName)
+
+	return NewReversePrefixIterator(reader, prefix, len(prefix), 8)
+}
+
 func NewPebbleTxRangeIterator(reader dal.PebbleReader, ledgerName string, lower, upper []byte) (*PebbleTxRangeIterator, error) {
 	prefix := txAttributeCode(ledgerName)
 

--- a/internal/storage/readstore/iterator_pebble.go
+++ b/internal/storage/readstore/iterator_pebble.go
@@ -236,16 +236,22 @@ type PebbleReverseAccountIterator struct {
 }
 
 // newSingleTypeReverseAccountIterator creates a reverse account iterator for one attribute type.
-func newSingleTypeReverseAccountIterator(reader dal.PebbleReader, attrType byte, ledgerName string) (*PebbleReverseAccountIterator, error) {
+func newSingleTypeReverseAccountIterator(reader dal.PebbleReader, attrType byte, ledgerName string, addrPrefix string) (*PebbleReverseAccountIterator, error) {
 	prefix := make([]byte, 2+dal.LedgerNameFixedSize)
 	prefix[0] = dal.ZoneAttributes
 	prefix[1] = attrType
 	copy(prefix[2:], ledgerName)
 
-	upperBound := IncrementBytes(prefix)
+	// Bounds mirror newSingleTypeAccountIterator: an empty addrPrefix scans
+	// the whole ledger, a non-empty one scans that address range.
+	lowerBound := make([]byte, len(prefix)+len(addrPrefix))
+	copy(lowerBound, prefix)
+	copy(lowerBound[len(prefix):], addrPrefix)
+
+	upperBound := IncrementBytes(lowerBound)
 
 	iter, err := reader.NewIter(&pebble.IterOptions{
-		LowerBound: prefix,
+		LowerBound: lowerBound,
 		UpperBound: upperBound,
 	})
 	if err != nil {
@@ -261,12 +267,20 @@ func newSingleTypeReverseAccountIterator(reader dal.PebbleReader, attrType byte,
 // NewPebbleReverseAccountIterator creates a reverse account iterator that merges
 // V and M attribute types, yielding unique addresses in descending order.
 func NewPebbleReverseAccountIterator(reader dal.PebbleReader, ledgerName string) (*OrIterator[Desc], error) {
-	vIter, err := newSingleTypeReverseAccountIterator(reader, dal.SubAttrVolume, ledgerName)
+	return NewPebbleReverseAccountPrefixIterator(reader, ledgerName, "")
+}
+
+// NewPebbleReverseAccountPrefixIterator is the descending twin of
+// NewPebbleAccountPrefixIterator: unique addresses under addrPrefix, high to
+// low. Accounts are entity-ordered in the attributes zone, so an address
+// prefix match streams in both directions (EN-1966).
+func NewPebbleReverseAccountPrefixIterator(reader dal.PebbleReader, ledgerName string, addrPrefix string) (*OrIterator[Desc], error) {
+	vIter, err := newSingleTypeReverseAccountIterator(reader, dal.SubAttrVolume, ledgerName, addrPrefix)
 	if err != nil {
 		return nil, err
 	}
 
-	mIter, err := newSingleTypeReverseAccountIterator(reader, dal.SubAttrMetadata, ledgerName)
+	mIter, err := newSingleTypeReverseAccountIterator(reader, dal.SubAttrMetadata, ledgerName, addrPrefix)
 	if err != nil {
 		vIter.Close()
 
@@ -591,6 +605,42 @@ func NewPebbleReverseTxIterator(reader dal.PebbleReader, ledgerName string) (*Pe
 
 	iter, err := reader.NewIter(&pebble.IterOptions{
 		LowerBound: prefix,
+		UpperBound: upperBound,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &PebbleReverseTxIterator{
+		iter:     iter,
+		prefix:   prefix,
+		idOffset: len(prefix),
+	}, nil
+}
+
+// NewPebbleReverseTxRangeIterator is NewPebbleReverseTxIterator restricted to
+// [lower, upper) on the transaction id, mirroring NewPebbleTxRangeIterator's
+// bound construction. A nil bound means "open on that side". The traversal
+// logic is unchanged: Last/Prev/SeekLT all respect the Pebble bounds, so the
+// descending id-range scan streams exactly like the ascending one (EN-1966).
+func NewPebbleReverseTxRangeIterator(reader dal.PebbleReader, ledgerName string, lower, upper []byte) (*PebbleReverseTxIterator, error) {
+	prefix := txAttributeCode(ledgerName)
+
+	lowerBound := make([]byte, len(prefix)+len(lower))
+	copy(lowerBound, prefix)
+	copy(lowerBound[len(prefix):], lower)
+
+	var upperBound []byte
+	if upper != nil {
+		upperBound = make([]byte, len(prefix)+len(upper))
+		copy(upperBound, prefix)
+		copy(upperBound[len(prefix):], upper)
+	} else {
+		upperBound = IncrementBytes(prefix)
+	}
+
+	iter, err := reader.NewIter(&pebble.IterOptions{
+		LowerBound: lowerBound,
 		UpperBound: upperBound,
 	})
 	if err != nil {

--- a/internal/storage/readstore/iterator_pebble.go
+++ b/internal/storage/readstore/iterator_pebble.go
@@ -829,7 +829,6 @@ type PebbleTxRangeIterator struct {
 	floor     seekFloor
 }
 
-// NewPebbleTxRangeIterator creates a bounded transaction iterator for range queries.
 // NewReverseLedgerLogIterator is the descending twin of NewLedgerLogIterator:
 // log ids under the ledger's log prefix, high to low. Logs are entity-ordered
 // in the index, so the scan streams in both directions (EN-1966).
@@ -839,6 +838,7 @@ func NewReverseLedgerLogIterator(reader dal.PebbleReader, kb *dal.KeyBuilder, le
 	return NewReversePrefixIterator(reader, prefix, len(prefix), 8)
 }
 
+// NewPebbleTxRangeIterator creates a bounded transaction iterator for range queries.
 func NewPebbleTxRangeIterator(reader dal.PebbleReader, ledgerName string, lower, upper []byte) (*PebbleTxRangeIterator, error) {
 	prefix := txAttributeCode(ledgerName)
 

--- a/internal/storage/readstore/iterator_reverse.go
+++ b/internal/storage/readstore/iterator_reverse.go
@@ -1,6 +1,8 @@
 package readstore
 
 import (
+	"encoding/binary"
+	"fmt"
 	"slices"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -19,6 +21,14 @@ type ReversePrefixIterator struct {
 	started      bool
 	exhausted    bool
 	ceil         seekCeil
+	// stampPin gates rows by the fold sequence stored in their value,
+	// identically to PrefixIterator.stampPin. The gate MUST exist on both
+	// directions: a row written after the reader's pin that ascending pages
+	// hide but descending pages admit is a direction-dependent visibility
+	// bug, and a whole-set parity test cannot see it — both directions are
+	// compared against the same pinned view (EN-1966).
+	stampPin uint64
+	stampErr error
 }
 
 // NewReversePrefixIterator creates an iterator that scans all keys with the
@@ -48,6 +58,46 @@ func NewReversePrefixIterator(
 	}, nil
 }
 
+// NewStampGatedReversePrefixIterator is NewReversePrefixIterator with the
+// fold-sequence gate armed at pin — the descending twin of
+// NewStampGatedPrefixIterator.
+func NewStampGatedReversePrefixIterator(
+	reader dal.PebbleReader,
+	prefix []byte,
+	entityOffset int,
+	entityLen int,
+	pin uint64,
+) (*ReversePrefixIterator, error) {
+	it, err := NewReversePrefixIterator(reader, prefix, entityOffset, entityLen)
+	if err != nil {
+		return nil, err
+	}
+
+	it.stampPin = pin
+
+	return it, nil
+}
+
+// admitStamp applies the fold-sequence gate to the row under the cursor. A
+// malformed value latches an error and exhausts the iterator: refusing per
+// invariant #7 beats silently folding an unreadable row into the page.
+// See PrefixIterator.admitStamp.
+func (it *ReversePrefixIterator) admitStamp() bool {
+	if it.stampPin == 0 {
+		return true
+	}
+
+	v := it.iter.Value()
+	if len(v) != 8 {
+		it.stampErr = fmt.Errorf("stamp-gated reverse scan: row %x carries a %d-byte value (want an 8-byte fold sequence)", it.iter.Key(), len(v))
+		it.exhausted = true
+
+		return false
+	}
+
+	return binary.BigEndian.Uint64(v) <= it.stampPin
+}
+
 func (it *ReversePrefixIterator) Next() bool {
 	if it.exhausted {
 		return false
@@ -62,19 +112,27 @@ func (it *ReversePrefixIterator) Next() bool {
 		}
 
 		entity := it.extractEntity(it.iter.Key())
-		if entity != nil {
+		if entity != nil && it.admitStamp() {
 			it.current = entity
 
 			return true
+		}
+
+		if it.stampErr != nil {
+			return false
 		}
 	}
 
 	for it.iter.Prev() {
 		entity := it.extractEntity(it.iter.Key())
-		if entity != nil {
+		if entity != nil && it.admitStamp() {
 			it.current = entity
 
 			return true
+		}
+
+		if it.stampErr != nil {
+			return false
 		}
 	}
 
@@ -87,7 +145,7 @@ func (it *ReversePrefixIterator) Current() []byte {
 	return it.current
 }
 
-// Seek positions the iterator at the first entity whose key is <= target.
+// Seek positions the iterator at the largest entity whose key is <= target.
 func (it *ReversePrefixIterator) Seek(target []byte) bool {
 	// A prior failed seek at or above target proves this one empty too.
 	if it.ceil.covers(target) {
@@ -107,14 +165,18 @@ func (it *ReversePrefixIterator) Seek(target []byte) bool {
 
 	it.started = true
 
-	// Seek positions at first key >= seekKey. If exact match, check it.
+	// SeekGE positions at first key >= seekKey. If exact match, check it.
 	// If past target, step back.
 	if it.iter.SeekGE(seekKey) {
 		entity := it.extractEntity(it.iter.Key())
-		if entity != nil && compareEntities(entity, target) <= 0 {
+		if entity != nil && compareEntities(entity, target) <= 0 && it.admitStamp() {
 			it.current = entity
 
 			return true
+		}
+
+		if it.stampErr != nil {
+			return false
 		}
 		// Key is > target, step back
 		if !it.iter.Prev() {
@@ -133,10 +195,14 @@ func (it *ReversePrefixIterator) Seek(target []byte) bool {
 
 	for it.iter.Valid() {
 		entity := it.extractEntity(it.iter.Key())
-		if entity != nil && compareEntities(entity, target) <= 0 {
+		if entity != nil && compareEntities(entity, target) <= 0 && it.admitStamp() {
 			it.current = entity
 
 			return true
+		}
+
+		if it.stampErr != nil {
+			return false
 		}
 
 		if !it.iter.Prev() {
@@ -151,6 +217,10 @@ func (it *ReversePrefixIterator) Seek(target []byte) bool {
 }
 
 func (it *ReversePrefixIterator) Err() error {
+	if it.stampErr != nil {
+		return it.stampErr
+	}
+
 	if it.iter == nil {
 		return nil
 	}
@@ -196,6 +266,8 @@ func IncrementBytes(b []byte) []byte {
 	// Overflow
 	return append(result, 0xFF)
 }
+
+var _ ReverseIterator = (*ReversePrefixIterator)(nil)
 
 // Direction is the compile-time direction witness; see Iterator.Direction.
 func (it *ReversePrefixIterator) Direction() (d Desc) { return }

--- a/internal/storage/readstore/iterator_reverse.go
+++ b/internal/storage/readstore/iterator_reverse.go
@@ -1,8 +1,6 @@
 package readstore
 
 import (
-	"encoding/binary"
-	"fmt"
 	"slices"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -83,19 +81,13 @@ func NewStampGatedReversePrefixIterator(
 // invariant #7 beats silently folding an unreadable row into the page.
 // See PrefixIterator.admitStamp.
 func (it *ReversePrefixIterator) admitStamp() bool {
-	if it.stampPin == 0 {
-		return true
-	}
-
-	v := it.iter.Value()
-	if len(v) != 8 {
-		it.stampErr = fmt.Errorf("stamp-gated reverse scan: row %x carries a %d-byte value (want an 8-byte fold sequence)", it.iter.Key(), len(v))
+	admitted, err := admitFoldStamp(it.iter, it.stampPin)
+	if err != nil {
+		it.stampErr = err
 		it.exhausted = true
-
-		return false
 	}
 
-	return binary.BigEndian.Uint64(v) <= it.stampPin
+	return admitted
 }
 
 func (it *ReversePrefixIterator) Next() bool {

--- a/internal/storage/readstore/iterator_reverse_bitset.go
+++ b/internal/storage/readstore/iterator_reverse_bitset.go
@@ -1,0 +1,126 @@
+package readstore
+
+import (
+	"encoding/binary"
+	"math/bits"
+
+	"github.com/formancehq/ledger/v3/internal/pkg/bitset"
+)
+
+// ReverseBitsetIterator iterates the set bits of a bitset in DESCENDING order,
+// emitting each bit position as an 8-byte big-endian entity ID — the mirror of
+// BitsetIterator. It backs the `reverted` transaction filter on descending
+// pages. Being in-memory, it never errors.
+type ReverseBitsetIterator struct {
+	bs      *bitset.Bitset
+	wordIdx uint64
+	// remaining is the current word with already-emitted (higher) bits cleared.
+	remaining uint64
+	current   []byte
+	started   bool
+	done      bool
+}
+
+// NewReverseBitsetIterator creates a descending iterator over the set bits of
+// bs. A nil bitset yields no entities.
+func NewReverseBitsetIterator(bs *bitset.Bitset) *ReverseBitsetIterator {
+	return &ReverseBitsetIterator{bs: bs}
+}
+
+// emit yields the HIGHEST remaining set bit of the current word.
+func (it *ReverseBitsetIterator) emit() bool {
+	pos := uint64(63 - bits.LeadingZeros64(it.remaining))
+	it.remaining &^= uint64(1) << pos
+	it.current = EncodeTxID(nil, it.wordIdx*64+pos)
+
+	return true
+}
+
+// advance walks down to the next word holding a set bit.
+func (it *ReverseBitsetIterator) advance() bool {
+	for it.remaining == 0 {
+		if it.wordIdx == 0 {
+			it.done = true
+
+			return false
+		}
+
+		it.wordIdx--
+		it.remaining = it.bs.Word(it.wordIdx)
+	}
+
+	return it.emit()
+}
+
+func (it *ReverseBitsetIterator) Next() bool {
+	if it.done || it.bs == nil {
+		return false
+	}
+
+	if !it.started {
+		it.started = true
+
+		wc := it.bs.WordCount()
+		if wc == 0 {
+			it.done = true
+
+			return false
+		}
+
+		it.wordIdx = wc - 1
+		it.remaining = it.bs.Word(it.wordIdx)
+	}
+
+	return it.advance()
+}
+
+func (it *ReverseBitsetIterator) Current() []byte { return it.current }
+
+// Seek positions at the highest set bit <= target. Like BitsetIterator.SeekGE
+// it is absolute repositioning: the position is recomputed from target even
+// after a prior walk exhausted the iterator, because the composite reverse
+// merge iterators re-seek children freely.
+func (it *ReverseBitsetIterator) Seek(target []byte) bool {
+	if it.bs == nil {
+		return false
+	}
+
+	it.started = true
+	it.done = false
+
+	wc := it.bs.WordCount()
+	if wc == 0 {
+		it.done = true
+
+		return false
+	}
+
+	// A target shorter than an encoded entity cannot address a bit above 0;
+	// mirroring BitsetIterator.SeekGE, it reads as position 0.
+	var from uint64
+	if len(target) >= 8 {
+		from = binary.BigEndian.Uint64(target[:8])
+	}
+
+	it.wordIdx = from / 64
+	if it.wordIdx >= wc {
+		// Target is past every stored word: start from the top.
+		it.wordIdx = wc - 1
+		it.remaining = it.bs.Word(it.wordIdx)
+	} else {
+		// Keep only bits at or below the target's position within its word.
+		shift := from % 64
+		it.remaining = it.bs.Word(it.wordIdx) & (^uint64(0) >> (63 - shift))
+	}
+
+	return it.advance()
+}
+
+func (it *ReverseBitsetIterator) Err() error { return nil }
+
+func (it *ReverseBitsetIterator) Close() {}
+
+// Direction is the compile-time direction witness; see Iterator.Direction.
+func (it *ReverseBitsetIterator) Direction() (d Desc) { return }
+
+var _ ReverseIterator = (*ReverseBitsetIterator)(nil)

--- a/internal/storage/readstore/iterator_reverse_bitset_test.go
+++ b/internal/storage/readstore/iterator_reverse_bitset_test.go
@@ -1,0 +1,63 @@
+package readstore_test
+
+import (
+	"encoding/binary"
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/pkg/bitset"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+func TestReverseBitsetIterator_BoundariesAndAbsoluteSeek(t *testing.T) {
+	t.Parallel()
+	bs := &bitset.Bitset{}
+	for _, id := range []uint64{0, 3, 63, 64, 65, 200, 4095} {
+		bs.Set(id)
+	}
+	it := readstore.NewReverseBitsetIterator(bs)
+	defer it.Close()
+	var got []uint64
+	for it.Next() {
+		got = append(got, binary.BigEndian.Uint64(it.Current()))
+	}
+	require.Equal(t, []uint64{4095, 200, 65, 64, 63, 3, 0}, got)
+	require.False(t, it.Next())
+	for _, tc := range []struct{ target, want uint64 }{
+		{math.MaxUint64, 4095}, {64, 64}, {64, 64}, {199, 65}, {63, 63}, {62, 3}, {4095, 4095}, {0, 0},
+	} {
+		require.True(t, it.Seek(be8(tc.target)), "target %d", tc.target)
+		require.Equal(t, tc.want, binary.BigEndian.Uint64(it.Current()))
+	}
+	require.False(t, it.Next())
+	require.True(t, it.Seek(be8(65)))
+	require.True(t, it.Next())
+	require.Equal(t, uint64(64), binary.BigEndian.Uint64(it.Current()))
+	require.True(t, it.Seek(nil))
+	require.Equal(t, uint64(0), binary.BigEndian.Uint64(it.Current()))
+	require.NoError(t, it.Err())
+}
+
+func TestReverseBitsetIterator_EmptyAndFailedSeek(t *testing.T) {
+	t.Parallel()
+	for _, bs := range []*bitset.Bitset{nil, {}} {
+		it := readstore.NewReverseBitsetIterator(bs)
+		require.False(t, it.Next())
+		require.False(t, it.Seek(be8(math.MaxUint64)))
+		require.False(t, it.Next())
+		require.NoError(t, it.Err())
+		it.Close()
+	}
+	bs := &bitset.Bitset{}
+	bs.Set(64)
+	it := readstore.NewReverseBitsetIterator(bs)
+	defer it.Close()
+	require.False(t, it.Seek(be8(63)))
+	require.False(t, it.Next())
+	require.True(t, it.Seek(be8(64)))
+	require.Equal(t, uint64(64), binary.BigEndian.Uint64(it.Current()))
+	require.False(t, it.Next())
+	require.NoError(t, it.Err())
+}

--- a/internal/storage/readstore/iterator_reverse_stamp_test.go
+++ b/internal/storage/readstore/iterator_reverse_stamp_test.go
@@ -1,0 +1,72 @@
+package readstore
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReversePrefixIteratorStampVisibility(t *testing.T) {
+	for _, seek := range []bool{false, true} {
+		name := "next"
+		if seek {
+			name = "seek"
+		}
+		t.Run(name, func(t *testing.T) {
+			s := newTestStore(t)
+			prefix := []byte("stamp/")
+			for entity, stamp := range map[string]uint64{"a": 9, "b": 11, "c": 10, "d": 12} {
+				require.NoError(t, s.DB().Set(append(append([]byte(nil), prefix...), entity...), binary.BigEndian.AppendUint64(nil, stamp), pebble.NoSync))
+			}
+			it, err := NewStampGatedReversePrefixIterator(s.DB(), prefix, len(prefix), 0, 10)
+			require.NoError(t, err)
+			defer it.Close()
+			if seek {
+				require.True(t, it.Seek([]byte("d")))
+			} else {
+				require.True(t, it.Next())
+			}
+			require.Equal(t, "c", string(it.Current()), "admit the pin itself and reject a newer first row")
+			require.True(t, it.Next())
+			require.Equal(t, "a", string(it.Current()), "skip newer rows between visible rows")
+			require.False(t, it.Next())
+			require.NoError(t, it.Err())
+			require.True(t, it.Seek([]byte("b")))
+			require.Equal(t, "a", string(it.Current()), "reposition after exhaustion while applying the gate")
+		})
+	}
+}
+
+func TestReversePrefixIteratorMalformedStamp(t *testing.T) {
+	for _, seek := range []bool{false, true} {
+		name := "next"
+		if seek {
+			name = "seek"
+		}
+		t.Run(name, func(t *testing.T) {
+			s := newTestStore(t)
+			prefix := []byte("stamp/")
+			require.NoError(t, s.DB().Set([]byte("stamp/b"), []byte{1}, pebble.NoSync))
+			require.NoError(t, s.DB().Set([]byte("stamp/a"), binary.BigEndian.AppendUint64(nil, 1), pebble.NoSync))
+			it, err := NewStampGatedReversePrefixIterator(s.DB(), prefix, len(prefix), 0, 10)
+			require.NoError(t, err)
+			defer it.Close()
+			if seek {
+				require.False(t, it.Seek([]byte("b")))
+			} else {
+				require.False(t, it.Next())
+			}
+			require.ErrorContains(t, it.Err(), "1-byte value")
+			require.False(t, it.Next(), "malformed values must latch exhaustion")
+			require.ErrorContains(t, it.Err(), "1-byte value")
+			ungated, err := NewStampGatedReversePrefixIterator(s.DB(), prefix, len(prefix), 0, 0)
+			require.NoError(t, err)
+			defer ungated.Close()
+			require.True(t, ungated.Next(), "pin zero disables value validation")
+			require.Equal(t, "b", string(ungated.Current()))
+			require.NoError(t, ungated.Err())
+		})
+	}
+}


### PR DESCRIPTION
[EN-1966](https://formance-team.atlassian.net/browse/EN-1966)

Adds the foundation for a direction-parameterized query compiler, following #1951 and the review of #1930. This PR targets `release/v3.0` and is ready for review. The compiler conversion is follow-up work: `leaves[D]` has no live callers yet.

## Changes

- Expose generic `And`, `Or`, `Not`, `Slice`, and `Filter` constructors while retaining the named direction-specific constructors.
- Add descending bitset, event-resolution, account-prefix, transaction-range, and ledger-log leaves.
- Add a stamp-gated descending prefix constructor that excludes rows folded after the reader's pin. This stages the visibility fix for the future compiler; the existing descending path in `internal/application/ctrl/list_entities.go` still uses the ungated constructor.
- Define the ten-method `leaves[D]` interface with ascending and descending factories. Compile-time assertions verify that each factory implements this interface; they do not prove that every direction-dependent leaf is represented.
- Use one `AddressTxIterator[D]` over a direction-independent account-to-transaction union. Materializing range scans remain outside the interface: both directions can consume the same sorted result.
- Share fold-stamp validation and event-key parsing between iterators, and add focused regression tests for descending visibility, bitset traversal, event resolution, and absolute seek repositioning.

## Follow-up

Convert `compile.go` to a single recursion parameterized by direction while keeping shared compilation semantics non-generic. Replace the existing `newReverseIterator` path in `internal/application/ctrl/list_entities.go` with the shared compiler. There is no `compile_reverse.go` in this branch.

Add end-to-end ascending/descending parity and error checks across accounts, transactions, and logs, including filters, cursors, page sizes, index/schema gates, and pinned visibility. Add registry exhaustiveness checks to detect omitted leaf pairs. These broader compiler guarantees are not delivered by this foundation.

## Validation

`go test -race ./internal/storage/readstore ./internal/query/... ./internal/application/ctrl` passes, as do the focused descending regression tests. Readstore lint passes with the unavailable custom `gomodguard_v2` plugin omitted; the full configured lint run requires that plugin. Query lint also reports a pre-existing `modernize` warning in unchanged `compact_account.go`. GitHub CI will rerun on the updated head; patch coverage remains subject to Codecov's result.


[EN-1966]: https://formance-team.atlassian.net/browse/EN-1966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ