### PR TITLE
test(query): guard prepared-query snapshot pinning against the pre-fix ordering (EN-1867)

### DIFF
--- a/internal/query/executor_alignment_test.go
+++ b/internal/query/executor_alignment_test.go
@@ -3,6 +3,7 @@ package query_test
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -30,9 +31,25 @@ func seedPreparedQuery(t *testing.T, s *dal.Store, attrs *attributes.Attributes,
 	require.NoError(t, batch.Commit())
 }
 
+// mutatingQueryHandleStore commits a barrier mutation around the opening of the
+// request's main snapshot, and fires it only for the first handle so a control
+// read-back cannot trigger it again.
+//
+// beforeOpen commits while the snapshot is still unopened — the window the
+// pre-EN-1867 executor read its definition in, because it read the live store
+// before any handle existed. afterOpen commits once the snapshot is fixed.
+// The two hooks bracket the ordering under test, so a definition sourced from
+// either side of the snapshot is observable.
+//
+// The store is embedded rather than held in a field: the type then satisfies
+// both the handle opener and dal.PebbleGetter, so this harness compiles against
+// either read ordering and a mutation experiment needs no test-side edits.
 type mutatingQueryHandleStore struct {
-	store     *dal.Store
-	afterOpen func()
+	*dal.Store
+
+	beforeOpen func()
+	afterOpen  func()
+	once       sync.Once
 }
 
 type failingQueryHandleStore struct{ err error }
@@ -57,12 +74,21 @@ func TestExecutePropagatesMainSnapshotOpenFailure(t *testing.T) {
 }
 
 func (s *mutatingQueryHandleStore) NewReadHandle() (*dal.ReadHandle, error) {
-	handle, err := s.store.NewReadHandle()
+	first := false
+	s.once.Do(func() { first = true })
+
+	if first && s.beforeOpen != nil {
+		s.beforeOpen()
+	}
+
+	handle, err := s.Store.NewReadHandle()
 	if err != nil {
 		return nil, err
 	}
 
-	s.afterOpen()
+	if first && s.afterOpen != nil {
+		s.afterOpen()
+	}
 
 	return handle, nil
 }
@@ -82,7 +108,7 @@ func TestExecute_ReadsDefinitionAndLedgerFromMainSnapshot(t *testing.T) {
 			seedPreparedQuery(t, store, attrs, "l", "q", commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, nil)
 
 			opener := &mutatingQueryHandleStore{
-				store: store,
+				Store: store,
 				afterOpen: func() {
 					batch := store.OpenWriteSession()
 					switch mutation {
@@ -106,6 +132,15 @@ func TestExecute_ReadsDefinitionAndLedgerFromMainSnapshot(t *testing.T) {
 			)
 			require.NoError(t, err,
 				"definition and schema reads must stay on the handle opened before the live mutation")
+
+			// NoError alone would also hold for a live read that happened not to
+			// fail. Name the branch: a live read after the mutation surfaces the
+			// not-found error for whichever object was removed.
+			var pqNotFound *domain.ErrPreparedQueryNotFound
+			require.NotErrorAs(t, err, &pqNotFound)
+
+			var ledgerNotFound *domain.ErrLedgerNotFound
+			require.NotErrorAs(t, err, &ledgerNotFound)
 		})
 	}
 }
@@ -164,6 +199,294 @@ func TestExecute_UnfilteredQueryDoesNotWaitForTheFold(t *testing.T) {
 			}
 
 			require.NotErrorIs(t, err, context.DeadlineExceeded, "must not wait on a fold it does not read")
+		})
+	}
+}
+
+// The alignment decision must follow the definition the request read through
+// its own snapshot. A filter replacement or a deletion committed after that
+// snapshot belongs to a later state; compiling it against the snapshot's
+// entities would tear the result the other way round.
+//
+// This guards the forward direction only, and deliberately so: a barrier that
+// commits after the snapshot opens cannot distinguish snapshot-sourced from
+// live-sourced lookups, because the pre-EN-1867 executor read the live store
+// *before* any handle existed and so saw the pre-mutation state too. Both this
+// table and TestExecute_ReadsDefinitionAndLedgerFromMainSnapshot pass against
+// that ordering; TestExecute_DefinitionCommittedBeforeSnapshotIsObserved is the
+// EN-1867 regression guard. What this table does catch is a future change that
+// re-reads the definition from a later snapshot mid-request.
+//
+// Alignment is the discriminator because it is a pure function of the
+// definition (AlignmentOwed) with an externally visible consequence: against a
+// permanently lagging read store, a definition that reads an index leaf blocks
+// on the fold and one that does not returns immediately. Asserting the wait
+// therefore names which definition drove compilation, which a bare NoError
+// cannot.
+func TestExecute_DefinitionMutationAfterSnapshotIsNotObserved(t *testing.T) {
+	t.Parallel()
+
+	alignedFilter := func() *commonpb.QueryFilter {
+		return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Field{
+			Field: &commonpb.FieldCondition{
+				Field:     &commonpb.FieldRef{Metadata: "tier"},
+				Condition: &commonpb.FieldCondition_ExistsCond{ExistsCond: &commonpb.ExistsCondition{}},
+			},
+		}}
+	}
+
+	for _, tc := range []struct {
+		name     string
+		seeded   *commonpb.QueryFilter
+		replaced *commonpb.QueryFilter
+		deleted  bool
+		wantWait bool
+	}{
+		{
+			name:     "unaligned definition, aligned replacement committed after the snapshot",
+			seeded:   nil,
+			replaced: alignedFilter(),
+			wantWait: false,
+		},
+		{
+			name:     "aligned definition, unaligned replacement committed after the snapshot",
+			seeded:   alignedFilter(),
+			replaced: nil,
+			wantWait: true,
+		},
+		{
+			name:     "aligned definition, deletion committed after the snapshot",
+			seeded:   alignedFilter(),
+			deleted:  true,
+			wantWait: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := newTestStore(t)
+			registerLedger(t, store, "l")
+			appendLogs(t, store, 3, createTestLogsForLedger("l", 1)...)
+
+			rs := newTestReadStore(t)
+			setReadStoreProgress(t, rs, 1) // permanently behind the main store
+
+			attrs := attributes.New()
+			key := domain.PreparedQueryKey{LedgerName: "l", Name: "q"}.Bytes()
+			seedPreparedQuery(t, store, attrs, "l", "q", commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, tc.seeded)
+
+			opener := &mutatingQueryHandleStore{
+				Store: store,
+				afterOpen: func() {
+					batch := store.OpenWriteSession()
+					if tc.deleted {
+						require.NoError(t, attrs.PreparedQuery.Delete(batch, key))
+					} else {
+						_, err := attrs.PreparedQuery.Set(batch, key, &commonpb.PreparedQuery{
+							Name:   "q",
+							Target: commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS,
+							Filter: tc.replaced,
+						})
+						require.NoError(t, err)
+					}
+
+					require.NoError(t, batch.Commit())
+				},
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+			defer cancel()
+
+			_, err := query.Execute(
+				ctx, rs, opener, attrs.Volume, attrs.PreparedQuery, attrs.Index,
+				&servicepb.ExecutePreparedQueryRequest{Ledger: "l", QueryName: "q"}, nil, nil,
+			)
+
+			// Control: the barrier mutation is a committed write, so a handle
+			// opened after the request sees it. Without this the subtests would
+			// also pass if afterOpen silently wrote nothing.
+			assertLivePreparedQuery(t, store, attrs, tc.deleted, tc.replaced)
+
+			var notFound *domain.ErrPreparedQueryNotFound
+			require.NotErrorAs(t, err, &notFound,
+				"the definition must come from the request's own snapshot, where it still exists")
+
+			if tc.wantWait {
+				require.ErrorIs(t, err, context.DeadlineExceeded,
+					"the snapshot's definition reads an index leaf, so alignment is still owed")
+
+				return
+			}
+
+			require.NoError(t, err,
+				"the snapshot's definition reads no index leaf, so no fold wait is owed")
+		})
+	}
+}
+
+// assertLivePreparedQuery reads the definition back through a fresh handle and
+// proves the barrier mutation reached the store.
+func assertLivePreparedQuery(
+	t *testing.T,
+	store *dal.Store,
+	attrs *attributes.Attributes,
+	deleted bool,
+	replaced *commonpb.QueryFilter,
+) {
+	t.Helper()
+
+	control, err := store.NewReadHandle()
+	require.NoError(t, err)
+
+	defer func() { _ = control.Close() }()
+
+	live, err := query.ReadPreparedQuery(t.Context(), attrs.PreparedQuery, control, "l", "q")
+	require.NoError(t, err)
+
+	if deleted {
+		require.Nil(t, live, "the barrier deletion must be committed")
+
+		return
+	}
+
+	require.NotNil(t, live, "the barrier replacement must be committed")
+
+	if replaced == nil {
+		require.Nil(t, live.GetFilter(), "the barrier replacement must clear the filter")
+
+		return
+	}
+
+	require.Equal(t, replaced.String(), live.GetFilter().String(),
+		"the barrier replacement must be committed")
+}
+
+// EN-1867 regression guard. The executor once read the ledger schema and the
+// prepared-query definition from the live store and only afterwards opened the
+// request's snapshot, so a commit landing in that window produced a result
+// assembled from an old definition and a newer main-store view.
+//
+// The barrier commits before the snapshot opens, which is exactly that window.
+// A snapshot-sourced definition therefore reflects the mutation; a live-sourced
+// one reflects the state before it. The two disagree observably because the
+// seeded and replacement filters differ in whether they read an index leaf, and
+// the read store here never catches up: the compiled definition either waits on
+// the fold or it does not. The deletion case separates the same way — the
+// snapshot cannot see a definition removed before it was taken.
+//
+// Each expectation is therefore the opposite of what the pre-EN-1867 ordering
+// produces, which is what makes these subtests a guard rather than a
+// description.
+func TestExecute_DefinitionCommittedBeforeSnapshotIsObserved(t *testing.T) {
+	t.Parallel()
+
+	alignedFilter := func() *commonpb.QueryFilter {
+		return &commonpb.QueryFilter{Filter: &commonpb.QueryFilter_Field{
+			Field: &commonpb.FieldCondition{
+				Field:     &commonpb.FieldRef{Metadata: "tier"},
+				Condition: &commonpb.FieldCondition_ExistsCond{ExistsCond: &commonpb.ExistsCondition{}},
+			},
+		}}
+	}
+
+	const (
+		outcomeWait     = "waits on the fold"
+		outcomeOK       = "returns without waiting"
+		outcomeNotFound = "reports the prepared query as missing"
+	)
+
+	for _, tc := range []struct {
+		name     string
+		seeded   *commonpb.QueryFilter
+		replaced *commonpb.QueryFilter
+		deleted  bool
+		want     string
+	}{
+		{
+			// Live-sourced definition: unaligned, returns immediately.
+			name:     "unaligned definition replaced by an aligned one before the snapshot",
+			seeded:   nil,
+			replaced: alignedFilter(),
+			want:     outcomeWait,
+		},
+		{
+			// Live-sourced definition: aligned, blocks on the fold.
+			name:     "aligned definition replaced by an unaligned one before the snapshot",
+			seeded:   alignedFilter(),
+			replaced: nil,
+			want:     outcomeOK,
+		},
+		{
+			// Live-sourced definition: still present, blocks on the fold.
+			name:    "aligned definition deleted before the snapshot",
+			seeded:  alignedFilter(),
+			deleted: true,
+			want:    outcomeNotFound,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := newTestStore(t)
+			registerLedger(t, store, "l")
+			appendLogs(t, store, 3, createTestLogsForLedger("l", 1)...)
+
+			rs := newTestReadStore(t)
+			setReadStoreProgress(t, rs, 1) // permanently behind the main store
+
+			attrs := attributes.New()
+			key := domain.PreparedQueryKey{LedgerName: "l", Name: "q"}.Bytes()
+			seedPreparedQuery(t, store, attrs, "l", "q", commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS, tc.seeded)
+
+			opener := &mutatingQueryHandleStore{
+				Store: store,
+				beforeOpen: func() {
+					batch := store.OpenWriteSession()
+					if tc.deleted {
+						require.NoError(t, attrs.PreparedQuery.Delete(batch, key))
+					} else {
+						_, err := attrs.PreparedQuery.Set(batch, key, &commonpb.PreparedQuery{
+							Name:   "q",
+							Target: commonpb.QueryTarget_QUERY_TARGET_ACCOUNTS,
+							Filter: tc.replaced,
+						})
+						require.NoError(t, err)
+					}
+
+					require.NoError(t, batch.Commit())
+				},
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+			defer cancel()
+
+			_, err := query.Execute(
+				ctx, rs, opener, attrs.Volume, attrs.PreparedQuery, attrs.Index,
+				&servicepb.ExecutePreparedQueryRequest{Ledger: "l", QueryName: "q"}, nil, nil,
+			)
+
+			// Control: without a committed barrier write the subtest would pass
+			// on the seeded definition alone and assert nothing about ordering.
+			assertLivePreparedQuery(t, store, attrs, tc.deleted, tc.replaced)
+
+			var notFound *domain.ErrPreparedQueryNotFound
+
+			switch tc.want {
+			case outcomeWait:
+				require.ErrorIs(t, err, context.DeadlineExceeded,
+					"the snapshot's definition reads an index leaf; a live read would have seen the unaligned one and returned")
+
+			case outcomeOK:
+				require.NoError(t, err,
+					"the snapshot's definition reads no index leaf; a live read would have seen the aligned one and waited")
+
+			case outcomeNotFound:
+				require.ErrorAs(t, err, &notFound,
+					"the snapshot cannot see a definition deleted before it was taken; a live read would have found it and waited")
+
+			default:
+				t.Fatalf("unknown outcome %q", tc.want)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Closes the test half of [EN-1867](https://formance-team.atlassian.net/browse/EN-1867). **No production change** — the structural fix already landed.

## DISCOVERY

EN-1867 (confirmed audit finding `read-consistency-projections/prepared-query-torn-snapshot`, audited at `0213c4223`) reported that `query.Execute` read `LedgerInfo` and the prepared-query definition from the **live store** before opening the request snapshot. A concurrent `UpdatePreparedQuery` / `DeletePreparedQuery` commit could therefore pair an old definition with a newer main-store and aligned-index view — a result attributable to no single committed state.

The ticket's recommended action had two halves. The first landed in 3b8622bcd (#1894): both lookups now go through a handle opened first by `OpenReservedQueryHandle`. This PR is the second half — "add deterministic update and deletion race tests".

## BEFORE_FIX

**#1894's own tests do not fail against the ordering they fixed.**

`TestExecute_ReadsDefinitionAndLedgerFromMainSnapshot` commits its barrier mutation via `afterOpen`, i.e. *after* `NewReadHandle()` returns. That cannot distinguish the two orderings: the pre-EN-1867 executor read the live store **before any handle existed**, so it also saw the pre-mutation state. Both orderings agree and the subtest passes either way. Its assertions were also bare `require.NoError`, which names no branch — it proves the read resolved, not *which* definition drove compilation.

Reproduced by reverting `executor.go` to the pre-#1894 ordering in a detached worktree:

```
--- PASS: TestExecute_ReadsDefinitionAndLedgerFromMainSnapshot/prepared_query_deleted
--- PASS: TestExecute_ReadsDefinitionAndLedgerFromMainSnapshot/ledger_deleted
```

It also never covered the ticket's *primary* scenario: an **update** replacing filter A with a mutually exclusive filter B.

## AFTER_FIX

Adds a `beforeOpen` barrier — the mutation commits while the snapshot is still unopened, which is exactly the window the defect lived in:

| | fixed (#1894) | pre-#1894 |
|---|---|---|
| lookups source | the handle, opened after the barrier → **post**-mutation definition | live store, before the barrier → **pre**-mutation definition |
| alignment follows | the replacement filter | the seeded filter |

The two disagree observably because the seeded and replacement filters differ in whether they read an index leaf (`AlignmentOwed`), against a permanently lagging read store: the request either waits on the fold or it does not. Asserting the wait therefore names which definition drove compilation. Deletion separates the same way — the snapshot cannot see a definition removed before it was taken, while a live read finds it and proceeds.

Against the reverted ordering, all three subtests of `TestExecute_DefinitionCommittedBeforeSnapshotIsObserved` **FAIL**:

```
--- FAIL: …/unaligned_definition_replaced_by_an_aligned_one_before_the_snapshot
    Expected error with "context deadline exceeded" in chain but got nil.
--- FAIL: …/aligned_definition_replaced_by_an_unaligned_one_before_the_snapshot
    Received unexpected error
--- FAIL: …/aligned_definition_deleted_before_the_snapshot
    Should be in error chain
```

All three PASS on the fix. The mutation worktree was removed.

## Also included, additively

- `TestExecute_DefinitionMutationAfterSnapshotIsNotObserved` — the reverse tear direction (a definition re-read from a *later* snapshot mid-request). Its doc comment states plainly that it does **not** fail against the pre-#1894 ordering, so it is not mistaken for the guard.
- A **control read-back** per subtest, proving each barrier mutation actually committed. Without it a subtest that silently wrote nothing would pass on the seeded definition alone.
- Branch-unique `NotErrorAs` assertions on the existing #1894 subtests, keeping their original `NoError` trigger intact (regression triggers are additive).
- `mutatingQueryHandleStore` now **embeds** `*dal.Store` so it satisfies both the handle opener and `dal.PebbleGetter` — the mutation experiment then needs no test-side edits. Hooks fire only for the first handle (`sync.Once`) so the control read-back cannot retrigger them.

## Validation

- `bash scripts/agent-check` — PASS
- `go test ./internal/query/` — PASS
- `go test -race ./internal/query/` — PASS
- `golangci-lint run ./internal/query/...` — 0 issues
- No `time.Sleep`; `t.Parallel()` at both table levels
- Docs: N/A — tests only; #1894 already updated `prepared-queries.md`

## Reviewer note

The one judgement call worth checking: alignment (wait / no wait) is used as the discriminator instead of asserting on returned rows as the ticket suggested. At the `internal/query` level a row-level assertion needs a seeded main-store account projection and a real `EntityEnricher` (`Execute` dereferences a `nil` enricher in `LIST` mode), while alignment is a pure function of the definition with an already-proven observable consequence — sharper, and still sleep-free. Happy to add a row-level variant if preferred.


[EN-1867]: https://formance-team.atlassian.net/browse/EN-1867?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ