### PR TITLE
fix(transport): finish shutdown after stop cancellation (EN-1986)

### DIFF
--- a/docs/technical/architecture/subsystems/consensus/README.md
+++ b/docs/technical/architecture/subsystems/consensus/README.md
@@ -6,7 +6,7 @@ The replication and ordering layer (`internal/infra/node`, `internal/infra/trans
 
 | Document | Description |
 |----------|-------------|
-| [raft-consensus.md](raft-consensus.md) | Raft consensus implementation, CP failure model, quorum sizing, leader election, retained-log catch-up, snapshot transfer, deadline-independent shutdown requests and commit drain, and fail-stop on force-removal persistence failure. |
+| [raft-consensus.md](raft-consensus.md) | Raft consensus implementation, CP failure model, quorum sizing, leader election, retained-log catch-up, snapshot transfer, deadline-independent shutdown requests and commit drain, transport shutdown and cleanup, and fail-stop on force-removal persistence failure. |
 | [global-log.md](global-log.md) | Two-level log architecture enabling system-level atomic bulk operations. |
 | [hybrid-logical-clock.md](hybrid-logical-clock.md) | Monotonic HLC timestamps across leader changes and clock skew. |
 | [removed-member-registry.md](removed-member-registry.md) | Replicated `(nodeID, instanceID)` set that prevents a removed member from silently rejoining and being auto-promoted; force-removal write ordering and durable restart states. |

--- a/docs/technical/architecture/subsystems/consensus/raft-consensus.md
+++ b/docs/technical/architecture/subsystems/consensus/raft-consensus.md
@@ -193,6 +193,37 @@ graph TB
     Transport --> RaftNode
 ```
 
+#### Transport shutdown
+
+The transport remains available through the node's leadership-transfer and
+shutdown hook. Its own Fx stop hook runs afterwards. Once that hook enters,
+cancellation must not abandon the dispatcher or peer cleanup (EN-1986): the
+former cancellation-sensitive rendezvous could leave the hook waiting forever
+for a worker that never received its stop request.
+
+`DefaultTransport.Stop` rejects subsequent sends, cancels the peer connection
+loops, then closes a persistent stop signal exactly once. Its context bounds
+only the caller's wait for completion. The dispatcher finishes any publication
+already in progress, observes the stop signal, snapshots the peers, joins each
+peer loop and closes its priority queues, then closes the connection pool and
+publishes completion before returning from `Start`. Peer joins use an
+uncancelled context. Repeated stop callers share that same completion.
+
+The bootstrap hook unconditionally joins `Start`, so hook completion proves peer
+and pool cleanup even when `Stop` returned a context error. Fx's outer
+`App.Stop` can still return on its deadline while the hook finishes cleanup;
+that timeout does not establish that the worker has already exited. Transport
+receive, unreachable, and pending-send channels remain open, guarded by the
+stopped flag, as before. Shutdown does not promise delivery of queued Raft
+messages after peer cancellation and does not change node drain ordering.
+
+`TestTransportShutdown` blocks the actual dispatcher during peer publication,
+cancels after Fx hook entry, and checks both the context-bounded outer stop and
+the later worker/hook join. It also delays peer completion to prove cleanup
+ordering and covers normal, already-cancelled, and repeated stops. A persistent
+signal alone would prevent the lost wakeup but still leave cleanup vulnerable;
+keeping cleanup in the worker's exit path makes its existing join sufficient.
+
 ## Raft Configuration
 
 ### Configurable Parameters

--- a/internal/infra/node/transport.go
+++ b/internal/infra/node/transport.go
@@ -63,7 +63,10 @@ type DefaultTransport struct {
 
 	bufferSize           int
 	pendingSendQueue     chan []*raftpb.Message
-	stopCh               chan chan struct{}
+	stopCh               chan struct{}
+	stopDone             chan struct{}
+	stopOnce             sync.Once
+	stopErr              error // published by closing stopDone
 	advertiseAddr        string
 	serviceAdvertiseAddr string
 	// Metrics for recv queues (indexed by priority: 0=high, 1=medium, 2=low)
@@ -164,7 +167,8 @@ func NewTransport(
 		nodeID:               nodeID,
 		clusterID:            clusterID,
 		bufferSize:           bufferSize,
-		stopCh:               make(chan chan struct{}),
+		stopCh:               make(chan struct{}),
+		stopDone:             make(chan struct{}),
 		pendingSendQueue:     make(chan []*raftpb.Message, pendingSendCapacity),
 		advertiseAddr:        advertiseAddr,
 		serviceAdvertiseAddr: serviceAdvertiseAddr,
@@ -292,29 +296,30 @@ func (t *DefaultTransport) CancelPeerConnections() {
 	}
 }
 
-// Stop stops the transport.
+// Stop initiates shutdown exactly once. Cancellation bounds only this caller's
+// wait; Start still joins peers and closes the pool before it returns.
 func (t *DefaultTransport) Stop(ctx context.Context) error {
-	t.logger.Infof("Stopping raft transport")
+	t.stopOnce.Do(func() {
+		t.logger.Infof("Stopping raft transport")
 
-	// Mark as stopped so orphaned goroutines skip channel sends.
-	t.stopped.Store(true)
+		// Reject new sends, cancel peer loops, then persist the dispatcher stop
+		// request even when the caller has already exhausted its stop deadline.
+		t.stopped.Store(true)
+		t.CancelPeerConnections()
+		close(t.stopCh)
+	})
 
-	// Cancel all peer reconnection loops upfront so pc.stop() below
-	// returns instantly (loops already exited).
-	t.CancelPeerConnections()
-
-	stopCh := make(chan struct{})
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
-	case t.stopCh <- stopCh:
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-stopCh:
-		}
+	case <-t.stopDone:
+		return t.stopErr
 	}
+}
 
+// closePeers runs on the dispatcher after its last publication. Its joins must
+// outlive the Stop caller's deadline so an Fx worker join also proves cleanup.
+func (t *DefaultTransport) closePeers() error {
 	t.peersMu.RLock()
 	peersSnapshot := make([]*peerConnection, 0, len(t.peers))
 	for _, pc := range t.peers {
@@ -323,7 +328,7 @@ func (t *DefaultTransport) Stop(ctx context.Context) error {
 	t.peersMu.RUnlock()
 
 	for _, pc := range peersSnapshot {
-		err := pc.stop(ctx)
+		err := pc.stop(context.Background())
 		if err != nil {
 			return err
 		}
@@ -507,8 +512,9 @@ func messagePriority(msgType raftpb.MessageType) int {
 func (t *DefaultTransport) Start(_ context.Context) {
 	for {
 		select {
-		case ch := <-t.stopCh:
-			close(ch)
+		case <-t.stopCh:
+			t.stopErr = t.closePeers()
+			close(t.stopDone)
 
 			return
 		case msgs := <-t.pendingSendQueue:

--- a/internal/infra/node/transport_shutdown_test.go
+++ b/internal/infra/node/transport_shutdown_test.go
@@ -1,0 +1,176 @@
+package node
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/raft/v3/raftpb"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/metric/noop"
+	"go.uber.org/fx"
+	"google.golang.org/protobuf/proto"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/infra/monitoring/otlplogs"
+	transportpkg "github.com/formancehq/ledger/v3/internal/infra/transport"
+)
+
+// Block the dispatcher in a real peer publication, away from its stop receive.
+// Channels let synctest establish quiescence without scheduler timing guesses.
+type shutdownHistogram struct {
+	metric.Int64Histogram
+
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (h shutdownHistogram) Record(context.Context, int64, ...metric.RecordOption) {
+	close(h.entered)
+	<-h.release
+}
+
+func TestTransportShutdown(t *testing.T) {
+	t.Parallel()
+	for _, mode := range []string{"normal", "cancelAfterHookEntry", "cancelDuringCleanup", "alreadyCanceled"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+			synctest.Test(t, func(t *testing.T) {
+				pool := transportpkg.NewConnectionPool(transportpkg.TLSPolicy{}, transportpkg.PoolConfig{})
+				tr := NewTransport(logging.Testing(), pool, noop.NewMeterProvider(), 1,
+					TransportConfig{Reception: []int{1, 1, 1}, Send: []int{1, 1, 1}}, "test", 1, "", "")
+				peer := newTestPeerConn(t, 2, func(uint64) bool { return true })
+				peer.highPriorityCh = make(chan []*raftpb.Message, 1)
+				peer.stopCtx, peer.stopCancel = context.WithCancel(context.Background())
+				peer.loopDone = make(chan struct{})
+				peerRelease := make(chan struct{})
+				go func() {
+					<-peer.stopCtx.Done()
+					<-peerRelease
+					close(peer.loopDone)
+				}()
+				tr.peers[2] = peer
+				publication := shutdownHistogram{entered: make(chan struct{}), release: make(chan struct{})}
+				peer.sendQueueLoadHistogram[0] = publication
+
+				// Mirror the bootstrap Fx hook: Stop is followed by an unconditional GoWait
+				// join. App.Stop itself can return on cancellation while its hook continues.
+				hookEntered := make(chan struct{})
+				hookDone := make(chan struct{})
+				workerDone := make(chan struct{})
+				var hookErr error
+				app := fx.New(fx.NopLogger, fx.Invoke(func(lc fx.Lifecycle) {
+					var wait func()
+					lc.Append(fx.Hook{
+						OnStart: func(ctx context.Context) error {
+							wait = otlplogs.GoWait(func() {
+								tr.Start(context.WithoutCancel(ctx))
+								close(workerDone)
+							}, logging.Testing())
+
+							return nil
+						},
+						OnStop: func(ctx context.Context) error {
+							close(hookEntered)
+							hookErr = tr.Stop(ctx)
+							wait()
+							close(hookDone)
+
+							return hookErr
+						},
+					})
+				}))
+				require.NoError(t, app.Start(context.Background()))
+				tr.Send([]*raftpb.Message{{To: proto.Uint64(2), Type: raftpb.MsgHeartbeat.Enum()}})
+				<-publication.entered
+
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				// Fx skips hooks if the context is canceled before dispatch. Exercise that
+				// boundary directly through Stop, while retaining the same worker join.
+				appDone := make(chan error, 1)
+				if mode == "alreadyCanceled" {
+					cancel()
+					go func() { appDone <- tr.Stop(ctx) }()
+				} else {
+					go func() { appDone <- app.Stop(ctx) }()
+					<-hookEntered
+				}
+				synctest.Wait()
+				require.True(t, tr.stopped.Load(), "Stop must have entered before cancellation")
+				if mode == "cancelAfterHookEntry" {
+					cancel()
+					synctest.Wait()
+				}
+				if mode == "cancelAfterHookEntry" || mode == "alreadyCanceled" {
+					require.ErrorIs(t, <-appDone, context.Canceled)
+				}
+				assert.False(t, shutdownComplete(workerDone), "worker must wait for cleanup")
+				close(publication.release)
+				synctest.Wait()
+				if mode == "cancelDuringCleanup" {
+					cancel()
+					synctest.Wait()
+					require.ErrorIs(t, <-appDone, context.Canceled)
+				}
+				// Cleanup must join the peer before the worker (and thus Fx hook) exits.
+				assert.False(t, shutdownComplete(workerDone), "worker must wait for cleanup")
+				close(peerRelease)
+				synctest.Wait()
+
+				finished := false
+				select {
+				case <-workerDone:
+					finished = true
+				default:
+				}
+				// Rescue the old implementation after observing the leak so BEFORE_FIX
+				// fails on the assertion, without leaving goroutines behind in the bubble.
+				if !finished {
+					require.NoError(t, tr.Stop(context.Background()))
+					synctest.Wait()
+				}
+				require.True(t, finished, "transport worker must finish after cancellation without a second stop signal")
+				if mode != "alreadyCanceled" {
+					<-hookDone
+					if mode == "normal" {
+						require.NoError(t, <-appDone)
+						require.NoError(t, hookErr)
+					} else {
+						require.ErrorIs(t, hookErr, context.Canceled)
+					}
+				}
+				assert.True(t, shutdownComplete(peer.loopDone))
+				assert.True(t, peer.stopped, "peer queues must close before worker join")
+				require.Len(t, peer.highPriorityCh, 1)
+				<-peer.highPriorityCh // Discard the batch whose publication we held.
+				for _, queue := range []chan []*raftpb.Message{peer.highPriorityCh, peer.mediumPriorityCh, peer.lowPriorityCh} {
+					select {
+					case _, open := <-queue:
+						assert.False(t, open, "peer priority queue must be closed")
+					default:
+						t.Error("peer priority queue was left open")
+					}
+				}
+				// Repeated Stop calls must share completion without closing peer queues twice.
+				require.NoError(t, tr.Stop(context.Background()))
+				if mode == "alreadyCanceled" {
+					require.NoError(t, app.Stop(context.Background()))
+				}
+				require.ErrorContains(t, pool.AddPeer(3, "unused"), "connection pool is closed")
+			})
+		})
+	}
+}
+
+func shutdownComplete(done <-chan struct{}) bool {
+	select {
+	case <-done:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
## What changed

Transport stop requests now survive caller cancellation. The dispatcher joins peers, closes their queues and the connection pool, then publishes completion; repeated stop callers share that completion.

## Why

Fixes [EN-1986](https://formance-team.atlassian.net/browse/EN-1986). A timeout after Fx hook entry could abandon the only dispatcher stop signal, leaving the worker and hook unfinished and skipping resource cleanup. Fx's outer `App.Stop` still returned on its deadline.

## Product / operational motivation

Shutdown must initiate transport termination even when its caller times out, and the existing worker join must prove peer/pool cleanup. The deterministic reproduction and durable shutdown contract are in `internal/infra/node/transport_shutdown_test.go` and `docs/technical/architecture/subsystems/consensus/raft-consensus.md`.

## Technical decision

Close the stop signal exactly once and let the dispatcher own cleanup. A buffered rendezvous would preserve termination but still abandon cleanup on timeout. Keeping cleanup in the worker's exit path reuses the existing Fx join without another background worker. Node drain and leadership-transfer ordering are unchanged.

## Risk

**MEDIUM** — changes transport shutdown ownership. No wire, persisted-state, or FSM changes.

## Validation

- `bash scripts/agent-check`: PASS.
- `AI_REVIEW_BASE_SHA=8c33007e46efaa95c6d8f02d474ac2fcea9e39ed bash scripts/agent-check-pr`: PASS (generation/tidy, root/operator lint, invariants/build, full node-package race tests).
- `go test -race ./internal/infra/node -run '^TestTransportShutdown$' -count=20`: PASS in pinned Nix.
- Native exact-base `agent-check-pr` on `658dfacacafd6a14b074c7ab2ddb484630178c56`: PASS for final candidate `f738803de754168d311a37fd48f69cf823840748`.
- Independent native final review: APPROVE, zero findings, clean worktree, `ROOT_UNCHANGED=PASS`, and final target refresh unchanged.
- Local ignored launcher/adapter copies corrected two macOS tooling issues (SIGPIPE from early-exit worktree enumeration; a portable multi-variable binding probe). All native validation, identity, sandbox, and review gates remained enabled; no tooling changes are in this PR.

DISCOVERY: NO_EXISTING_WORK
BEFORE_FIX: BUG_REPRODUCED
AFTER_FIX: PASS

On initial current base `8c33007e46efaa95c6d8f02d474ac2fcea9e39ed`, channel barriers keep the real dispatcher in peer publication while a live Fx hook begins stopping. Cancellation makes the outer App.Stop return, but the old hook/worker remain unfinished until a second Stop rescues them. Reverting the transport source to that base fails the exact missing-termination assertion in 5/5 repetitions. The fixed regression covers normal stop, cancellation after hook entry, cancellation during peer cleanup, already-cancelled callers, queue/pool closure, and repeated stops. The target advancement did not change the affected transport/bootstrap source.

## Architecture / behavior impact

`Stop` cancellation ends only that caller's completion wait. `Start` exits after peer/pool cleanup; the Fx hook joins it even if the outer `App.Stop` has already returned a context error. Pending Raft messages are not promised delivery after peer cancellation.

## Review focus

Persistent termination under cancellation; cleanup ownership and ordering; deterministic worker/hook and peer queue assertions.

## Known concerns

None identified. CI and human approval remain required before merge.


[EN-1986]: https://formance-team.atlassian.net/browse/EN-1986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ