### PR TITLE
fix(node): preserve shutdown requests after caller timeout

### DIFF
--- a/docs/technical/architecture/subsystems/consensus/README.md
+++ b/docs/technical/architecture/subsystems/consensus/README.md
@@ -6,7 +6,7 @@ The replication and ordering layer (`internal/infra/node`, `internal/infra/trans
 
 | Document | Description |
 |----------|-------------|
-| [raft-consensus.md](raft-consensus.md) | Raft consensus implementation, CP failure model, quorum sizing, leader election, retained-log catch-up, snapshot transfer, and fail-stop on force-removal persistence failure. |
+| [raft-consensus.md](raft-consensus.md) | Raft consensus implementation, CP failure model, quorum sizing, leader election, retained-log catch-up, snapshot transfer, deadline-independent shutdown requests and commit drain, and fail-stop on force-removal persistence failure. |
 | [global-log.md](global-log.md) | Two-level log architecture enabling system-level atomic bulk operations. |
 | [hybrid-logical-clock.md](hybrid-logical-clock.md) | Monotonic HLC timestamps across leader changes and clock skew. |
 | [removed-member-registry.md](removed-member-registry.md) | Replicated `(nodeID, instanceID)` set that prevents a removed member from silently rejoining and being auto-promoted; force-removal write ordering and durable restart states. |

--- a/docs/technical/architecture/subsystems/consensus/raft-consensus.md
+++ b/docs/technical/architecture/subsystems/consensus/raft-consensus.md
@@ -103,6 +103,30 @@ type Node struct {
 }
 ```
 
+#### Node shutdown
+
+`Node.Stop(ctx)` first attempts a best-effort leadership transfer while peer
+connections remain available. It then closes a persistent stop signal exactly
+once, even when the caller context has expired during transfer or `Run` has not
+reached its outer stop select. The context bounds transfer and waiting; it must
+never abandon the shutdown request. Concurrent callers share this signal and
+wait for the same `Run` completion.
+
+`Run` owns task termination: it closes the task stop channels and joins the
+orchestrator, ready processor, maintenance loop, and applier. During applier
+exit, any pending commit is drained, the commit queue is closed, the committer
+is joined, and the decoder is cancelled and joined. `Run` then stops FSM
+background tasks and publishes completion. A successful `Stop` waits for this
+whole sequence. This preserves the existing pending-commit drain; it does not
+promise to apply every queued entry before shutdown.
+
+Bootstrap leaves the run context live until `Stop` returns so normal shutdown
+can complete pending commits. If `Stop` times out, the shutdown request remains
+published and bootstrap cancels context-aware work, but that cancellation does
+not itself terminate idle tasks or join `Run`. Task/drain completion may still
+be pending, so a timeout must not be treated as permission to close the node's
+storage or transport. `Stop` after `Run` has exited returns immediately.
+
 #### Applier
 
 `internal/infra/node/applier.go` decouples WAL writes from FSM application by running as a dedicated goroutine. This provides two levels of pipelining:

--- a/internal/bootstrap/module.go
+++ b/internal/bootstrap/module.go
@@ -943,8 +943,9 @@ func Module() fx.Option {
 
 						// Use a dedicated context for node.Run that survives
 						// the OnStart return (unlike ctx which expires). On
-						// startup failure we cancel it to abandon the goroutine;
-						// on graceful shutdown node.Stop is the signal, NOT this
+						// startup failure we cancel context-aware work; this
+						// cancellation alone does not join Run. During shutdown,
+						// node.Stop supplies the task termination signal, not this
 						// cancel — see the OnStop hook below for the rationale.
 						var runCtx context.Context
 						runCtx, cancelRun = context.WithCancel(context.Background())
@@ -993,18 +994,15 @@ func Module() fx.Option {
 						// pool error" from Node.Run, panics the bootstrap
 						// goroutine, and crashes the process mid-shutdown
 						// instead of returning a clean nil (#345).
-						// Defer the cancel so it runs on EVERY return path,
-						// including the error path below. If node.Stop returns
-						// ctx.Err() (e.g. fx stop timeout expired during the
-						// leadership transfer or stopChannel handshake), the
-						// Run goroutine is still alive and waiting; without
-						// this cancel the goroutine would outlive OnStop while
-						// downstream fx hooks tear down transport and Pebble
-						// underneath it. The cancel propagates into the tasks'
-						// FSM calls (PrepareEntries / CommitPreparedBatch /
-						// InstallSnapshot) so the bootstrap goroutine exits
-						// via a logged task-pool error rather than racing with
-						// concurrent infrastructure teardown.
+						// Cancel only after Stop returns, preserving the run
+						// context through successful task/commit drain. Stop
+						// publishes its shutdown request even if ctx expires
+						// during transfer or before Run reaches its stop select.
+						// On timeout, cancellation can interrupt context-aware
+						// work, but does not join Run or terminate idle tasks;
+						// Run's explicit stop path still owns their termination.
+						// A timeout is not proof that infrastructure is safe to
+						// close. Only successful Stop confirms the drain/join.
 						defer cancelRun()
 
 						err := node.Stop(ctx)

--- a/internal/infra/node/applier_test.go
+++ b/internal/infra/node/applier_test.go
@@ -102,6 +102,12 @@ func newTestApplierSetup(t *testing.T) *testApplierSetup {
 func newTestApplierSetupWithSink(t *testing.T, sink LocalResponses) *testApplierSetup {
 	t.Helper()
 
+	return newTestApplierSetupWithNotifier(t, sink, newNoopNotifier(t))
+}
+
+func newTestApplierSetupWithNotifier(t *testing.T, sink LocalResponses, notifier state.Notifier) *testApplierSetup {
+	t.Helper()
+
 	logger := logging.Testing()
 	meterProvider := noop.NewMeterProvider()
 	meter := meterProvider.Meter("test")
@@ -131,7 +137,7 @@ func newTestApplierSetupWithSink(t *testing.T, sink LocalResponses) *testApplier
 	nodeSnapshotter := state.NewCacheSnapshotter(logger, nodeRegistry, nil)
 	fsm, err := state.NewMachine(
 		logger, nodeRegistry, nodeSnapshotter, pebbleStore, dal.NewSentinelFactory(pebbleStore, false), meterProvider,
-		nil, state.NewSharedState(), newNoopNotifier(t), nil, "test-cluster", 0,
+		nil, state.NewSharedState(), notifier, nil, "test-cluster", 0,
 		func(*raftpb.Entry, *dal.WriteSession) error { return nil },
 	)
 	require.NoError(t, err)

--- a/internal/infra/node/force_remove_run_test.go
+++ b/internal/infra/node/force_remove_run_test.go
@@ -58,15 +58,9 @@ func TestForceRemoveNodeDurabilityFailureStopsRun(t *testing.T) {
 	t.Cleanup(func() {
 		// Also stop and join Run when an earlier assertion fails, before the
 		// shared fixture closes the WAL, spool, and Pebble store.
-		select {
-		case <-done:
-			return
-		case n.stopChannel <- make(chan struct{}):
-		case <-time.After(5 * time.Second):
-			t.Error("could not request node shutdown")
-
-			return
-		}
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, n.Stop(ctx))
 		select {
 		case <-done:
 		case <-time.After(5 * time.Second):

--- a/internal/infra/node/node.go
+++ b/internal/infra/node/node.go
@@ -374,7 +374,8 @@ type Node struct {
 	// touch it). Used only when raft.Config.AsyncStorageWrites is true.
 	localResponseCh LocalResponses
 	tasks           *taskSet
-	stopChannel     chan chan struct{}
+	stopChannel     chan struct{}
+	stopOnce        sync.Once
 	runDone         chan struct{} // closed when Run() exits
 	// terminalCh closes when an irreversible live Raft mutation could not be
 	// durably established. New work is rejected immediately while the task
@@ -681,7 +682,7 @@ func NewNode(
 		readyTerminated:  make(chan readyResult, 1),
 		localResponseCh:  localResponses,
 		tasks:            newTaskSet(),
-		stopChannel:      make(chan chan struct{}),
+		stopChannel:      make(chan struct{}),
 		terminalCh:       make(chan struct{}),
 		pendingReads:     &SyncMap[uint64, *readIndexRequest]{},
 		membership:       membership,
@@ -974,6 +975,11 @@ func (node *Node) doMaintenance() {
 }
 
 func (node *Node) Run(ctx context.Context, ready chan struct{}) error {
+	return node.run(ctx, func() { close(ready) })
+}
+
+// run publishes readiness after starting the tasks and owns their shutdown.
+func (node *Node) run(ctx context.Context, ready func()) error {
 	node.runDone = make(chan struct{})
 	defer close(node.runDone)
 
@@ -1163,10 +1169,10 @@ func (node *Node) Run(ctx context.Context, ready chan struct{}) error {
 	// specific index (index builder, event manager, cluster-config
 	// reconciler) call fsm.WaitForApplied on demand rather than piggybacking
 	// on node.Run's ready signal.
-	close(ready)
+	ready()
 
 	select {
-	case ch := <-node.stopChannel:
+	case <-node.stopChannel:
 		err := node.tasks.stop()
 		if err != nil {
 			node.logger.Errorf("Error stopping task pool: %v", err)
@@ -1176,8 +1182,6 @@ func (node *Node) Run(ctx context.Context, ready chan struct{}) error {
 		// Must run after tasks.stop() (which stops the applier that can
 		// trigger new bloom tasks) and before the fx hook closes the DB.
 		node.fsm.StopBackgroundTasks()
-
-		close(ch)
 
 		return nil
 	case err := <-node.tasks.err():
@@ -2465,11 +2469,13 @@ func (node *Node) tryTransferLeadershipBeforeShutdown(ctx context.Context) {
 	node.logger.Infof("Leadership transferred successfully before shutdown")
 }
 
+// Stop requests task shutdown after a best-effort leadership transfer. The
+// context bounds transfer and waiting, but cannot abandon the shutdown request.
+// A nil result means Run has joined its tasks and stopped FSM background work.
 func (node *Node) Stop(ctx context.Context) error {
 	node.logger.Infof("Stopping node")
 
-	// If Run() has already exited (e.g. task error or context cancellation),
-	// skip the leadership transfer and stopChannel handshake.
+	// If Run has already exited, skip the leadership transfer and stop request.
 	select {
 	case <-node.runDone:
 		node.logger.Infof("Run already exited, nothing to stop")
@@ -2482,20 +2488,15 @@ func (node *Node) Stop(ctx context.Context) error {
 		node.tryTransferLeadershipBeforeShutdown(ctx)
 	}
 
-	ch := make(chan struct{})
+	// Publish a persistent request even if the caller's deadline expired during
+	// transfer or Run has not reached its outer select yet. Run owns task stop
+	// and drain; cancelling its context is not a substitute for this signal.
+	node.stopOnce.Do(func() { close(node.stopChannel) })
+
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case node.stopChannel <- ch:
-		select {
-		case <-ch:
-			return nil
-		case <-ctx.Done():
-			return ctx.Err()
-		}
 	case <-node.runDone:
-		// Run() exited while we were trying to send on stopChannel
-		// (e.g. a task crashed between our check and the send).
 		return nil
 	}
 }

--- a/internal/infra/node/node_shutdown_test.go
+++ b/internal/infra/node/node_shutdown_test.go
@@ -1,0 +1,269 @@
+package node
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/raft/v3"
+	"go.etcd.io/raft/v3/raftpb"
+	"go.opentelemetry.io/otel/metric/noop"
+	"go.uber.org/mock/gomock"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/infra/state"
+	"github.com/formancehq/ledger/v3/internal/pkg/futures"
+)
+
+// startShutdownNode pauses the real Run implementation after task startup,
+// before it can receive a shutdown request. Cleanup joins it before closing
+// the fixture's WAL, spool, and store, including on the unfixed failure path.
+func startShutdownNode(t *testing.T, ctx context.Context, setup *testApplierSetup) (*Node, <-chan error, func()) {
+	t.Helper()
+	n, err := NewNode(NodeConfig{
+		NodeID: 1, AdvertiseAddr: "node-1:7000", ServiceAdvertiseAddr: "node-1:8000",
+		InstanceID: []byte("0000000000000001"), TickInterval: time.Hour,
+		ProcessingTickInterval: time.Hour, MaintenanceInterval: time.Hour,
+	}, newForceRemoveTransport(t), setup.applier, logging.Testing(),
+		noop.NewMeterProvider().Meter("node-shutdown"), setup.wal, setup.fsm,
+		setup.applier.recovery, setup.applier.synchronizer, newTestMembership(t), setup.responseSink)
+	require.NoError(t, err)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	resume := sync.OnceFunc(func() { close(release) })
+	result := make(chan error, 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		result <- n.run(ctx, func() {
+			close(started)
+			<-release
+		})
+	}()
+	t.Cleanup(func() {
+		resume()
+		stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		require.NoError(t, n.Stop(stopCtx))
+		select {
+		case <-done:
+		case <-stopCtx.Done():
+			t.Error("Node.Run was not joined before fixture cleanup")
+		}
+	})
+	select {
+	case <-started:
+	case err := <-result:
+		t.Fatalf("Node.Run failed before readiness: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Node.Run did not start its tasks")
+	}
+	// Drain traverses the real decoder/applier and proves their startup without
+	// a scheduling delay. The committer starts before this barrier is handled.
+	setup.applier.Drain(setup.stop)
+
+	return n, result, resume
+}
+
+func TestNodeStopExpiredContextStillTerminatesRun(t *testing.T) {
+	t.Parallel()
+	for _, deadline := range []bool{false, true} {
+		name := "cancelled"
+		if deadline {
+			name = "expired deadline"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			runCtx, cancelRun := context.WithCancel(context.Background())
+			defer cancelRun()
+			n, result, resume := startShutdownNode(t, runCtx, newTestApplierSetup(t))
+			stopCtx, cancelStop := context.WithCancel(context.Background())
+			if deadline {
+				cancelStop()
+				stopCtx, cancelStop = context.WithDeadline(context.Background(), time.Unix(0, 0))
+			} else {
+				cancelStop()
+			}
+			defer cancelStop()
+			require.ErrorIs(t, n.Stop(stopCtx), stopCtx.Err())
+			// Reproduce bootstrap's fallback too: it cannot replace an explicit stop
+			// request when the applier/committer are idle.
+			cancelRun()
+			resume()
+			select {
+			case err := <-result:
+				require.NoError(t, err)
+			case <-time.After(time.Second):
+				t.Fatal("Stop abandoned shutdown: Node.Run and its idle applier/committer remain live")
+			}
+			select {
+			case <-n.runDone:
+			default:
+				t.Fatal("shutdown returned before Run lifecycle completion")
+			}
+		})
+	}
+}
+
+func TestNodeStopWaitsForCommitDrain(t *testing.T) {
+	t.Parallel()
+	commitEntered := make(chan struct{})
+	releaseCommit := make(chan struct{})
+	release := sync.OnceFunc(func() { close(releaseCommit) })
+	notifier := NewMockNotifier(gomock.NewController(t))
+	notifier.EXPECT().NotifyLogsCommitted(gomock.Any()).Do(func(uint64) {
+		close(commitEntered)
+		<-releaseCommit
+	})
+	setup := newTestApplierSetupWithNotifier(t, make(LocalResponses, 1024), notifier)
+	runCtx := t.Context()
+	n, result, resume := startShutdownNode(t, runCtx, setup)
+	t.Cleanup(release)
+	entry, id := makeCreateLedgerEntry(t, 1, "shutdown-drain")
+	future := futures.New[state.ApplyResult]()
+	setup.applier.StoreFuture(id, 1, future)
+	setup.applier.Submit([]*raftpb.Entry{entry}, setup.confState, nil, setup.stop)
+	select {
+	case <-commitEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("committer did not enter post-commit notification")
+	}
+	// The real commit is still in flight; futures and the committer completion
+	// signal are published only after this notification returns.
+	stopCtx, cancelStop := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelStop()
+	stopped := make(chan error, 1)
+	go func() { stopped <- n.Stop(stopCtx) }()
+	select {
+	case <-n.stopChannel:
+	case <-stopCtx.Done():
+		t.Fatal("Stop did not publish shutdown")
+	}
+	resume()
+	select {
+	case err := <-stopped:
+		t.Fatalf("Stop returned before commit drain: %v", err)
+	default:
+	}
+	require.NoError(t, runCtx.Err(), "graceful Stop must preserve the commit context")
+	release()
+	select {
+	case err := <-stopped:
+		require.NoError(t, err)
+	case <-stopCtx.Done():
+		t.Fatal("Stop did not join the completed commit")
+	}
+	require.NoError(t, <-result)
+	_, err := future.Wait(stopCtx)
+	require.NoError(t, err, "graceful drain must resolve the committed proposal")
+	require.True(t, listLedgerContains(setup.store, "shutdown-drain"))
+	require.Equal(t, uint64(1), setup.fsm.LastAppliedIndex())
+	select {
+	case <-n.tasks.terminated:
+	default:
+		t.Fatal("Stop returned without joining the task pool")
+	}
+}
+
+func TestNodeStopConcurrentCallersShareShutdown(t *testing.T) {
+	t.Parallel()
+	n, result, resume := startShutdownNode(t, context.Background(), newTestApplierSetup(t))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	const callers = 8
+	results := make(chan error, callers)
+	for range callers {
+		go func() { results <- n.Stop(ctx) }()
+	}
+	for range callers {
+		require.ErrorIs(t, <-results, context.Canceled)
+	}
+	resume()
+	select {
+	case err := <-result:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent Stop calls did not terminate Run")
+	}
+	require.NoError(t, n.Stop(ctx), "already-exited Run needs no transfer or waiting")
+}
+
+func TestNodeStopCancellationDuringLeadershipTransferStillRequestsShutdown(t *testing.T) {
+	t.Parallel()
+	// A minimal node holds the orchestrate command so cancellation occurs
+	// inside the transfer preflight, rather than before Stop starts. The
+	// command callback deliberately remains unexecuted, as with a stalled
+	// orchestrate loop; no rawNode access is needed on this failure path.
+	n := &Node{
+		logger: logging.Testing(), clusterCommandCh: make(chan *clusterCommand),
+		runDone: make(chan struct{}), stopChannel: make(chan struct{}),
+	}
+	n.lastSoftState.Store(&raft.SoftState{RaftState: raft.StateLeader, Lead: 1})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	result := make(chan error, 1)
+	go func() { result <- n.Stop(ctx) }()
+	select {
+	case <-n.clusterCommandCh:
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not enter leadership-transfer preflight")
+	}
+	cancel()
+	select {
+	case err := <-result:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("Stop did not respect transfer cancellation")
+	}
+	select {
+	case <-n.stopChannel:
+	default:
+		t.Fatal("leadership transfer consumed the caller context and abandoned shutdown")
+	}
+}
+
+func TestNodeStopWaitsForRunCompletionOrCallerCancellation(t *testing.T) {
+	t.Parallel()
+	for _, complete := range []bool{false, true} {
+		name := "cancel while draining"
+		if complete {
+			name = "complete drain"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				n := &Node{logger: logging.Testing(), runDone: make(chan struct{}), stopChannel: make(chan struct{})}
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				result := make(chan error, 1)
+				go func() { result <- n.Stop(ctx) }()
+				synctest.Wait()
+				select {
+				case <-n.stopChannel:
+				default:
+					t.Fatal("Stop did not publish its request before waiting")
+				}
+				select {
+				case err := <-result:
+					t.Fatalf("Stop returned before Run completed: %v", err)
+				default:
+				}
+				if complete {
+					close(n.runDone)
+				} else {
+					cancel()
+				}
+				synctest.Wait()
+				if complete {
+					require.NoError(t, <-result)
+				} else {
+					require.ErrorIs(t, <-result, context.Canceled)
+				}
+			})
+		})
+	}
+}


### PR DESCRIPTION
## What changed

`Node.Stop` now publishes a persistent shutdown request even when its caller context expires before `Run` reaches the stop select or during leadership transfer. Successful callers wait for `Run` to finish task shutdown, pending-commit drain, and FSM background-task cleanup. Bootstrap comments and consensus documentation describe the actual timeout behavior.

## Why

Fixes [EN-1985](https://formance-team.atlassian.net/browse/EN-1985): the cancellable stop handshake could leave the idle Raft task pool and committer alive. Cancelling bootstrap's run context does not terminate those idle tasks.

## Product / operational motivation

A shutdown deadline must limit caller waiting without discarding the termination request. Graceful shutdown must preserve pending committed work and join lifecycle-owned goroutines before reporting success. The deterministic regression pauses the real Run implementation after task startup and exercises both cancelled and expired caller contexts.

Durable contract: `docs/technical/architecture/subsystems/consensus/raft-consensus.md`, “Node shutdown”.

## Technical decision

Close a stop channel through `sync.Once`, then wait on the existing `runDone` signal. This requires no background sender or new task owner and supports concurrent callers. Run retains responsibility for stopping and joining tasks. Context cancellation alone cannot provide this contract and would interrupt normal drain.

## Risk

**MEDIUM** — node lifecycle synchronization changes, covered by deterministic cancellation, transfer-preflight, concurrent-stop, real pending-commit and completion-boundary regressions.

## Validation

DISCOVERY: NO_EXISTING_WORK
BEFORE_FIX: BUG_REPRODUCED
AFTER_FIX: PASS

Reproduction and initial validation base: `8c33007e46efaa95c6d8f02d474ac2fcea9e39ed`.

Current PR base: `658dfacacafd6a14b074c7ab2ddb484630178c56`. The intervening #1950/#1951 changes do not touch node, bootstrap, or consensus documentation. The native review workflow passed fresh exact-base proportional validation and independently approved candidate `bc264c024e788f2d5a46559bcb7c6d491c510aec` with zero findings.

- BEFORE_FIX: both cancelled and expired-context regressions fail with Run/applier/committer still live after the readiness barrier is released, including bootstrap cancellation.
- Mutation sensitivity: making publication conditional on a live context reproduces both failures; skipping the Run join fails the deterministic `testing/synctest` completion tests.
- Pinned `go test -race ./internal/infra/node -run "TestNodeStop|TestForceRemoveNodeDurabilityFailureStopsRun|TestApplierRunStopPrecedenceOverCtxCancel" -count=1 -timeout 2m`: PASS.
- `bash scripts/agent-check`: PASS.
- `AI_REVIEW_BASE_SHA=8c33007e46efaa95c6d8f02d474ac2fcea9e39ed bash scripts/agent-check-pr`: PASS, including generation/tidy, root and operator lint (zero issues), and bootstrap/node race suites.
- AFTER_FIX: focused `TestNodeStop*` cases pass across three runs, along with existing force-removal lifecycle and applier stop-precedence regressions.

- Fresh `agent-check-pr` against current base: PASS; bootstrap race 4.102s, node race 14.714s.
- Exact independent review: APPROVE, zero findings; worktree clean and `ROOT_UNCHANGED=PASS`. The launcher required an execution-only SIGPIPE workaround to read the full worktree listing; all pinned validation/review/integrity gates were unchanged.

## Architecture / behavior impact

Termination requests survive caller cancellation. Nil from Stop confirms Run completion. A timeout still does not prove that drain/join has completed. No persisted formats, gRPC contracts, FSM apply rules, or configuration validation change.

## Review focus

Persistent stop publication, Run-owned task/committer drain, and preservation of the best-effort leadership-transfer ordering.

## Known concerns

None beyond the documented distinction between requesting shutdown and completing shutdown after a caller deadline. CI and human review remain merge gates.


[EN-1985]: https://formance-team.atlassian.net/browse/EN-1985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ