### PR TITLE
fix(api)!: redact sink and mirror credentials from reads (EN-1632)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,12 @@ This file is the always-loaded entry point for AI agents working on Ledger v3. K
 
 ### Service protocol revision — required during pre-release
 
-Every incompatible service gRPC contract change must increment
-`pkg/grpcprotocol.Version` in the same PR, including during pre-release. Read the
+Increment `pkg/grpcprotocol.Version` primarily for breaking changes to exposed
+protobuf messages or RPC definitions, including during pre-release. Compatible
+response-value changes (such as credential redaction or sanitized diagnostics)
+do not automatically require a bump. Any non-schema bump must identify the
+concrete client/server incompatibility that requires rejecting older clients.
+Read the
 [protocol maintenance rules](docs/technical/architecture/subsystems/api/protocol-compatibility.md#maintaining-the-revision)
 before modifying this contract.
 

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -5076,3 +5076,17 @@ ledgerctl query-checkpoint get-schedule
 # Output (no schedule):
 #  SUCCESS  No query checkpoint schedule configured (automatic creation disabled)
 ```
+
+### Sink and mirror credentials in read output
+
+The server masks reusable sink/mirror credentials in ledger, event-sink, log,
+and audit reads, including structured and result-file output. Connection status
+retains its error presence and timestamp, but its diagnostic message is masked.
+Read connection strings are display projections and must not be copied back
+into configuration. The write path still accepts the original credentials.
+
+For audit reads, an unchanged signed payload retains its signature. When a
+credential is replaced, the signature bytes are omitted and the displayed
+payload cannot reproduce the original audit hash. Use protected original
+store/backup evidence for verification; see the
+[read projection contract](../technical/architecture/subsystems/api/secret-redaction.md).

--- a/docs/technical/architecture/subsystems/admission/signing.md
+++ b/docs/technical/architecture/subsystems/admission/signing.md
@@ -100,3 +100,12 @@ The signed payload format is fixed by vtprotobuf encoding rules — `internal/pk
 | Bootstrap registration rejected | `RequireSignatures()` is true and there is no parent key — solution is the maintenance-mode workaround above. |
 | Client cannot verify a stored log | Server's response key has rotated; client must refresh via the Discovery RPC or the `--response-verify-key` flag. |
 | Audit chain hash mismatch on entries with valid `Log.Signature` | Log entry tampered after the fact — caught by the checker, not by signature verification (the signature still verifies; the hash chain doesn't). |
+
+## Credential-bearing read projections
+
+Public audit/log reads apply the [credential projection contract](../api/secret-redaction.md).
+The original stored bytes remain verifiable. A redacted read payload is a
+display projection: it cannot reproduce the original signature or audit hash,
+and its cryptographic signature bytes are omitted when the payload changes.
+Unchanged read payloads retain their exact bytes and original signatures.
+Request admission and signed write responses keep the contract described above.

--- a/docs/technical/architecture/subsystems/api/README.md
+++ b/docs/technical/architecture/subsystems/api/README.md
@@ -11,6 +11,7 @@ Client-facing transport layers (`internal/adapter/grpc`, `internal/adapter/http`
 | [protocol-compatibility.md](protocol-compatibility.md) | Mandatory service protocol revision, client/server rejection behavior, diagnostics, and revision maintenance (EN-1851). |
 | [http-api.md](http-api.md) | HTTP REST API endpoints, response formats, and error handling. |
 | [auth.md](auth.md) | Client JWT authentication (OIDC + Ed25519), scope-based authorization, and the Raft inter-node cluster-secret auth layer. |
+| [secret-redaction.md](secret-redaction.md) | Shared sink/mirror credential projections, public status diagnostics, and audit verification limits. |
 
 ## Related
 

--- a/docs/technical/architecture/subsystems/api/protocol-compatibility.md
+++ b/docs/technical/architecture/subsystems/api/protocol-compatibility.md
@@ -20,7 +20,7 @@ compatibility of development revisions.
 ## Wire contract and failure behavior
 
 `pkg/grpcprotocol.Version` is the compiled service protocol revision, currently
-`"5"`. `pkg/grpcprotocol.MetadataKey` is `ledger-protocol-version`. Clients send
+`"6"`. `pkg/grpcprotocol.MetadataKey` is `ledger-protocol-version`. Clients send
 exactly one value for this metadata key on every RPC. The Go
 `grpcprotocol.ClientOption()` dial option supplies the local revision for unary
 and streaming calls. Local `dev` builds carry the same constant without release
@@ -55,6 +55,11 @@ codes. Internal read failures in restore validation retain `Internal` with a
 sanitized correlation message. AuditFailure records retain their original
 diagnostic message and context.
 
+Revision 6 (EN-1632, EN-1634, EN-1635) projects sink/mirror credentials and
+transport status diagnostics out of public reads. Redacted audit payloads no
+longer constitute verifiable original evidence; unmodified envelopes retain
+their original bytes. See [credential read projections](secret-redaction.md).
+
 ## Client and deployment scope
 
 Enforcement starts with servers implementing EN-1851: they reject old clients
@@ -67,10 +72,10 @@ servers or support for mixed wire-format upgrades.
 
 Every consumer of the service gRPC endpoint must declare its protocol,
 including SDKs, automation, `grpcurl`, and internal requests forwarded to a
-leader. For example, with a schema implementing revision 5:
+leader. For example, with a schema implementing revision 6:
 
 ```bash
-grpcurl -plaintext -H 'ledger-protocol-version: 5' \
+grpcurl -plaintext -H 'ledger-protocol-version: 6' \
   localhost:8888 cluster.ClusterService.GetClusterState
 ```
 

--- a/docs/technical/architecture/subsystems/api/protocol-compatibility.md
+++ b/docs/technical/architecture/subsystems/api/protocol-compatibility.md
@@ -20,7 +20,7 @@ compatibility of development revisions.
 ## Wire contract and failure behavior
 
 `pkg/grpcprotocol.Version` is the compiled service protocol revision, currently
-`"6"`. `pkg/grpcprotocol.MetadataKey` is `ledger-protocol-version`. Clients send
+`"5"`. `pkg/grpcprotocol.MetadataKey` is `ledger-protocol-version`. Clients send
 exactly one value for this metadata key on every RPC. The Go
 `grpcprotocol.ClientOption()` dial option supplies the local revision for unary
 and streaming calls. Local `dev` builds carry the same constant without release
@@ -55,9 +55,10 @@ codes. Internal read failures in restore validation retain `Internal` with a
 sanitized correlation message. AuditFailure records retain their original
 diagnostic message and context.
 
-Revision 6 (EN-1632, EN-1634, EN-1635) projects sink/mirror credentials and
-transport status diagnostics out of public reads. Redacted audit payloads no
-longer constitute verifiable original evidence; unmodified envelopes retain
+Credential read projections (EN-1632, EN-1634, EN-1635) retain revision 5:
+the exposed protobuf messages and RPC definitions remain compatible. They mask
+sink/mirror credentials and transport status diagnostics in public reads.
+Redacted audit payloads no longer constitute verifiable original evidence; unmodified envelopes retain
 their original bytes. See [credential read projections](secret-redaction.md).
 
 ## Client and deployment scope
@@ -72,10 +73,10 @@ servers or support for mixed wire-format upgrades.
 
 Every consumer of the service gRPC endpoint must declare its protocol,
 including SDKs, automation, `grpcurl`, and internal requests forwarded to a
-leader. For example, with a schema implementing revision 6:
+leader. For example, with a schema implementing revision 5:
 
 ```bash
-grpcurl -plaintext -H 'ledger-protocol-version: 6' \
+grpcurl -plaintext -H 'ledger-protocol-version: 5' \
   localhost:8888 cluster.ClusterService.GetClusterState
 ```
 
@@ -99,15 +100,29 @@ their own contracts.
 
 ## Maintaining the revision
 
-The author of a service contract change must determine whether an existing
-client or server would interpret requests, responses, or operations differently.
-Increment the decimal counter `pkg/grpcprotocol.Version` by one in the same PR
-for an incompatible wire or semantic change (for example, `"1"` to `"2"`), and
-rebuild every service client and server that will communicate. This includes
-renumbering or changing the interpretation of exposed
-protobuf fields, and incompatible semantics even when the `.proto` text stays
-unchanged. Reviewers must check this classification; the revision is not inferred
-from a release tag or automatically negotiated from a schema hash.
+The revision primarily protects against breaking changes to exposed protobuf
+messages and RPC definitions. Increment `pkg/grpcprotocol.Version` by one in the
+same PR when old and new peers cannot safely exchange those messages: for
+example, field renumbering/reuse, incompatible field types or oneof layouts,
+removed RPCs, or changed request/response message types. Rebuild the clients and
+servers that will communicate. A textual `.proto` change alone is not proof of
+incompatibility: compatible additions do not automatically require a bump.
+
+Do not use this counter as a general API behavior version. Changes to response
+values, credential redaction, sanitized diagnostics, validation bug fixes, and
+compatible additions do not automatically require rejecting every older client.
+Document observable behavior changes and their client impact in the relevant
+API contract and PR. In particular, credential read projections retain the
+revision even though consumers of redacted audit evidence must account for the
+loss of direct hash/signature verification.
+
+A change without a schema break may exceptionally require a bump if peers can
+no longer safely communicate under the existing protocol (for example, changing
+the unit of a numeric wire field, or introducing a mandatory handshake). The PR
+must identify the affected RPC/field, a concrete old-client/new-server or
+new-client/old-server failure, and why rejecting older clients is necessary.
+A generic claim of changed semantics is insufficient. Reviewers check this
+assessment; revisions are not inferred from release tags or schema hashes.
 
 This obligation applies to AI agents throughout pre-release development, even
 though older Ledger versions and storage formats are not supported. Before

--- a/docs/technical/architecture/subsystems/api/secret-redaction.md
+++ b/docs/technical/architecture/subsystems/api/secret-redaction.md
@@ -87,8 +87,11 @@ it was read. The checker continues to verify original store records. Consumers
 needing original evidence must use the protected original store/backup workflow;
 these read endpoints do not offer a scope-dependent raw bypass.
 
-This changes public response semantics and increments service protocol revision
-5 to 6. Deploy matching service clients and servers.
+This changes public response values while preserving the protobuf messages and
+RPC definitions. Service protocol revision remains 5: existing revision-5 clients
+can still decode and call these APIs. Consumers verifying audit evidence must
+account for the display-projection contract above; this behavior change does
+not require rejecting all existing clients.
 
 ## Validation
 

--- a/docs/technical/architecture/subsystems/api/secret-redaction.md
+++ b/docs/technical/architecture/subsystems/api/secret-redaction.md
@@ -1,0 +1,101 @@
+# Credentials in read responses
+
+## Requirement and boundary (EN-1632, EN-1634, EN-1635)
+
+Read scopes must not grant the reusable credentials used to connect to event
+sinks or mirror sources. The original configuration also appears in historical
+creation logs and accepted orders, including the opaque bytes of signed batches.
+Redacting only live configuration would leave those same credentials readable
+through history after rotation or removal. EN-1796 duplicates the gRPC part of
+EN-1632; the earlier HTTP DTO proposal was closed without being merged.
+
+`internal/adapter/readprojection` supplies one policy for HTTP and gRPC. The
+adapters project deep clones immediately before serialization or streaming:
+
+- `GetEventsSinks`: configurations and sink status diagnostics;
+- `GetLedger` / `ListLedgers`: mirror configuration and mirror diagnostics;
+- `GetLog` / `ListLogs`: sink and mirror creation payloads;
+- `GetAuditEntry` / `ListAuditEntries`: serialized orders and signed batch
+  payloads (the list includes the signed payload even when items are absent).
+
+The projection runs after controller/checkpoint selection and on every serving
+node, including a follower forwarding a response. It is idempotent. gRPC list
+projection occurs at `Send`, preserving the source cursor and its continuation
+trailer. Sequences, pagination, caller identity, error presence/timestamps, and
+non-secret configuration remain usable.
+
+Controllers, query/store readers, and internal workers retain the original
+values. There is no mutation of accepted orders, FSM behavior, persisted bytes,
+idempotency hashes, audit capture, or checker inputs. Backup/checkpoint and
+incremental restore still preserve the same original credentials; this change
+creates no persisted effect to restore. EN-1945 removed archived/cold history;
+all current history resides permanently in the main store.
+
+## Field policy
+
+Nonempty opaque credentials become `[redacted]`; empty credentials remain empty.
+That covers Kafka SASL passwords, HTTP webhook HMAC keys, Databricks PAT/OAuth
+client secrets, and HTTP mirror OAuth client secrets. Names, auth modes, topics,
+batch settings, OAuth client IDs/scopes, and mirror state remain visible.
+
+Credential-bearing URLs are display values, not connection strings to reuse:
+
+- NATS server URLs mask token/password userinfo, including server lists.
+- HTTP sink endpoints and mirror base/token URLs mask userinfo and query
+  values. Query authentication names are arbitrary, so preserving them by a
+  password-key heuristic cannot guarantee confidentiality.
+- ClickHouse DSNs mask password material and credentials in nested proxy URLs.
+- PostgreSQL URI and keyword DSNs mask password material while preserving
+  non-secret host/database/connection settings.
+- Malformed credential containers fail closed to an opaque redaction marker.
+
+Sink and mirror transport errors can repeat credentials from request URLs or
+driver responses, including values no longer present in the live configuration.
+Their public status message becomes `[redacted diagnostic]`, retaining the
+presence of the error and its timestamp. These read APIs are for status, not
+raw connection diagnostics. Protected operator diagnostics and persisted
+technical state retain their existing behavior. Business `AuditFailure` reason,
+message, and context retain their existing authoritative semantics (EN-1623).
+
+This is a field-scoped credential policy, not a scrubber for caller-defined
+ledger metadata or business payloads. Credentials must not be stored in those
+fields, URL paths, identifiers, or other non-credential configuration metadata.
+Write responses may echo the credentials the writer submitted; the read policy
+does not change write admission or response-signing behavior.
+
+## Audit and signature verification
+
+The stored audit chain is the authoritative evidence. The returned `hash`
+still identifies that original record; it is not a hash of the display
+projection. If an order or signed payload contains a redacted credential, a
+client **cannot recompute the original hash from the read response**.
+
+For a changed `SignedApplyBatch.payload`, retain the signing key ID and redacted
+payload, but omit the cryptographic signature: it does not authenticate the
+replacement bytes. The same rule applies if a read contains a `SignedLog`
+envelope. Malformed encoded containers fail the read rather than leaking
+unchecked bytes. Before decoding, a schema-aware wire guard rejects duplicate
+singular/oneof occurrences that shadow credential material. Ordinary protobuf
+decoding alone can discard an earlier secret field while retaining it in the
+original signed bytes. Duplicate non-secret fields and field ordering retain
+their original encoding. A nested `SignedLog` envelope is an invariant failure because
+the response signer excludes its own envelope from the signed preimage.
+
+When no field is redacted, preserve the exact original serialized order,
+payload, and signature bytes. Do not normalize a signed payload merely because
+it was read. The checker continues to verify original store records. Consumers
+needing original evidence must use the protected original store/backup workflow;
+these read endpoints do not offer a scope-dependent raw bypass.
+
+This changes public response semantics and increments service protocol revision
+5 to 6. Deploy matching service clients and servers.
+
+## Validation
+
+Deterministic tests exercise all sink/mirror variants, URI/query/keyword
+credentials, duplicate projection, original-object preservation, both HTTP and
+gRPC read routes, and pagination. Audit tests decode the binary containers
+(HTTP order bytes are hex, signed payloads are base64), prove signature
+preservation for unchanged data and invalidation for changed data, and reject
+malformed payloads. Current-HEAD qualification also reproduces an HTTP transport
+failure that copies an endpoint credential into the sink status message.

--- a/docs/technical/architecture/subsystems/events-mirror/events.md
+++ b/docs/technical/architecture/subsystems/events-mirror/events.md
@@ -645,3 +645,11 @@ The HTTP sink sends each event as an individual HTTP POST request with the follo
 ### ClickHouse Sink Details
 
 The ClickHouse sink auto-creates the target table using the experimental JSON type with Variant support (ClickHouse 24.x-25.x compatibility). The `format` setting is ignored — events are always inserted as ClickHouse-native JSON for optimal query performance.
+
+## Public credential reads
+
+The HTTP and gRPC adapters return [secret-safe display projections](../api/secret-redaction.md)
+for live sink/mirror configuration, historical creation logs, and audit payloads.
+Public sink/mirror status messages are masked because connection diagnostics
+can repeat credentials. The workers, persisted configuration, audit records,
+and protected operator diagnostics retain their original values.

--- a/docs/technical/architecture/subsystems/events-mirror/mirror.md
+++ b/docs/technical/architecture/subsystems/events-mirror/mirror.md
@@ -213,3 +213,11 @@ There is no automatic "skip the broken log" mode. Operators investigate, fix the
 - **It does not reconcile against v2 hashes.** The worker trusts the source's log content; it does not cross-check that the resulting v3 state has the same balances as v2. That kind of comparison is a future work item (and would require v2 exposing canonical state hashes).
 - **It does not run on followers.** Leadership change suspends the worker until the new leader's manager picks it up.
 - **It does not act as a generic CDC sink.** The only sources are Ledger v2 instances; arbitrary event streams are the [events](events.md) subsystem's concern.
+
+## Public credential reads
+
+The HTTP and gRPC adapters return [secret-safe display projections](../api/secret-redaction.md)
+for live sink/mirror configuration, historical creation logs, and audit payloads.
+Public sink/mirror status messages are masked because connection diagnostics
+can repeat credentials. The workers, persisted configuration, audit records,
+and protected operator diagnostics retain their original values.

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -951,3 +951,17 @@ if ok {
     }
 }
 ```
+
+## Sink and mirror credential reads (EN-1632, EN-1634, EN-1635)
+
+HTTP and gRPC share the [credential projection contract](../architecture/subsystems/api/secret-redaction.md).
+Get/list ledger, event sink, audit, and log responses mask reusable sink/mirror
+credentials on deep clones. Sink/mirror status errors retain their timestamp
+and error presence, but their diagnostic message is masked. Write requests and
+internal consumers still use the original credentials.
+
+Read audit hashes identify original stored records. Modified order/batch bytes
+are display projections; they cannot reproduce the original hash. Signature
+bytes are omitted only for a modified signed payload; unchanged evidence
+retains its exact encoding. This applies to HTTP hex-encoded serializedOrder
+and base64 signed payloads as well as binary gRPC responses.

--- a/docs/technical/contributing/protobuf.md
+++ b/docs/technical/contributing/protobuf.md
@@ -60,11 +60,14 @@ go install github.com/planetscale/vtprotobuf/cmd/protoc-gen-go-vtproto@v0.6.1-0.
 ## Modifying Protocol Definitions
 
 The service API has a compiled protocol revision independent of release versions.
-For every exposed wire or semantic change, assess client/server compatibility and
-bump `pkg/grpcprotocol.Version` in the same change when the contract breaks.
-Renumbering exposed fields is a breaking change even if the generated code still
-compiles. Internal persisted/Raft-only changes require an impact assessment of
-shared service types rather than an automatic service revision bump. See the
+Increment `pkg/grpcprotocol.Version` primarily for breaking changes to exposed
+protobuf messages or RPC definitions. Renumbering exposed fields is a breaking
+change even if the generated code still compiles. Response-value changes such as
+credential redaction and sanitized diagnostics do not automatically require a
+bump. A non-schema bump needs a concrete client/server incompatibility that
+justifies rejecting older clients, as described in the maintenance rules.
+Internal persisted/Raft-only changes require an impact assessment of shared
+service types rather than an automatic service revision bump. See the
 [service protocol contract](../architecture/subsystems/api/protocol-compatibility.md)
 for the gate, client obligations, and review criteria. This does not change the
 unreleased-v3 rule: remove obsolete fields and realign their numbers; do not add

--- a/internal/adapter/grpc/read_projection.go
+++ b/internal/adapter/grpc/read_projection.go
@@ -1,0 +1,20 @@
+package grpc
+
+import ggrpc "google.golang.org/grpc"
+
+// readProjectionStream projects only messages leaving the adapter. Keeping the
+// cursor intact preserves its pagination and upstream-trailer capabilities.
+type readProjectionStream[T any] struct {
+	ggrpc.ServerStreamingServer[T]
+
+	project func(*T) (*T, error)
+}
+
+func (s *readProjectionStream[T]) Send(value *T) error {
+	projected, err := s.project(value)
+	if err != nil {
+		return err
+	}
+
+	return s.ServerStreamingServer.Send(projected)
+}

--- a/internal/adapter/grpc/server_bucket.go
+++ b/internal/adapter/grpc/server_bucket.go
@@ -22,6 +22,7 @@ import (
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
 	internalauth "github.com/formancehq/ledger/v3/internal/adapter/auth"
+	"github.com/formancehq/ledger/v3/internal/adapter/readprojection"
 	"github.com/formancehq/ledger/v3/internal/application/check"
 	"github.com/formancehq/ledger/v3/internal/application/ctrl"
 	"github.com/formancehq/ledger/v3/internal/domain"
@@ -524,7 +525,14 @@ func (impl *BucketServiceServerImpl) ListLedgers(req *servicepb.ListLedgersReque
 		return fmt.Errorf("paginating ledgers: %w", err)
 	}
 
-	return sendPagedToStream(ctx, c, stream, "ledger", pageSize, func(l *commonpb.LedgerInfo) string {
+	projectedStream := &readProjectionStream[commonpb.LedgerInfo]{
+		ServerStreamingServer: stream,
+		project: func(info *commonpb.LedgerInfo) (*commonpb.LedgerInfo, error) {
+			return readprojection.Ledger(info), nil
+		},
+	}
+
+	return sendPagedToStream(ctx, c, projectedStream, "ledger", pageSize, func(l *commonpb.LedgerInfo) string {
 		return l.GetName()
 	})
 }
@@ -549,7 +557,12 @@ func (impl *BucketServiceServerImpl) GetLedger(ctx context.Context, req *service
 	}
 	defer cleanup()
 
-	return c.GetLedgerByName(ctx, req.GetLedger())
+	info, err := c.GetLedgerByName(ctx, req.GetLedger())
+	if err != nil {
+		return nil, err
+	}
+
+	return readprojection.Ledger(info), nil
 }
 
 func (impl *BucketServiceServerImpl) GetAccount(ctx context.Context, req *servicepb.GetAccountRequest) (*commonpb.Account, error) {
@@ -774,7 +787,12 @@ func (impl *BucketServiceServerImpl) GetAuditEntry(ctx context.Context, req *ser
 		return nil, err
 	}
 
-	return impl.ctrl.GetAuditEntry(ctx, req.GetSequence())
+	entry, err := impl.ctrl.GetAuditEntry(ctx, req.GetSequence())
+	if err != nil {
+		return nil, err
+	}
+
+	return readprojection.Audit(entry)
 }
 
 func (impl *BucketServiceServerImpl) ListAuditEntries(req *servicepb.ListAuditEntriesRequest, stream servicepb.BucketService_ListAuditEntriesServer) error {
@@ -828,7 +846,7 @@ func (impl *BucketServiceServerImpl) ListAuditEntries(req *servicepb.ListAuditEn
 		return fmt.Errorf("listing audit entries: %w", err)
 	}
 
-	return sendPagedToStream(ctx, c, stream, "audit entry", pageSize, func(e *auditpb.AuditEntry) string {
+	return sendPagedToStream(ctx, c, &readProjectionStream[auditpb.AuditEntry]{ServerStreamingServer: stream, project: readprojection.Audit}, "audit entry", pageSize, func(e *auditpb.AuditEntry) string {
 		return strconv.FormatUint(e.GetSequence(), 10)
 	})
 }
@@ -844,7 +862,12 @@ func (impl *BucketServiceServerImpl) GetLog(ctx context.Context, req *servicepb.
 	}
 	defer cleanup()
 
-	return c.GetLog(ctx, req.GetSequence())
+	log, err := c.GetLog(ctx, req.GetSequence())
+	if err != nil {
+		return nil, err
+	}
+
+	return readprojection.Log(log)
 }
 
 func (impl *BucketServiceServerImpl) ListLogs(req *servicepb.ListLogsRequest, stream servicepb.BucketService_ListLogsServer) error {
@@ -899,7 +922,7 @@ func (impl *BucketServiceServerImpl) ListLogs(req *servicepb.ListLogsRequest, st
 	// which would publish a bogus `x-next-cursor: "0"` and trap the client
 	// in an infinite resume loop. Return an empty cursor in that case so the
 	// stream signals "no more pages" instead.
-	return sendPagedToStream(ctx, cur, stream, "log", pageSize, func(l *commonpb.Log) string {
+	return sendPagedToStream(ctx, cur, &readProjectionStream[commonpb.Log]{ServerStreamingServer: stream, project: readprojection.Log}, "log", pageSize, func(l *commonpb.Log) string {
 		apply := l.GetPayload().GetApply()
 		if apply == nil {
 			return ""
@@ -921,10 +944,15 @@ func (impl *BucketServiceServerImpl) GetEventsSinks(ctx context.Context, _ *serv
 		return nil, fmt.Errorf("loading events sinks: %w", err)
 	}
 
-	return &servicepb.GetEventsSinksResponse{
-		Sinks:        sinks,
-		SinkStatuses: statuses,
-	}, nil
+	response := &servicepb.GetEventsSinksResponse{}
+	for _, sink := range sinks {
+		response.Sinks = append(response.Sinks, readprojection.Sink(sink))
+	}
+	for _, sinkStatus := range statuses {
+		response.SinkStatuses = append(response.SinkStatuses, readprojection.SinkStatus(sinkStatus))
+	}
+
+	return response, nil
 }
 
 func (impl *BucketServiceServerImpl) ListSigningKeys(req *servicepb.ListSigningKeysRequest, stream servicepb.BucketService_ListSigningKeysServer) error {

--- a/internal/adapter/grpc/server_bucket_credential_projection_test.go
+++ b/internal/adapter/grpc/server_bucket_credential_projection_test.go
@@ -1,0 +1,216 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/metric/noop"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	internalauth "github.com/formancehq/ledger/v3/internal/adapter/auth"
+	"github.com/formancehq/ledger/v3/internal/application/ctrl"
+	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/infra/state"
+	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/internal/proto/signaturepb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+	"github.com/formancehq/ledger/v3/internal/storage/readstore"
+)
+
+func credentialReadAuth(scope internalauth.Scope) internalauth.AuthConfig {
+	return internalauth.AuthConfig{Enabled: true, ScopeMapping: internalauth.ScopeMapping{internalauth.ScopeMappingAnonymousKey: {scope}}}
+}
+
+func requireCredentialFreeProto(t *testing.T, message proto.Message) {
+	t.Helper()
+	encoded, err := proto.Marshal(message)
+	require.NoError(t, err)
+	require.NotContains(t, string(encoded), "credentialSentinel")
+	require.NotContains(t, string(encoded), "urlSentinel")
+}
+
+func TestCredentialProjectionLiveGRPC(t *testing.T) {
+	t.Parallel()
+	impl, backend := newListHandlerHarness(t)
+	impl.authCfg = credentialReadAuth(internalauth.ScopeOpsRead)
+	sink := &commonpb.SinkConfig{Name: "sink", Type: &commonpb.SinkConfig_Http{Http: &commonpb.HttpSinkConfig{Secret: "credentialSentinel", Endpoint: "https://u:urlSentinel@localhost"}}}
+	sinkStatus := &commonpb.SinkStatus{SinkName: "sink", Cursor: 12, Error: &commonpb.SinkError{Message: "dial https://u:credentialSentinel@localhost failed"}}
+	originalSink, originalStatus := sink.CloneVT(), sinkStatus.CloneVT()
+	backend.EXPECT().GetEventsSinks(gomock.Any()).Return([]*commonpb.SinkConfig{sink}, []*commonpb.SinkStatus{sinkStatus}, nil)
+	response, err := impl.GetEventsSinks(context.Background(), &servicepb.GetEventsSinksRequest{})
+	require.NoError(t, err)
+	requireCredentialFreeProto(t, response)
+	require.Equal(t, uint64(12), response.GetSinkStatuses()[0].GetCursor())
+	require.True(t, proto.Equal(originalSink, sink))
+	require.True(t, proto.Equal(originalStatus, sinkStatus))
+	impl.authCfg = credentialReadAuth(internalauth.ScopeLedgersRead)
+	info := &commonpb.LedgerInfo{Name: "a", MirrorSource: &commonpb.MirrorSourceConfig{Type: &commonpb.MirrorSourceConfig_Postgres{Postgres: &commonpb.PostgresMirrorSourceConfig{Dsn: "postgres://u:credentialSentinel@localhost/db?password=urlSentinel"}}}}
+	original := info.CloneVT()
+	backend.EXPECT().GetLedgerByName(gomock.Any(), "a").Return(info, nil)
+	got, err := impl.GetLedger(context.Background(), &servicepb.GetLedgerRequest{Ledger: "a"})
+	require.NoError(t, err)
+	requireCredentialFreeProto(t, got)
+	require.Equal(t, "a", got.GetName())
+	// Two pages prove the projection leaves exclusive name cursors intact.
+	second := info.CloneVT()
+	second.Name = "b"
+	backend.EXPECT().ListLedgers(gomock.Any()).Return(page(info, second), nil)
+	backend.EXPECT().ListLedgers(gomock.Any()).Return(page(info, second), nil)
+	firstPage := newFakeServerStream[commonpb.LedgerInfo](t)
+	require.NoError(t, impl.ListLedgers(&servicepb.ListLedgersRequest{Options: &commonpb.ListOptions{PageSize: 1}}, firstPage))
+	require.Len(t, firstPage.sent, 1)
+	require.Equal(t, "a", firstPage.trailerCursor())
+	requireCredentialFreeProto(t, firstPage.sent[0])
+	lastPage := newFakeServerStream[commonpb.LedgerInfo](t)
+	require.NoError(t, impl.ListLedgers(&servicepb.ListLedgersRequest{Options: &commonpb.ListOptions{PageSize: 1, Cursor: firstPage.trailerCursor()}}, lastPage))
+	require.Len(t, lastPage.sent, 1)
+	require.Equal(t, "b", lastPage.sent[0].GetName())
+	require.Empty(t, lastPage.trailerCursor())
+	requireCredentialFreeProto(t, lastPage.sent[0])
+	require.True(t, proto.Equal(original, info))
+}
+
+func TestCredentialProjectionHistoryGRPC(t *testing.T) {
+	t.Parallel()
+	for _, config := range []struct{ name, order, batch, log string }{
+		{"sink", `{"systemScoped":{"addEventsSink":{"config":{"name":"sink","http":{"secret":"credentialSentinel","endpoint":"https://u:urlSentinel@localhost"}}}}}`, `{"requests":[{"addEventsSink":{"config":{"name":"sink","http":{"secret":"credentialSentinel","endpoint":"https://u:urlSentinel@localhost"}}}}]}`, `{"payload":{"addedEventsSink":{"config":{"name":"sink","http":{"secret":"credentialSentinel","endpoint":"https://u:urlSentinel@localhost"}}}}}`},
+		{"mirror", `{"ledgerScoped":{"ledger":"mirror","createLedger":{"mirrorSource":{"postgres":{"dsn":"postgres://u:credentialSentinel@localhost/db?password=urlSentinel"}}}}}`, `{"requests":[{"createLedger":{"name":"mirror","mirrorSource":{"postgres":{"dsn":"postgres://u:credentialSentinel@localhost/db?password=urlSentinel"}}}}]}`, `{"payload":{"createLedger":{"name":"mirror","mirrorSource":{"postgres":{"dsn":"postgres://u:credentialSentinel@localhost/db?password=urlSentinel"}}}}}`},
+	} {
+		t.Run(config.name, func(t *testing.T) {
+			t.Parallel()
+			impl, backend := newListHandlerHarness(t)
+			impl.authCfg = credentialReadAuth(internalauth.ScopeAuditRead)
+			order := &raftcmdpb.Order{}
+			require.NoError(t, protojson.Unmarshal([]byte(config.order), order))
+			orderBytes, err := proto.Marshal(order)
+			require.NoError(t, err)
+			batch := &servicepb.ApplyBatch{}
+			require.NoError(t, protojson.Unmarshal([]byte(config.batch), batch))
+			batchBytes, err := proto.Marshal(batch)
+			require.NoError(t, err)
+			entry := &auditpb.AuditEntry{Sequence: 7, Items: []*auditpb.AuditItem{{SerializedOrder: orderBytes}}, Signature: &signaturepb.SignedApplyBatch{Payload: batchBytes, Signature: []byte("signature")}}
+			original := entry.CloneVT()
+			backend.EXPECT().GetAuditEntry(gomock.Any(), uint64(7)).Return(entry, nil)
+			got, err := impl.GetAuditEntry(context.Background(), &servicepb.GetAuditEntryRequest{Sequence: 7})
+			require.NoError(t, err)
+			requireCredentialFreeProto(t, got)
+			require.NotEmpty(t, got.GetItems()[0].GetSerializedOrder())
+			require.NotEmpty(t, got.GetSignature().GetPayload())
+			listed := entry.CloneVT()
+			listed.Items = nil
+			// A forwarded cursor's trailer must survive projection, even though its
+			// token is different from the last entry's sequence.
+			backend.EXPECT().ListAuditEntries(gomock.Any(), uint32(3), uint64(0), gomock.Any(), false).Return(&upstreamCursor[auditpb.AuditEntry]{items: []*auditpb.AuditEntry{listed}, nextCursor: "17"}, nil)
+			stream := newFakeServerStream[auditpb.AuditEntry](t)
+			require.NoError(t, impl.ListAuditEntries(&servicepb.ListAuditEntriesRequest{Options: &commonpb.ListOptions{PageSize: 2}}, stream))
+			require.Len(t, stream.sent, 1)
+			require.Equal(t, "17", stream.trailerCursor())
+			requireCredentialFreeProto(t, stream.sent[0])
+			require.True(t, proto.Equal(original, entry))
+			log := &commonpb.Log{}
+			require.NoError(t, protojson.Unmarshal([]byte(config.log), log))
+			log.Sequence = 9
+			originalLog := log.CloneVT()
+			impl.authCfg = credentialReadAuth(internalauth.ScopeOpsRead)
+			backend.EXPECT().GetLog(gomock.Any(), uint64(9)).Return(log, nil)
+			gotLog, err := impl.GetLog(context.Background(), &servicepb.GetLogRequest{Sequence: 9})
+			require.NoError(t, err)
+			requireCredentialFreeProto(t, gotLog)
+			// Current ListLogs only yields Apply records; this additional synthetic
+			// creation-log case guards the shared response boundary if that scope grows.
+			// GetLog above independently covers the currently reachable system history.
+			impl.authCfg = credentialReadAuth(internalauth.ScopeLedgersRead)
+			backend.EXPECT().ListLogs(gomock.Any(), "mirror", uint64(0), uint32(3), gomock.Any()).Return(&upstreamCursor[commonpb.Log]{items: []*commonpb.Log{log}, nextCursor: "19"}, nil)
+			logStream := newFakeServerStream[commonpb.Log](t)
+			require.NoError(t, impl.ListLogs(&servicepb.ListLogsRequest{Ledger: "mirror", Options: &commonpb.ListOptions{PageSize: 2}}, logStream))
+			require.Len(t, logStream.sent, 1)
+			require.Equal(t, "19", logStream.trailerCursor())
+			requireCredentialFreeProto(t, logStream.sent[0])
+			require.True(t, proto.Equal(originalLog, log))
+		})
+	}
+}
+
+func TestCredentialProjectionMalformedAuditGRPC(t *testing.T) {
+	t.Parallel()
+	impl, backend := newListHandlerHarness(t)
+	impl.authCfg = credentialReadAuth(internalauth.ScopeAuditRead)
+	entry := &auditpb.AuditEntry{Sequence: 7, Items: []*auditpb.AuditItem{{SerializedOrder: []byte("credentialSentinel")}}}
+	backend.EXPECT().GetAuditEntry(gomock.Any(), uint64(7)).Return(entry, nil)
+	got, err := impl.GetAuditEntry(context.Background(), &servicepb.GetAuditEntryRequest{Sequence: 7})
+	require.Error(t, err)
+	require.Nil(t, got)
+	require.NotContains(t, err.Error(), "credentialSentinel")
+	backend.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(page(entry), nil)
+	stream := newFakeServerStream[auditpb.AuditEntry](t)
+	require.Error(t, impl.ListAuditEntries(&servicepb.ListAuditEntriesRequest{}, stream))
+	require.Empty(t, stream.sent)
+}
+
+// A real checkpoint controller reads the preserved creation-time credentials
+// even after live state changes. Projection belongs after controller selection,
+// while both live and checkpoint storage retain their authoritative payloads.
+func TestCredentialProjectionCheckpointGRPC(t *testing.T) {
+	t.Parallel()
+	logger := logging.NopZap()
+	meter := noop.NewMeterProvider().Meter("credential-projection")
+	store, err := dal.NewStore(t.TempDir(), logger, meter, dal.DefaultConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, store.Close()) })
+	index, err := readstore.New(t.TempDir(), logger, readstore.DefaultConfig())
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, index.Close()) })
+	info := &commonpb.LedgerInfo{Name: "mirror", Mode: commonpb.LedgerMode_LEDGER_MODE_MIRROR, MirrorSource: &commonpb.MirrorSourceConfig{Type: &commonpb.MirrorSourceConfig_Postgres{Postgres: &commonpb.PostgresMirrorSourceConfig{Dsn: "postgres://u:credentialSentinel@localhost/db?password=urlSentinel"}}}}
+	log := &commonpb.Log{Sequence: 9, Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_CreateLedger{CreateLedger: &commonpb.CreatedLedgerLog{Name: "mirror", MirrorSource: info.GetMirrorSource().CloneVT()}}}}
+	batch := store.OpenWriteSession()
+	require.NoError(t, state.SaveLedger(batch, "mirror", info))
+	require.NoError(t, state.AppendLogs(batch, []*commonpb.Log{log}))
+	require.NoError(t, batch.Commit())
+	const checkpointID uint64 = 42
+	_, err = store.CreateQueryCheckpoint(checkpointID)
+	require.NoError(t, err)
+	require.NoError(t, index.CreateCheckpoint(store.QueryCheckpointReadIndexDir(checkpointID)))
+	require.NoError(t, readstore.MarkCheckpointReady(store.QueryCheckpointReadIndexDir(checkpointID)))
+	// Remove the source from live data to uniquely identify the checkpoint path.
+	liveInfo := info.CloneVT()
+	liveInfo.MirrorSource = nil
+	liveLog := log.CloneVT()
+	liveLog.Payload.GetCreateLedger().MirrorSource = nil
+	batch = store.OpenWriteSession()
+	require.NoError(t, state.SaveLedger(batch, "mirror", liveInfo))
+	require.NoError(t, state.AppendLogs(batch, []*commonpb.Log{liveLog}))
+	require.NoError(t, batch.Commit())
+	local := ctrl.NewDefaultController(nil, store, logger, attributes.New(), index, nil, meter)
+	impl := &BucketServiceServerImpl{logger: logger, ctrl: local, localCtrl: local, store: store, authCfg: credentialReadAuth(internalauth.ScopeLedgersRead)}
+	got, err := impl.GetLedger(context.Background(), &servicepb.GetLedgerRequest{Ledger: "mirror", Read: &commonpb.ReadOptions{CheckpointId: checkpointID}})
+	require.NoError(t, err)
+	require.NotNil(t, got.GetMirrorSource())
+	requireCredentialFreeProto(t, got)
+	live, err := impl.GetLedger(context.Background(), &servicepb.GetLedgerRequest{Ledger: "mirror"})
+	require.NoError(t, err)
+	require.Nil(t, live.GetMirrorSource())
+	impl.authCfg = credentialReadAuth(internalauth.ScopeOpsRead)
+	gotLog, err := impl.GetLog(context.Background(), &servicepb.GetLogRequest{Sequence: 9, CheckpointId: checkpointID})
+	require.NoError(t, err)
+	require.NotNil(t, gotLog.GetPayload().GetCreateLedger().GetMirrorSource())
+	requireCredentialFreeProto(t, gotLog)
+	// Reopen the checkpoint directly through the controller: the public reads
+	// must neither rewrite the snapshot nor strip worker/recovery credentials.
+	checkpoint, cleanup, err := impl.readController(context.Background(), checkpointID)
+	require.NoError(t, err)
+	defer cleanup()
+	original, err := checkpoint.GetLedgerByName(context.Background(), "mirror")
+	require.NoError(t, err)
+	require.True(t, proto.Equal(info.GetMirrorSource(), original.GetMirrorSource()))
+	originalLog, err := checkpoint.GetLog(context.Background(), 9)
+	require.NoError(t, err)
+	require.True(t, proto.Equal(log, originalLog))
+}

--- a/internal/adapter/http/credential_projection_test.go
+++ b/internal/adapter/http/credential_projection_test.go
@@ -1,0 +1,196 @@
+package http
+
+import (
+	"encoding/base64"
+	"encoding/hex"
+	stdjson "encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	internalauth "github.com/formancehq/ledger/v3/internal/adapter/auth"
+	"github.com/formancehq/ledger/v3/internal/pkg/cursor"
+	"github.com/formancehq/ledger/v3/internal/pkg/version"
+	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/internal/proto/signaturepb"
+)
+
+// Exercise the registered routes with auth enabled and only the read scope
+// each route requires, rather than bypassing middleware by calling handlers.
+func credentialReadHandler(backend Backend, scope internalauth.Scope) http.Handler {
+	return NewHandler(logging.Testing(), backend, internalauth.AuthConfig{Enabled: true, ScopeMapping: internalauth.ScopeMapping{internalauth.ScopeMappingAnonymousKey: {scope}}}, version.Info{})
+}
+
+func credentialRead(t *testing.T, handler http.Handler, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, path, nil))
+	require.Equal(t, http.StatusOK, response.Code, response.Body.String())
+
+	return response
+}
+
+func TestCredentialProjectionLiveHTTP(t *testing.T) {
+	t.Parallel()
+	sinks := []*commonpb.SinkConfig{
+		{Name: "nats", Type: &commonpb.SinkConfig_Nats{Nats: &commonpb.NatsSinkConfig{Url: "nats://natsSecret@localhost:4222,user:natsPassword@localhost:4223"}}},
+		{Name: "clickhouse", Type: &commonpb.SinkConfig_Clickhouse{Clickhouse: &commonpb.ClickHouseSinkConfig{Dsn: "clickhouse://u:chSecret@localhost/db?password=chQuerySecret"}}},
+		{Name: "kafka", Type: &commonpb.SinkConfig_Kafka{Kafka: &commonpb.KafkaSinkConfig{SaslPassword: "kafkaSecret"}}},
+		{Name: "http", Type: &commonpb.SinkConfig_Http{Http: &commonpb.HttpSinkConfig{Endpoint: "https://u:httpBasicSecret@localhost/?key=httpQuerySecret", Secret: "hmacSecret"}}},
+		{Name: "databricks-pat", Type: &commonpb.SinkConfig_Databricks{Databricks: &commonpb.DatabricksSinkConfig{Auth: &commonpb.DatabricksSinkConfig_Token{Token: "patSecret"}}}},
+		{Name: "databricks-oauth", Type: &commonpb.SinkConfig_Databricks{Databricks: &commonpb.DatabricksSinkConfig{Auth: &commonpb.DatabricksSinkConfig_OauthM2M{OauthM2M: &commonpb.DatabricksOAuthM2M{ClientSecret: "dbOAuthSecret"}}}}},
+	}
+	originals := make([]*commonpb.SinkConfig, len(sinks))
+	for i, sink := range sinks {
+		originals[i] = sink.CloneVT()
+	}
+	statuses := []*commonpb.SinkStatus{{SinkName: "http", Error: &commonpb.SinkError{Message: "dial https://u:statusSecret@localhost failed"}}}
+	originalStatus := statuses[0].CloneVT()
+	backend := NewMockBackend(gomock.NewController(t))
+	backend.EXPECT().GetEventsSinks(gomock.Any()).Return(sinks, statuses, nil)
+	response := credentialRead(t, credentialReadHandler(backend, internalauth.ScopeOpsRead), "/v3/_/events-sinks")
+	for _, secret := range []string{"natsSecret", "natsPassword", "chSecret", "chQuerySecret", "kafkaSecret", "httpBasicSecret", "httpQuerySecret", "hmacSecret", "patSecret", "dbOAuthSecret", "statusSecret"} {
+		require.NotContains(t, response.Body.String(), secret)
+	}
+	var body struct{ Data stdjson.RawMessage }
+	require.NoError(t, stdjson.Unmarshal(response.Body.Bytes(), &body))
+	projected := &servicepb.GetEventsSinksResponse{}
+	require.NoError(t, protojson.Unmarshal(body.Data, projected))
+	require.Len(t, projected.GetSinks(), len(sinks))
+	require.Equal(t, "http", projected.GetSinkStatuses()[0].GetSinkName())
+	for i, sink := range sinks {
+		require.True(t, proto.Equal(originals[i], sink))
+	}
+	require.True(t, proto.Equal(originalStatus, statuses[0]))
+	for _, mirror := range []*commonpb.MirrorSourceConfig{
+		{Type: &commonpb.MirrorSourceConfig_Http{Http: &commonpb.HttpMirrorSourceConfig{BaseUrl: "https://u:mirrorBasicSecret@localhost", Oauth2ClientCredentials: &commonpb.OAuth2ClientCredentials{ClientSecret: "mirrorOAuthSecret", TokenEndpoint: "https://u:tokenEndpointSecret@localhost/token"}}}},
+		{Type: &commonpb.MirrorSourceConfig_Postgres{Postgres: &commonpb.PostgresMirrorSourceConfig{Dsn: "postgres://u:postgresSecret@localhost/db?password=postgresQuerySecret"}}},
+	} {
+		info := &commonpb.LedgerInfo{Name: "mirror", MirrorSource: mirror}
+		original := info.CloneVT()
+		backend.EXPECT().GetLedgerByName(gomock.Any(), "mirror").Return(info, nil)
+		backend.EXPECT().ListLedgers(gomock.Any()).Return(cursor.NewSliceCursor([]*commonpb.LedgerInfo{info}), nil)
+		handler := credentialReadHandler(backend, internalauth.ScopeLedgersRead)
+		for _, path := range []string{"/v3/mirror", "/v3/"} {
+			response := credentialRead(t, handler, path)
+			for _, secret := range []string{"postgresSecret", "postgresQuerySecret", "mirrorBasicSecret", "mirrorOAuthSecret", "tokenEndpointSecret"} {
+				require.NotContains(t, response.Body.String(), secret)
+			}
+			require.Contains(t, response.Body.String(), "mirror")
+		}
+		require.True(t, proto.Equal(original, info))
+	}
+}
+
+func TestCredentialProjectionHistoryHTTP(t *testing.T) {
+	t.Parallel()
+	for _, config := range []struct{ name, order, batch, log string }{
+		{"sink", `{"systemScoped":{"addEventsSink":{"config":{"name":"sink","http":{"secret":"credentialSentinel","endpoint":"https://u:urlSentinel@localhost"}}}}}`, `{"requests":[{"addEventsSink":{"config":{"name":"sink","http":{"secret":"credentialSentinel","endpoint":"https://u:urlSentinel@localhost"}}}}]}`, `{"payload":{"addedEventsSink":{"config":{"name":"sink","http":{"secret":"credentialSentinel","endpoint":"https://u:urlSentinel@localhost"}}}}}`},
+		{"mirror", `{"ledgerScoped":{"ledger":"mirror","createLedger":{"mirrorSource":{"postgres":{"dsn":"postgres://u:credentialSentinel@localhost/db?password=urlSentinel"}}}}}`, `{"requests":[{"createLedger":{"name":"mirror","mirrorSource":{"postgres":{"dsn":"postgres://u:credentialSentinel@localhost/db?password=urlSentinel"}}}}]}`, `{"payload":{"createLedger":{"name":"mirror","mirrorSource":{"postgres":{"dsn":"postgres://u:credentialSentinel@localhost/db?password=urlSentinel"}}}}}`},
+	} {
+		t.Run(config.name, func(t *testing.T) {
+			t.Parallel()
+			order := &raftcmdpb.Order{}
+			require.NoError(t, protojson.Unmarshal([]byte(config.order), order))
+			orderBytes, err := proto.Marshal(order)
+			require.NoError(t, err)
+			batch := &servicepb.ApplyBatch{}
+			require.NoError(t, protojson.Unmarshal([]byte(config.batch), batch))
+			batchBytes, err := proto.Marshal(batch)
+			require.NoError(t, err)
+			entry := &auditpb.AuditEntry{Sequence: 7, OrderCount: 1, Items: []*auditpb.AuditItem{{SerializedOrder: orderBytes, LogSequence: 9}}, Signature: &signaturepb.SignedApplyBatch{Payload: batchBytes, Signature: []byte("signature")}}
+			original := entry.CloneVT()
+			listed := entry.CloneVT()
+			listed.Items = nil
+			originalList := listed.CloneVT()
+			backend := NewMockBackend(gomock.NewController(t))
+			backend.EXPECT().GetAuditEntry(gomock.Any(), uint64(7)).Return(entry, nil)
+			backend.EXPECT().ListAuditEntries(gomock.Any(), uint32(100), uint64(0), gomock.Any(), false).Return(cursor.NewSliceCursor([]*auditpb.AuditEntry{listed}), nil)
+			handler := credentialReadHandler(backend, internalauth.ScopeAuditRead)
+			for _, path := range []string{"/v3/_/audit-entries/7", "/v3/_/audit-entries"} {
+				response := credentialRead(t, handler, path)
+				var body struct{ Data stdjson.RawMessage }
+				require.NoError(t, stdjson.Unmarshal(response.Body.Bytes(), &body))
+				var entries []struct {
+					Items     []struct{ SerializedOrder string }
+					Signature struct{ Payload string }
+				}
+				if path == "/v3/_/audit-entries/7" {
+					body.Data = append(append([]byte{'['}, body.Data...), ']')
+				}
+				require.NoError(t, stdjson.Unmarshal(body.Data, &entries))
+				require.Len(t, entries, 1)
+				for _, item := range entries[0].Items {
+					decoded, err := hex.DecodeString(item.SerializedOrder)
+					require.NoError(t, err)
+					require.NotEmpty(t, decoded)
+					require.NotContains(t, string(decoded), "credentialSentinel")
+					require.NotContains(t, string(decoded), "urlSentinel")
+					projected := &raftcmdpb.Order{}
+					require.NoError(t, proto.Unmarshal(decoded, projected))
+				}
+				decoded, err := base64.StdEncoding.DecodeString(entries[0].Signature.Payload)
+				require.NoError(t, err)
+				require.NotEmpty(t, decoded)
+				require.NotContains(t, string(decoded), "credentialSentinel")
+				require.NotContains(t, string(decoded), "urlSentinel")
+				projected := &servicepb.ApplyBatch{}
+				require.NoError(t, proto.Unmarshal(decoded, projected))
+				require.Len(t, projected.GetRequests(), 1)
+			}
+			require.True(t, proto.Equal(original, entry))
+			require.True(t, proto.Equal(originalList, listed))
+			log := &commonpb.Log{}
+			require.NoError(t, protojson.Unmarshal([]byte(config.log), log))
+			log.Sequence = 9
+			originalLog := log.CloneVT()
+			backend.EXPECT().GetLog(gomock.Any(), uint64(9)).Return(log, nil)
+			// ListLogs currently returns Apply only; retain this defensive boundary
+			// case alongside the independent, reachable GetLog system-history case.
+			backend.EXPECT().ListLogs(gomock.Any(), "mirror", uint64(0), uint32(100), gomock.Any()).Return(cursor.NewSliceCursor([]*commonpb.Log{log}), nil)
+			for _, test := range []struct {
+				path  string
+				scope internalauth.Scope
+			}{{"/v3/_/logs/9", internalauth.ScopeOpsRead}, {"/v3/mirror/logs", internalauth.ScopeLedgersRead}} {
+				response := credentialRead(t, credentialReadHandler(backend, test.scope), test.path)
+				require.NotContains(t, response.Body.String(), "credentialSentinel")
+				require.NotContains(t, response.Body.String(), "urlSentinel")
+				require.Contains(t, response.Body.String(), "9")
+			}
+			require.True(t, proto.Equal(originalLog, log))
+		})
+	}
+}
+
+func TestCredentialProjectionMalformedAuditHTTP(t *testing.T) {
+	t.Parallel()
+	for _, list := range []bool{false, true} {
+		t.Run(map[bool]string{false: "get", true: "list"}[list], func(t *testing.T) {
+			t.Parallel()
+			backend := NewMockBackend(gomock.NewController(t))
+			entry := &auditpb.AuditEntry{Sequence: 7, Items: []*auditpb.AuditItem{{SerializedOrder: []byte("credentialSentinel")}}}
+			path := "/v3/_/audit-entries/7"
+			if list {
+				path = "/v3/_/audit-entries"
+				backend.EXPECT().ListAuditEntries(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(cursor.NewSliceCursor([]*auditpb.AuditEntry{entry}), nil)
+			} else {
+				backend.EXPECT().GetAuditEntry(gomock.Any(), uint64(7)).Return(entry, nil)
+			}
+			response := httptest.NewRecorder()
+			credentialReadHandler(backend, internalauth.ScopeAuditRead).ServeHTTP(response, httptest.NewRequest(http.MethodGet, path, nil))
+			require.Equal(t, http.StatusInternalServerError, response.Code)
+			require.NotContains(t, response.Body.String(), "credentialSentinel")
+			require.NotContains(t, response.Body.String(), "serializedOrder")
+		})
+	}
+}

--- a/internal/adapter/http/handlers_get_audit_entry.go
+++ b/internal/adapter/http/handlers_get_audit_entry.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
+
+	"github.com/formancehq/ledger/v3/internal/adapter/readprojection"
 )
 
 // handleGetAuditEntry handles GET /v3/_/audit-entries/{sequence}.
@@ -21,6 +23,13 @@ func (s *Server) handleGetAuditEntry(w http.ResponseWriter, r *http.Request) {
 	}
 
 	entry, err := s.backend.GetAuditEntry(r.Context(), sequence)
+	if err != nil {
+		handleError(w, r, err)
+
+		return
+	}
+
+	entry, err = readprojection.Audit(entry)
 	if err != nil {
 		handleError(w, r, err)
 

--- a/internal/adapter/http/handlers_get_events_sinks.go
+++ b/internal/adapter/http/handlers_get_events_sinks.go
@@ -6,6 +6,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/formancehq/ledger/v3/internal/adapter/json"
+	"github.com/formancehq/ledger/v3/internal/adapter/readprojection"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
 
@@ -25,10 +26,14 @@ func (s *Server) handleGetEventsSinks(w http.ResponseWriter, r *http.Request) {
 	// configs) serialize in camelCase — the sonic default would leak snake_case
 	// proto tags (sink_name) and the untagged oneof wrapper field. Reusing the
 	// gRPC GetEventsSinksResponse gives both transports an identical shape.
-	raw, err := protojson.Marshal(&servicepb.GetEventsSinksResponse{
-		Sinks:        sinks,
-		SinkStatuses: statuses,
-	})
+	response := &servicepb.GetEventsSinksResponse{}
+	for _, sink := range sinks {
+		response.Sinks = append(response.Sinks, readprojection.Sink(sink))
+	}
+	for _, status := range statuses {
+		response.SinkStatuses = append(response.SinkStatuses, readprojection.SinkStatus(status))
+	}
+	raw, err := protojson.Marshal(response)
 	if err != nil {
 		handleError(w, r, err)
 

--- a/internal/adapter/http/handlers_get_ledger.go
+++ b/internal/adapter/http/handlers_get_ledger.go
@@ -2,6 +2,8 @@ package http
 
 import (
 	"net/http"
+
+	"github.com/formancehq/ledger/v3/internal/adapter/readprojection"
 )
 
 // handleGetLedger handles GET /{ledgerName} to get a ledger.
@@ -19,5 +21,5 @@ func (s *Server) handleGetLedger(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Return ledger info wrapped in BaseResponse
-	writeOK(w, ledgerInfo)
+	writeOK(w, readprojection.Ledger(ledgerInfo))
 }

--- a/internal/adapter/http/handlers_get_log.go
+++ b/internal/adapter/http/handlers_get_log.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 
 	"github.com/go-chi/chi/v5"
+
+	"github.com/formancehq/ledger/v3/internal/adapter/readprojection"
 )
 
 // handleGetLog handles GET /logs/{sequence} to fetch a single system log by
@@ -27,5 +29,11 @@ func (s *Server) handleGetLog(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	log, err = readprojection.Log(log)
+	if err != nil {
+		handleError(w, r, err)
+
+		return
+	}
 	writeOKChecked(w, r, log)
 }

--- a/internal/adapter/http/handlers_list_all_ledgers.go
+++ b/internal/adapter/http/handlers_list_all_ledgers.go
@@ -2,6 +2,8 @@ package http
 
 import (
 	"net/http"
+
+	"github.com/formancehq/ledger/v3/internal/adapter/readprojection"
 )
 
 // handleListAllLedgers handles GET / to list all ledgers.
@@ -22,5 +24,8 @@ func (s *Server) handleListAllLedgers(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Return ledgers list wrapped in BaseResponse
+	for i, info := range ret {
+		ret[i] = readprojection.Ledger(info)
+	}
 	writeOK(w, ret)
 }

--- a/internal/adapter/http/handlers_list_audit_entries.go
+++ b/internal/adapter/http/handlers_list_audit_entries.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/formancehq/ledger/v3/internal/adapter/readprojection"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
@@ -75,6 +76,15 @@ func (s *Server) handleListAuditEntries(w http.ResponseWriter, r *http.Request) 
 	entries, ok := drainCursor(w, r, cursor)
 	if !ok {
 		return
+	}
+
+	for i, entry := range entries {
+		entries[i], err = readprojection.Audit(entry)
+		if err != nil {
+			handleError(w, r, err)
+
+			return
+		}
 	}
 
 	// writeOKChecked (not writeOK): audit DTOs marshal chain-bound submessages

--- a/internal/adapter/http/handlers_list_ledger_logs.go
+++ b/internal/adapter/http/handlers_list_ledger_logs.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/formancehq/ledger/v3/internal/adapter/readprojection"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 )
 
@@ -104,5 +105,13 @@ func (s *Server) handleListLedgerLogs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	for i, log := range logs {
+		logs[i], err = readprojection.Log(log)
+		if err != nil {
+			handleError(w, r, err)
+
+			return
+		}
+	}
 	writeOK(w, logs)
 }

--- a/internal/adapter/readprojection/audit.go
+++ b/internal/adapter/readprojection/audit.go
@@ -1,0 +1,116 @@
+package readprojection
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+)
+
+// Audit returns a display projection for public reads. Persisted audit records
+// remain the authoritative hash/signature preimages. When credentials change,
+// the returned bytes cannot be used to verify the original hash or signature.
+// Unchanged orders and signed batches retain their exact original encoding.
+func Audit(entry *auditpb.AuditEntry) (*auditpb.AuditEntry, error) {
+	if entry == nil {
+		return nil, nil
+	}
+	result := entry.CloneVT()
+	for _, item := range result.GetItems() {
+		if item == nil || len(item.GetSerializedOrder()) == 0 {
+			continue
+		}
+		order := &raftcmdpb.Order{}
+		if err := validateCredentialWire(item.GetSerializedOrder(), order); err != nil {
+			return nil, fmt.Errorf("decoding audit order for public projection: %w", err)
+		}
+		if err := order.UnmarshalVT(item.GetSerializedOrder()); err != nil {
+			return nil, fmt.Errorf("decoding audit order for public projection: %w", err)
+		}
+		if redactOrder(order) {
+			serialized, err := order.MarshalVT()
+			if err != nil {
+				return nil, fmt.Errorf("encoding audit order for public projection: %w", err)
+			}
+			item.SerializedOrder = serialized
+		}
+	}
+	if signed := result.GetSignature(); signed != nil && len(signed.GetPayload()) > 0 {
+		batch := &servicepb.ApplyBatch{}
+		if err := validateCredentialWire(signed.GetPayload(), batch); err != nil {
+			return nil, fmt.Errorf("decoding signed audit batch for public projection: %w", err)
+		}
+		if err := batch.UnmarshalVT(signed.GetPayload()); err != nil {
+			return nil, fmt.Errorf("decoding signed audit batch for public projection: %w", err)
+		}
+		changed := false
+		for _, request := range batch.GetRequests() {
+			changed = redactSink(request.GetAddEventsSink().GetConfig()) || changed
+			changed = redactMirror(request.GetCreateLedger().GetMirrorSource()) || changed
+		}
+		if changed {
+			payload, err := batch.MarshalVT()
+			if err != nil {
+				return nil, fmt.Errorf("encoding signed audit batch for public projection: %w", err)
+			}
+			signed.Payload = payload
+			// Keep the signing key identity, but do not present the old signature
+			// as proof of the redacted payload. The stored envelope is unchanged.
+			signed.Signature = nil
+		}
+	}
+
+	return result, nil
+}
+
+func redactOrder(order *raftcmdpb.Order) bool {
+	changed := redactSink(order.GetSystemScoped().GetAddEventsSink().GetConfig())
+
+	return redactMirror(order.GetLedgerScoped().GetCreateLedger().GetMirrorSource()) || changed
+}
+
+// Log returns a deep-cloned system-log display projection. It must never be
+// used by replay, backup, the checker, or delivery workers, which need the
+// original creation-time configuration. Response-signature envelopes normally
+// occur only on write responses; if present on a read, their payload is also
+// projected and their signature is retained only when its bytes are unchanged.
+func Log(entry *commonpb.Log) (*commonpb.Log, error) {
+	if entry == nil {
+		return nil, nil
+	}
+	result := entry.CloneVT()
+	redactLogPayload(result)
+	if signed := result.GetResponseSignature(); signed != nil && len(signed.GetPayload()) > 0 {
+		payload := &commonpb.Log{}
+		if err := validateCredentialWire(signed.GetPayload(), payload); err != nil {
+			return nil, fmt.Errorf("decoding signed log for public projection: %w", err)
+		}
+		if err := payload.UnmarshalVT(signed.GetPayload()); err != nil {
+			return nil, fmt.Errorf("decoding signed log for public projection: %w", err)
+		}
+		// SignLog excludes the envelope itself from its signed preimage. A
+		// nested envelope violates that contract; never send unchecked bytes.
+		if payload.GetResponseSignature() != nil {
+			return nil, errors.New("nested response signature in public log projection")
+		}
+		if redactLogPayload(payload) {
+			serialized, err := payload.MarshalVT()
+			if err != nil {
+				return nil, fmt.Errorf("encoding signed log for public projection: %w", err)
+			}
+			signed.Payload = serialized
+			signed.Signature = nil
+		}
+	}
+
+	return result, nil
+}
+
+func redactLogPayload(entry *commonpb.Log) bool {
+	changed := redactSink(entry.GetPayload().GetAddedEventsSink().GetConfig())
+
+	return redactMirror(entry.GetPayload().GetCreateLedger().GetMirrorSource()) || changed
+}

--- a/internal/adapter/readprojection/audit_hash_test.go
+++ b/internal/adapter/readprojection/audit_hash_test.go
@@ -1,0 +1,83 @@
+package readprojection
+
+import (
+	"crypto/ed25519"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/formancehq/ledger/v3/internal/domain/processing"
+	"github.com/formancehq/ledger/v3/internal/infra/state"
+	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/internal/proto/signaturepb"
+)
+
+// Exercise the actual audit preimage builders and hash primitive used by the
+// FSM and checker: a public projection must never rewrite their evidence.
+func TestAuditProjectionPreservesAuthoritativeHash(t *testing.T) {
+	t.Parallel()
+
+	for _, signed := range []bool{false, true} {
+		name := "unsigned"
+		if signed {
+			name = "signed"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			config := &commonpb.SinkConfig{
+				Name: "fixture",
+				Type: &commonpb.SinkConfig_Http{Http: &commonpb.HttpSinkConfig{
+					Endpoint: "https://example.test/hook", Secret: "hash-bound-credential",
+				}},
+			}
+			entry := &auditpb.AuditEntry{
+				Sequence: 7, OrderCount: 1,
+				Outcome: &auditpb.AuditEntry_Success{Success: &auditpb.AuditSuccess{
+					MinLogSequence: 12, MaxLogSequence: 12,
+				}},
+				Items: []*auditpb.AuditItem{{
+					LogSequence:     12,
+					SerializedOrder: processing.MarshalOrderBusinessIntent(addSinkOrder(config), nil),
+				}},
+			}
+			if signed {
+				payload, err := (&servicepb.ApplyBatch{Requests: []*servicepb.Request{{
+					Type: &servicepb.Request_AddEventsSink{AddEventsSink: &servicepb.AddEventsSinkRequest{Config: config}},
+				}}}).MarshalVT()
+				require.NoError(t, err)
+				key := ed25519.NewKeyFromSeed(make([]byte, ed25519.SeedSize))
+				entry.Signature = &signaturepb.SignedApplyBatch{
+					KeyId: "fixture", Payload: payload, Signature: ed25519.Sign(key, payload),
+				}
+			}
+			generator := processing.NewHashGenerator(commonpb.HashAlgorithm_HASH_ALGORITHM_BLAKE3, "fixture-cluster")
+			previousHash := []byte("previous-authoritative-hash")
+			compute := func(value *auditpb.AuditEntry) []byte {
+				header, err := state.BuildHashedHeaderPayload(value)
+				require.NoError(t, err)
+				payloads := [][]byte{header}
+				for _, item := range value.GetItems() {
+					payloads = append(payloads, state.BuildPerItemPayload(item))
+				}
+				_, hash := generator.Compute(nil, previousHash, payloads)
+
+				return hash
+			}
+			entry.HashVersion = uint32(generator.Algorithm())
+			entry.Hash = compute(entry)
+			original := proto.Clone(entry)
+
+			projected, err := Audit(entry)
+			require.NoError(t, err)
+			require.True(t, proto.Equal(original, entry), "projection changed authoritative evidence")
+			require.Equal(t, entry.GetHash(), compute(entry), "authoritative chain must still verify")
+			require.Equal(t, entry.GetHash(), projected.GetHash(), "display retains original evidence identity")
+			require.NotContains(t, string(projected.GetItems()[0].GetSerializedOrder()), "hash-bound-credential")
+			require.NotEqual(t, projected.GetHash(), compute(projected), "display bytes are not the original hash preimage")
+		})
+	}
+}

--- a/internal/adapter/readprojection/audit_test.go
+++ b/internal/adapter/readprojection/audit_test.go
@@ -1,0 +1,276 @@
+package readprojection
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/formancehq/ledger/v3/internal/domain/processing"
+	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/internal/proto/signaturepb"
+)
+
+func TestProjectAuditEntryForReadRedactsOrdersAndSignedPayload(t *testing.T) {
+	t.Parallel()
+
+	sinkConfigs, sinkSecrets := secretBearingSinkConfigs()
+	mirrorSources, mirrorSecrets := secretBearingMirrorSources()
+
+	var (
+		items    []*auditpb.AuditItem
+		requests []*servicepb.Request
+	)
+
+	for _, config := range sinkConfigs {
+		order := addSinkOrder(config.CloneVT())
+		items = append(items, &auditpb.AuditItem{
+			OrderIndex:      uint32(len(items)),
+			SerializedOrder: processing.MarshalOrderBusinessIntent(order, nil),
+		})
+		requests = append(requests, &servicepb.Request{Type: &servicepb.Request_AddEventsSink{
+			AddEventsSink: &servicepb.AddEventsSinkRequest{Config: config.CloneVT()},
+		}})
+	}
+
+	for _, source := range mirrorSources {
+		order := createLedgerOrder(source.CloneVT())
+		items = append(items, &auditpb.AuditItem{
+			OrderIndex:      uint32(len(items)),
+			SerializedOrder: processing.MarshalOrderBusinessIntent(order, nil),
+		})
+		requests = append(requests, &servicepb.Request{Type: &servicepb.Request_CreateLedger{
+			CreateLedger: &servicepb.CreateLedgerRequest{MirrorSource: source.CloneVT()},
+		}})
+	}
+
+	batchPayload, err := (&servicepb.ApplyBatch{Requests: requests}).MarshalVT()
+	require.NoError(t, err)
+
+	entry := &auditpb.AuditEntry{
+		Sequence: 42,
+		Items:    items,
+		Signature: &signaturepb.SignedApplyBatch{
+			KeyId:     "signer-key",
+			Signature: []byte("original-signature"),
+			Payload:   batchPayload,
+		},
+	}
+	original := entry.CloneVT()
+
+	projected, err := Audit(entry)
+	require.NoError(t, err)
+	require.Equal(t, original, entry, "read projection must not mutate authoritative audit data")
+	require.Empty(t, projected.GetSignature().GetSignature(), "signature does not cover projected bytes")
+	require.Equal(t, "signer-key", projected.GetSignature().GetKeyId())
+
+	projectedBatch := &servicepb.ApplyBatch{}
+	require.NoError(t, projectedBatch.UnmarshalVT(projected.GetSignature().GetPayload()))
+	require.Len(t, projectedBatch.GetRequests(), len(requests))
+
+	for _, item := range projected.GetItems() {
+		order := &raftcmdpb.Order{}
+		require.NoError(t, order.UnmarshalVT(item.GetSerializedOrder()))
+	}
+
+	rendered, err := json.Marshal(projected)
+	require.NoError(t, err)
+
+	for _, secret := range append(sinkSecrets, mirrorSecrets...) {
+		require.NotContains(t, string(rendered), secret)
+		require.NotContains(t, string(projected.GetSignature().GetPayload()), secret)
+		for _, item := range projected.GetItems() {
+			require.NotContains(t, string(item.GetSerializedOrder()), secret)
+		}
+	}
+}
+
+func TestProjectAuditEntryForReadPreservesVerifiableEvidenceWithoutCredentials(t *testing.T) {
+	t.Parallel()
+
+	order := &raftcmdpb.Order{Type: &raftcmdpb.Order_SystemScoped{SystemScoped: &raftcmdpb.SystemScopedOrder{
+		Payload: &raftcmdpb.SystemScopedOrder_RemoveEventsSink{RemoveEventsSink: &raftcmdpb.RemoveEventsSinkOrder{Name: "sink"}},
+	}}, Technical: &raftcmdpb.OrderTechnical{CoverageBits: []byte{0x01}}}
+	// A no-op display projection must preserve the original binary encoding,
+	// including technical fields when supplied by a controller fixture.
+	serializedOrder := order.MarshalDeterministicVT(nil)
+	batchPayload, err := (&servicepb.ApplyBatch{Requests: []*servicepb.Request{{
+		Type: &servicepb.Request_RemoveEventsSink{RemoveEventsSink: &servicepb.RemoveEventsSinkRequest{Name: "sink"}},
+	}}}).MarshalVT()
+	require.NoError(t, err)
+
+	entry := &auditpb.AuditEntry{
+		Sequence: 43,
+		Items:    []*auditpb.AuditItem{{SerializedOrder: serializedOrder}},
+		Signature: &signaturepb.SignedApplyBatch{
+			KeyId:     "signer-key",
+			Signature: []byte("original-signature"),
+			Payload:   batchPayload,
+		},
+	}
+
+	projected, err := Audit(entry)
+	require.NoError(t, err)
+	require.Equal(t, entry, projected)
+	require.Equal(t, serializedOrder, projected.GetItems()[0].GetSerializedOrder())
+	require.Equal(t, batchPayload, projected.GetSignature().GetPayload())
+	require.Equal(t, []byte("original-signature"), projected.GetSignature().GetSignature())
+}
+
+func TestProjectAuditEntryForReadRejectsUnparseableSecretContainers(t *testing.T) {
+	t.Parallel()
+
+	_, err := Audit(&auditpb.AuditEntry{
+		Items: []*auditpb.AuditItem{{SerializedOrder: []byte{0xff}}},
+	})
+	require.ErrorContains(t, err, "decoding audit order")
+
+	_, err = Audit(&auditpb.AuditEntry{
+		Signature: &signaturepb.SignedApplyBatch{Payload: []byte{0xff}},
+	})
+	require.ErrorContains(t, err, "decoding signed audit batch")
+}
+
+func TestAuditCryptographicEvidenceAndRepeatedProjection(t *testing.T) {
+	t.Parallel()
+	key := ed25519.NewKeyFromSeed(make([]byte, ed25519.SeedSize))
+	for _, secret := range []string{"", "credential-sentinel"} {
+		t.Run(secret, func(t *testing.T) {
+			t.Parallel()
+			config := &commonpb.SinkConfig{Type: &commonpb.SinkConfig_Http{Http: &commonpb.HttpSinkConfig{Endpoint: "https://example.test/hook", Secret: secret}}}
+			payload, err := (&servicepb.ApplyBatch{Requests: []*servicepb.Request{{Type: &servicepb.Request_AddEventsSink{AddEventsSink: &servicepb.AddEventsSinkRequest{Config: config}}}}}).MarshalVT()
+			require.NoError(t, err)
+			entry := &auditpb.AuditEntry{Signature: &signaturepb.SignedApplyBatch{KeyId: "fixture", Payload: payload, Signature: ed25519.Sign(key, payload)}}
+			original := proto.Clone(entry)
+			result, err := Audit(entry)
+			require.NoError(t, err)
+			require.True(t, proto.Equal(original, entry))
+			require.True(t, ed25519.Verify(key.Public().(ed25519.PublicKey), entry.GetSignature().GetPayload(), entry.GetSignature().GetSignature()))
+			if secret == "" {
+				require.True(t, proto.Equal(entry, result))
+				require.True(t, ed25519.Verify(key.Public().(ed25519.PublicKey), result.GetSignature().GetPayload(), result.GetSignature().GetSignature()))
+			} else {
+				require.Empty(t, result.GetSignature().GetSignature())
+				require.NotContains(t, string(result.GetSignature().GetPayload()), secret)
+				require.False(t, ed25519.Verify(key.Public().(ed25519.PublicKey), result.GetSignature().GetPayload(), entry.GetSignature().GetSignature()))
+			}
+			again, err := Audit(result)
+			require.NoError(t, err)
+			require.True(t, proto.Equal(result, again))
+		})
+	}
+}
+
+func TestLogProjectionIncludesSignedEnvelope(t *testing.T) {
+	t.Parallel()
+	configs, secrets := secretBearingSinkConfigs()
+	sources, mirrorSecrets := secretBearingMirrorSources()
+	var logs []*commonpb.Log
+	for _, config := range configs {
+		logs = append(logs, &commonpb.Log{Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_AddedEventsSink{AddedEventsSink: &commonpb.AddedEventsSinkLog{Config: config}}}})
+	}
+	for _, source := range sources {
+		logs = append(logs, &commonpb.Log{Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_CreateLedger{CreateLedger: &commonpb.CreatedLedgerLog{MirrorSource: source}}}})
+	}
+	secrets = append(secrets, mirrorSecrets...)
+	for i, log := range logs {
+		payload, err := log.MarshalVT()
+		require.NoError(t, err)
+		log.ResponseSignature = &signaturepb.SignedLog{KeyId: "fixture", Payload: payload, Signature: []byte("proof-of-original")}
+		original := proto.Clone(log)
+		result, err := Log(log)
+		require.NoError(t, err)
+		require.True(t, proto.Equal(original, log))
+		require.Empty(t, result.GetResponseSignature().GetSignature())
+		require.Equal(t, "fixture", result.GetResponseSignature().GetKeyId())
+		require.NotContains(t, result.String(), secrets[i])
+		require.NotContains(t, string(result.GetResponseSignature().GetPayload()), secrets[i])
+		decoded := &commonpb.Log{}
+		require.NoError(t, decoded.UnmarshalVT(result.GetResponseSignature().GetPayload()))
+		require.True(t, proto.Equal(result.GetPayload(), decoded.GetPayload()))
+		again, err := Log(result)
+		require.NoError(t, err)
+		require.True(t, proto.Equal(result, again))
+	}
+}
+
+func TestLogProjectionRejectsInvalidSignedPayload(t *testing.T) {
+	t.Parallel()
+	_, err := Log(&commonpb.Log{ResponseSignature: &signaturepb.SignedLog{Payload: []byte{0xff}}})
+	require.ErrorContains(t, err, "decoding signed log")
+	nested, err := (&commonpb.Log{ResponseSignature: &signaturepb.SignedLog{Payload: []byte("untrusted")}}).MarshalVT()
+	require.NoError(t, err)
+	_, err = Log(&commonpb.Log{ResponseSignature: &signaturepb.SignedLog{Payload: nested}})
+	require.ErrorContains(t, err, "nested response signature")
+}
+
+func TestProjectionNilAndUnchangedRecords(t *testing.T) {
+	t.Parallel()
+	log, err := Log(nil)
+	require.NoError(t, err)
+	require.Nil(t, log)
+	entry, err := Audit(nil)
+	require.NoError(t, err)
+	require.Nil(t, entry)
+	// Audit failures are authoritative business diagnostics, not sink/mirror
+	// transport status; their reason/context must not be changed by this policy.
+	original := &auditpb.AuditEntry{Outcome: &auditpb.AuditEntry_Failure{Failure: &auditpb.AuditFailure{Message: "business diagnostic", Context: map[string]string{"ledger": "main"}}}}
+	entry, err = Audit(original)
+	require.NoError(t, err)
+	require.True(t, proto.Equal(original, entry))
+	payload, err := (&commonpb.Log{Sequence: 7}).MarshalVT()
+	require.NoError(t, err)
+	plain := &commonpb.Log{Sequence: 7, ResponseSignature: &signaturepb.SignedLog{Payload: payload, Signature: []byte("original")}}
+	log, err = Log(plain)
+	require.NoError(t, err)
+	require.True(t, proto.Equal(plain, log))
+}
+
+func secretBearingSinkConfigs() ([]*commonpb.SinkConfig, []string) {
+	return []*commonpb.SinkConfig{
+		{Name: "nats", Type: &commonpb.SinkConfig_Nats{Nats: &commonpb.NatsSinkConfig{Url: "nats://token-secret@nats.example:4222", Topic: "ledger"}}},
+		{Name: "clickhouse", Type: &commonpb.SinkConfig_Clickhouse{Clickhouse: &commonpb.ClickHouseSinkConfig{Dsn: "clickhouse://user:clickhouse-secret@db.example/ledger", Table: "events"}}},
+		{Name: "kafka", Type: &commonpb.SinkConfig_Kafka{Kafka: &commonpb.KafkaSinkConfig{Brokers: []string{"broker:9092"}, SaslUsername: "ledger", SaslPassword: "kafka-secret"}}},
+		{Name: "http", Type: &commonpb.SinkConfig_Http{Http: &commonpb.HttpSinkConfig{Endpoint: "https://hooks.example/ledger", Secret: "webhook-secret"}}},
+		{Name: "databricks-token", Type: &commonpb.SinkConfig_Databricks{Databricks: &commonpb.DatabricksSinkConfig{ServerHostname: "db.example", Auth: &commonpb.DatabricksSinkConfig_Token{Token: "databricks-token-secret"}}}},
+		{Name: "databricks-oauth", Type: &commonpb.SinkConfig_Databricks{Databricks: &commonpb.DatabricksSinkConfig{ServerHostname: "db.example", Auth: &commonpb.DatabricksSinkConfig_OauthM2M{OauthM2M: &commonpb.DatabricksOAuthM2M{ClientId: "client", ClientSecret: "databricks-oauth-secret"}}}}},
+	}, []string{
+		"token-secret",
+		"clickhouse-secret",
+		"kafka-secret",
+		"webhook-secret",
+		"databricks-token-secret",
+		"databricks-oauth-secret",
+	}
+}
+
+func secretBearingMirrorSources() ([]*commonpb.MirrorSourceConfig, []string) {
+	return []*commonpb.MirrorSourceConfig{
+		{LedgerName: "source-http", Type: &commonpb.MirrorSourceConfig_Http{Http: &commonpb.HttpMirrorSourceConfig{
+			BaseUrl: "https://ledger.example",
+			Oauth2ClientCredentials: &commonpb.OAuth2ClientCredentials{
+				ClientId: "client", ClientSecret: "mirror-oauth-secret", TokenEndpoint: "https://auth.example/token",
+			},
+		}}},
+		{LedgerName: "source-postgres", Type: &commonpb.MirrorSourceConfig_Postgres{Postgres: &commonpb.PostgresMirrorSourceConfig{
+			Dsn: "postgres://ledger:mirror-postgres-secret@db.example/ledger",
+		}}},
+	}, []string{"mirror-oauth-secret", "mirror-postgres-secret"}
+}
+
+func addSinkOrder(config *commonpb.SinkConfig) *raftcmdpb.Order {
+	return &raftcmdpb.Order{Type: &raftcmdpb.Order_SystemScoped{SystemScoped: &raftcmdpb.SystemScopedOrder{
+		Payload: &raftcmdpb.SystemScopedOrder_AddEventsSink{AddEventsSink: &raftcmdpb.AddEventsSinkOrder{Config: config}},
+	}}}
+}
+
+func createLedgerOrder(source *commonpb.MirrorSourceConfig) *raftcmdpb.Order {
+	return &raftcmdpb.Order{Type: &raftcmdpb.Order_LedgerScoped{LedgerScoped: &raftcmdpb.LedgerScopedOrder{
+		Ledger: "mirror", Payload: &raftcmdpb.LedgerScopedOrder_CreateLedger{CreateLedger: &raftcmdpb.CreateLedgerOrder{MirrorSource: source}},
+	}}}
+}

--- a/internal/adapter/readprojection/config.go
+++ b/internal/adapter/readprojection/config.go
@@ -1,0 +1,362 @@
+// Package readprojection builds credential-safe public response copies without
+// changing the authoritative configurations or audit records held by callers.
+package readprojection
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+const (
+	redactedSecret     = "[redacted]"
+	redactedDiagnostic = "[redacted diagnostic]"
+)
+
+// Sink returns a deep copy of a sink with reusable credentials redacted.
+func Sink(config *commonpb.SinkConfig) *commonpb.SinkConfig {
+	out := config.CloneVT()
+	redactSink(out)
+
+	return out
+}
+
+// Mirror returns a deep copy of a mirror source with credentials redacted.
+func Mirror(config *commonpb.MirrorSourceConfig) *commonpb.MirrorSourceConfig {
+	out := config.CloneVT()
+	redactMirror(out)
+
+	return out
+}
+
+// Ledger preserves ledger metadata and mirror progress, while redacting source
+// credentials and the free-form mirror diagnostic, which can echo credentials.
+func Ledger(info *commonpb.LedgerInfo) *commonpb.LedgerInfo {
+	out := info.CloneVT()
+	if out == nil {
+		return nil
+	}
+	redactMirror(out.GetMirrorSource())
+	if progress := out.GetMirrorSyncProgress(); progress != nil && progress.GetError() != nil {
+		progress.Error.Message = redactedDiagnostic
+	}
+
+	return out
+}
+
+// SinkStatus preserves operational status, timestamps and cursor, while hiding
+// the free-form driver diagnostic, which can echo credentials from any config.
+func SinkStatus(status *commonpb.SinkStatus) *commonpb.SinkStatus {
+	out := status.CloneVT()
+	if out != nil && out.GetError() != nil {
+		out.Error.Message = redactedDiagnostic
+	}
+
+	return out
+}
+
+// redactSink only mutates the supplied projection. Its result says whether any
+// bytes changed, so an audit projection can retain untouched serialized orders.
+func redactSink(config *commonpb.SinkConfig) bool {
+	if config == nil {
+		return false
+	}
+	changed := false
+	switch source := config.GetType().(type) {
+	case *commonpb.SinkConfig_Nats:
+		if source.Nats != nil {
+			changed = replace(&source.Nats.Url, redactNATS(source.Nats.GetUrl()))
+		}
+	case *commonpb.SinkConfig_Clickhouse:
+		if source.Clickhouse != nil {
+			changed = replace(&source.Clickhouse.Dsn, redactURL(source.Clickhouse.GetDsn(), urlClickHouse))
+		}
+	case *commonpb.SinkConfig_Kafka:
+		if source.Kafka != nil {
+			changed = mask(&source.Kafka.SaslPassword)
+		}
+	case *commonpb.SinkConfig_Http:
+		if source.Http != nil {
+			changed = mask(&source.Http.Secret)
+			changed = replace(&source.Http.Endpoint, redactURL(source.Http.GetEndpoint(), urlHTTP)) || changed
+		}
+	case *commonpb.SinkConfig_Databricks:
+		if source.Databricks != nil {
+			switch auth := source.Databricks.GetAuth().(type) {
+			case *commonpb.DatabricksSinkConfig_Token:
+				changed = mask(&auth.Token)
+			case *commonpb.DatabricksSinkConfig_OauthM2M:
+				if auth.OauthM2M != nil {
+					changed = mask(&auth.OauthM2M.ClientSecret)
+				}
+			}
+		}
+	}
+
+	return changed
+}
+
+func redactMirror(config *commonpb.MirrorSourceConfig) bool {
+	if config == nil {
+		return false
+	}
+	changed := false
+	switch source := config.GetType().(type) {
+	case *commonpb.MirrorSourceConfig_Http:
+		if source.Http != nil {
+			changed = replace(&source.Http.BaseUrl, redactURL(source.Http.GetBaseUrl(), urlHTTP))
+			if auth := source.Http.GetOauth2ClientCredentials(); auth != nil {
+				changed = mask(&auth.ClientSecret) || changed
+				changed = replace(&auth.TokenEndpoint, redactURL(auth.GetTokenEndpoint(), urlHTTP)) || changed
+			}
+		}
+	case *commonpb.MirrorSourceConfig_Postgres:
+		if source.Postgres != nil {
+			dsn := source.Postgres.GetDsn()
+			if strings.HasPrefix(dsn, "postgres://") || strings.HasPrefix(dsn, "postgresql://") {
+				dsn = redactURL(dsn, urlPostgres)
+			} else {
+				dsn = redactPostgresKeywords(dsn)
+			}
+			changed = replace(&source.Postgres.Dsn, dsn)
+		}
+	}
+
+	return changed
+}
+
+func replace(target *string, value string) bool {
+	if *target == value {
+		return false
+	}
+	*target = value
+
+	return true
+}
+
+func mask(target *string) bool {
+	if *target == "" {
+		return false
+	}
+
+	return replace(target, redactedSecret)
+}
+
+type urlKind uint8
+
+const (
+	urlHTTP urlKind = iota
+	urlNATS
+	urlClickHouse
+	urlPostgres
+	urlProxy
+)
+
+func (kind urlKind) accepts(scheme string) bool {
+	switch kind {
+	case urlHTTP:
+		return scheme == "http" || scheme == "https"
+	case urlProxy:
+		return scheme == "http" || scheme == "https" || scheme == "socks5" || scheme == "socks5h"
+	case urlNATS:
+		return scheme == "nats" || scheme == "tls" || scheme == "ws" || scheme == "wss"
+	case urlClickHouse:
+		return scheme == "clickhouse" || scheme == "http" || scheme == "https"
+	case urlPostgres:
+		return scheme == "postgres" || scheme == "postgresql"
+	default:
+		return false
+	}
+}
+
+// redactURL fails closed on unparseable or unsupported addresses. HTTP query
+// values are opaque authentication material, regardless of parameter name.
+// Database parameters retain operational settings, with known credential fields
+// masked. Only changed URLs are re-encoded; untouched inputs remain byte-exact.
+func redactURL(raw string, kind urlKind) string {
+	if raw == "" || raw == redactedSecret {
+		return raw
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || (parsed.Host == "" && kind != urlPostgres) || parsed.Opaque != "" || !kind.accepts(parsed.Scheme) {
+		return redactedSecret
+	}
+	query, err := url.ParseQuery(parsed.RawQuery)
+	if err != nil {
+		return redactedSecret
+	}
+	changed := false
+	if parsed.User != nil {
+		password, hasPassword := parsed.User.Password()
+		if kind == urlHTTP || kind == urlNATS || kind == urlProxy {
+			// NATS also treats the username-only form as a bearer token.
+			if parsed.User.Username() != "" || password != "" {
+				if parsed.User.Username() != redactedSecret || hasPassword {
+					parsed.User = url.User(redactedSecret)
+					changed = true
+				}
+			}
+		} else if password != "" && password != redactedSecret {
+			parsed.User = url.UserPassword(parsed.User.Username(), redactedSecret)
+			changed = true
+		}
+	}
+	queryChanged := false
+	for key, values := range query {
+		for i, value := range values {
+			replacement := value
+			switch {
+			case kind == urlHTTP || kind == urlNATS || kind == urlProxy || strings.EqualFold(key, "password") || strings.EqualFold(key, "sslpassword"):
+				if value != "" {
+					replacement = redactedSecret
+				}
+			case kind == urlClickHouse && key == "http_proxy":
+				replacement = redactURL(value, urlProxy)
+			}
+			if replacement != value {
+				values[i] = replacement
+				queryChanged = true
+			}
+		}
+	}
+	if queryChanged {
+		parsed.RawQuery = query.Encode()
+		changed = true
+	}
+	if parsed.Fragment != "" && parsed.Fragment != redactedSecret {
+		parsed.Fragment = redactedSecret
+		parsed.RawFragment = ""
+		changed = true
+	}
+	if !changed {
+		return raw
+	}
+
+	return parsed.String()
+}
+
+func redactNATS(raw string) string {
+	if raw == "" || raw == redactedSecret {
+		return raw
+	}
+	servers := strings.Split(raw, ",")
+	for i, server := range servers {
+		address := strings.TrimSpace(server)
+		if address == "" {
+			return redactedSecret
+		}
+		hasScheme := strings.Contains(address, "://")
+		normalized := address
+		if !hasScheme {
+			normalized = "nats://" + address
+		}
+		projected := redactURL(normalized, urlNATS)
+		if projected == redactedSecret {
+			return redactedSecret
+		}
+		if projected == normalized {
+			continue
+		}
+		if !hasScheme {
+			projected = strings.TrimPrefix(projected, "nats://")
+		}
+		servers[i] = strings.Replace(server, address, projected, 1)
+	}
+
+	return strings.Join(servers, ",")
+}
+
+// redactPostgresKeywords follows the pinned pgx keyword/value lexical rules
+// (single quotes, backslash escapes and ASCII whitespace), without calling
+// ParseConfig: that API reads environment, service files and TLS files. Preserve
+// every non-credential substring verbatim; ambiguous/malformed input is hidden.
+func redactPostgresKeywords(raw string) string {
+	if raw == "" || raw == redactedSecret {
+		return raw
+	}
+	var out strings.Builder
+	written := 0
+	for position := 0; position < len(raw); {
+		for position < len(raw) && isKeywordSpace(raw[position]) {
+			position++
+		}
+		if position == len(raw) {
+			break
+		}
+		relativeEqual := strings.IndexByte(raw[position:], '=')
+		if relativeEqual < 0 {
+			return redactedSecret
+		}
+		equal := position + relativeEqual
+		key := strings.Trim(raw[position:equal], " \t\n\r\v\f")
+		if key == "" || strings.ContainsAny(key, " \t\n\r\v\f'\\:/") {
+			return redactedSecret
+		}
+		start := equal + 1
+		for start < len(raw) && isKeywordSpace(raw[start]) {
+			start++
+		}
+		end, content, ok := keywordValue(raw, start)
+		if !ok {
+			return redactedSecret
+		}
+		if (strings.EqualFold(key, "password") || strings.EqualFold(key, "sslpassword")) && content != "" && content != redactedSecret {
+			out.WriteString(raw[written:start])
+			if raw[start] == '\'' {
+				out.WriteByte('\'')
+				out.WriteString(redactedSecret)
+				out.WriteByte('\'')
+			} else {
+				out.WriteString(redactedSecret)
+			}
+			written = end
+		}
+		position = end
+		if position < len(raw) && isKeywordSpace(raw[position]) {
+			position++ // pgx consumes one delimiter after an unquoted value.
+		}
+	}
+	if written == 0 {
+		return raw
+	}
+	out.WriteString(raw[written:])
+
+	return out.String()
+}
+
+func keywordValue(raw string, start int) (end int, content string, ok bool) {
+	if start == len(raw) {
+		return start, "", true
+	}
+	quoted := raw[start] == '\''
+	position := start
+	if quoted {
+		position++
+	}
+	var value strings.Builder
+	for position < len(raw) {
+		character := raw[position]
+		if quoted && character == '\'' {
+			return position + 1, value.String(), true
+		}
+		if !quoted && isKeywordSpace(character) {
+			return position, value.String(), true
+		}
+		if character == '\\' {
+			position++
+			if position == len(raw) {
+				return 0, "", false
+			}
+			character = raw[position]
+		}
+		value.WriteByte(character)
+		position++
+	}
+
+	return position, value.String(), !quoted
+}
+
+func isKeywordSpace(character byte) bool {
+	return character == ' ' || character == '\t' || character == '\n' || character == '\r' || character == '\v' || character == '\f'
+}

--- a/internal/adapter/readprojection/config_test.go
+++ b/internal/adapter/readprojection/config_test.go
@@ -1,0 +1,329 @@
+package readprojection
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+func TestSink(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name    string
+		config  *commonpb.SinkConfig
+		secrets []string
+	}{
+		{"nil", nil, nil},
+		{"no variant", &commonpb.SinkConfig{Name: "unconfigured"}, nil},
+		{"nats", &commonpb.SinkConfig{Type: &commonpb.SinkConfig_Nats{Nats: &commonpb.NatsSinkConfig{Url: "nats://natsTokenSentinel@one:4222, user:natsPasswordSentinel@two:4222", Topic: "events"}}}, []string{"natsTokenSentinel", "natsPasswordSentinel"}},
+		{"clickhouse", &commonpb.SinkConfig{Type: &commonpb.SinkConfig_Clickhouse{Clickhouse: &commonpb.ClickHouseSinkConfig{Dsn: "clickhouse://reporter:clickhousePasswordSentinel@db:9000/events?password=clickhouseQuerySentinel&http_proxy=https%3A%2F%2FproxyUser%3AproxyPasswordSentinel%40proxy%3Fapi_key%3DproxyQuerySentinel&secure=true", Table: "events"}}}, []string{"clickhousePasswordSentinel", "clickhouseQuerySentinel", "proxyPasswordSentinel", "proxyQuerySentinel"}},
+		{"kafka", &commonpb.SinkConfig{Type: &commonpb.SinkConfig_Kafka{Kafka: &commonpb.KafkaSinkConfig{Brokers: []string{"broker:9092"}, Topic: "events", Tls: true, SaslMechanism: "PLAIN", SaslUsername: "writer", SaslPassword: "kafkaPasswordSentinel"}}}, []string{"kafkaPasswordSentinel"}},
+		{"http", &commonpb.SinkConfig{Type: &commonpb.SinkConfig_Http{Http: &commonpb.HttpSinkConfig{Endpoint: "https://user:httpPasswordSentinel@webhook/path?unusual=httpQuerySentinel", Secret: "hmacSecretSentinel"}}}, []string{"httpPasswordSentinel", "httpQuerySentinel", "hmacSecretSentinel"}},
+		{"databricks pat", &commonpb.SinkConfig{Type: &commonpb.SinkConfig_Databricks{Databricks: &commonpb.DatabricksSinkConfig{ServerHostname: "warehouse", HttpPath: "/sql/warehouse", Catalog: "catalog", Schema: "schema", Table: "events", Port: 443, Auth: &commonpb.DatabricksSinkConfig_Token{Token: "patSecretSentinel"}}}}, []string{"patSecretSentinel"}},
+		{"databricks oauth", &commonpb.SinkConfig{Type: &commonpb.SinkConfig_Databricks{Databricks: &commonpb.DatabricksSinkConfig{Auth: &commonpb.DatabricksSinkConfig_OauthM2M{OauthM2M: &commonpb.DatabricksOAuthM2M{ClientId: "client", ClientSecret: "databricksOAuthSentinel"}}}}}, []string{"databricksOAuthSentinel"}},
+		{"nil nats", &commonpb.SinkConfig{Type: &commonpb.SinkConfig_Nats{}}, nil},
+		{"nil clickhouse", &commonpb.SinkConfig{Type: &commonpb.SinkConfig_Clickhouse{}}, nil},
+		{"nil kafka", &commonpb.SinkConfig{Type: &commonpb.SinkConfig_Kafka{}}, nil},
+		{"nil http", &commonpb.SinkConfig{Type: &commonpb.SinkConfig_Http{}}, nil},
+		{"nil databricks", &commonpb.SinkConfig{Type: &commonpb.SinkConfig_Databricks{}}, nil},
+		{"nil oauth", &commonpb.SinkConfig{Type: &commonpb.SinkConfig_Databricks{Databricks: &commonpb.DatabricksSinkConfig{Auth: &commonpb.DatabricksSinkConfig_OauthM2M{}}}}, nil},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if test.config != nil {
+				test.config.Name = "named-sink"
+				test.config.Format = "protobuf"
+				test.config.BatchSize = 12
+				test.config.BatchDelayMs = 34
+				test.config.EventTypes = []commonpb.EventType{commonpb.EventType_COMMITTED_TRANSACTION}
+			}
+			before := test.config.CloneVT()
+			out := Sink(test.config)
+			require.True(t, proto.Equal(before, test.config), "input must remain authoritative")
+			require.True(t, proto.Equal(out, Sink(out)), "projection must be a fixed point")
+			assertNoSecrets(t, out, test.secrets)
+			if out != nil {
+				require.Equal(t, test.config.GetName(), out.GetName())
+				require.Equal(t, test.config.GetFormat(), out.GetFormat())
+				require.Equal(t, test.config.GetBatchSize(), out.GetBatchSize())
+				require.Equal(t, test.config.GetBatchDelayMs(), out.GetBatchDelayMs())
+				require.Equal(t, test.config.GetEventTypes(), out.GetEventTypes())
+				out.EventTypes[0] = commonpb.EventType_EVENT_TYPE_UNSPECIFIED
+				require.True(t, proto.Equal(before, test.config), "slices must be independently cloned")
+			}
+			projected := before.CloneVT()
+			require.Equal(t, len(test.secrets) != 0, redactSink(projected))
+			require.False(t, redactSink(projected), "already redacted data must leave signed bytes intact")
+		})
+	}
+}
+
+func TestMirror(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name    string
+		config  *commonpb.MirrorSourceConfig
+		secrets []string
+	}{
+		{"nil", nil, nil},
+		{"empty", &commonpb.MirrorSourceConfig{}, nil},
+		{"nil http", &commonpb.MirrorSourceConfig{Type: &commonpb.MirrorSourceConfig_Http{}}, nil},
+		{"nil postgres", &commonpb.MirrorSourceConfig{Type: &commonpb.MirrorSourceConfig_Postgres{}}, nil},
+		{"http", &commonpb.MirrorSourceConfig{Type: &commonpb.MirrorSourceConfig_Http{Http: &commonpb.HttpMirrorSourceConfig{BaseUrl: "https://user:mirrorBasicSentinel@source/v2?key=baseQuerySentinel", Oauth2ClientCredentials: &commonpb.OAuth2ClientCredentials{ClientId: "client", ClientSecret: "mirrorOAuthSentinel", TokenEndpoint: "https://tokenUser:tokenPasswordSentinel@auth/token?arbitrary=tokenQuerySentinel", Scopes: []string{"ledger:read"}}}}}, []string{"mirrorBasicSentinel", "baseQuerySentinel", "mirrorOAuthSentinel", "tokenPasswordSentinel", "tokenQuerySentinel"}},
+		{"postgres URI", &commonpb.MirrorSourceConfig{Type: &commonpb.MirrorSourceConfig_Postgres{Postgres: &commonpb.PostgresMirrorSourceConfig{Dsn: "postgres://reader:pgPasswordSentinel@database:5432/ledger?sslmode=require&password=pgQuerySentinel&sslpassword=tlsPasswordSentinel", AwsIamAuth: &commonpb.PostgresAwsIamAuth{Region: "eu-west-1", AssumeRoleArn: "role"}}}}, []string{"pgPasswordSentinel", "pgQuerySentinel", "tlsPasswordSentinel"}},
+		{"postgres keyword", &commonpb.MirrorSourceConfig{Type: &commonpb.MirrorSourceConfig_Postgres{Postgres: &commonpb.PostgresMirrorSourceConfig{Dsn: "host=database port=5432 dbname=ledger user=reader password='pgKeywordSentinel' sslmode=require"}}}, []string{"pgKeywordSentinel"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if test.config != nil {
+				test.config.LedgerName = "source-ledger"
+				test.config.BatchSize = 77
+			}
+			before := test.config.CloneVT()
+			out := Mirror(test.config)
+			require.True(t, proto.Equal(before, test.config))
+			require.True(t, proto.Equal(out, Mirror(out)))
+			assertNoSecrets(t, out, test.secrets)
+			if out != nil {
+				require.Equal(t, "source-ledger", out.GetLedgerName())
+				require.EqualValues(t, 77, out.GetBatchSize())
+				if pg := out.GetPostgres(); pg != nil {
+					require.True(t, proto.Equal(before.GetPostgres().GetAwsIamAuth(), pg.GetAwsIamAuth()))
+				}
+				if http := out.GetHttp(); http != nil && http.GetOauth2ClientCredentials() != nil {
+					require.Equal(t, "client", http.GetOauth2ClientCredentials().GetClientId())
+					require.Equal(t, []string{"ledger:read"}, http.GetOauth2ClientCredentials().GetScopes())
+					http.Oauth2ClientCredentials.Scopes[0] = "changed"
+					require.True(t, proto.Equal(before, test.config))
+				}
+			}
+			projected := before.CloneVT()
+			require.Equal(t, len(test.secrets) != 0, redactMirror(projected))
+			require.False(t, redactMirror(projected))
+		})
+	}
+}
+
+func TestLedgerAndSinkStatus(t *testing.T) {
+	t.Parallel()
+	require.Nil(t, Ledger(nil))
+	require.Nil(t, SinkStatus(nil))
+	for _, message := range []string{"", "transport error includes diagnosticSecretSentinel", redactedDiagnostic} {
+		t.Run(message, func(t *testing.T) {
+			t.Parallel()
+			info := &commonpb.LedgerInfo{
+				Name: "mirror", Id: 42,
+				Metadata:           map[string]*commonpb.MetadataValue{"label": {Type: &commonpb.MetadataValue_StringValue{StringValue: "keep"}}},
+				MirrorSyncProgress: &commonpb.MirrorSyncProgress{State: commonpb.MirrorSyncState_MIRROR_SYNC_STATE_FOLLOWING, Cursor: 4, SourceLogCount: 7, RemainingLogs: 3, Error: &commonpb.MirrorSyncError{Message: message, OccurredAt: &commonpb.Timestamp{Data: 17}}},
+				MirrorSource:       &commonpb.MirrorSourceConfig{Type: &commonpb.MirrorSourceConfig_Postgres{Postgres: &commonpb.PostgresMirrorSourceConfig{Dsn: "postgres://user:ledgerSecretSentinel@host/db"}}},
+			}
+			before := info.CloneVT()
+			out := Ledger(info)
+			require.True(t, proto.Equal(info, before))
+			require.Equal(t, redactedDiagnostic, out.GetMirrorSyncProgress().GetError().GetMessage())
+			require.EqualValues(t, 17, out.GetMirrorSyncProgress().GetError().GetOccurredAt().GetData())
+			require.Equal(t, before.GetMirrorSyncProgress().GetState(), out.GetMirrorSyncProgress().GetState())
+			require.Equal(t, before.GetMirrorSyncProgress().GetCursor(), out.GetMirrorSyncProgress().GetCursor())
+			require.Equal(t, before.GetMirrorSyncProgress().GetSourceLogCount(), out.GetMirrorSyncProgress().GetSourceLogCount())
+			require.Equal(t, before.GetMirrorSyncProgress().GetRemainingLogs(), out.GetMirrorSyncProgress().GetRemainingLogs())
+			require.Len(t, out.GetMetadata(), len(before.GetMetadata()))
+			for key, value := range before.GetMetadata() {
+				require.True(t, proto.Equal(value, out.GetMetadata()[key]), key)
+			}
+			require.Equal(t, before.GetName(), out.GetName())
+			require.Equal(t, before.GetId(), out.GetId())
+			assertNoSecrets(t, out, []string{"ledgerSecretSentinel", "diagnosticSecretSentinel"})
+			require.True(t, proto.Equal(out, Ledger(out)))
+			out.Metadata["label"].Type = &commonpb.MetadataValue_StringValue{StringValue: "changed"}
+			out.MirrorSyncProgress.Error.OccurredAt.Data = 99
+			require.True(t, proto.Equal(before, info))
+			status := &commonpb.SinkStatus{SinkName: "sink", Cursor: 33, Error: &commonpb.SinkError{Message: message, OccurredAt: &commonpb.Timestamp{Data: 17}}}
+			statusBefore := status.CloneVT()
+			projected := SinkStatus(status)
+			require.Equal(t, redactedDiagnostic, projected.GetError().GetMessage())
+			require.EqualValues(t, 17, projected.GetError().GetOccurredAt().GetData())
+			require.EqualValues(t, 33, projected.GetCursor())
+			require.Equal(t, "sink", projected.GetSinkName())
+			require.True(t, proto.Equal(projected, SinkStatus(projected)))
+			projected.Error.OccurredAt.Data = 99
+			require.True(t, proto.Equal(status, statusBefore))
+		})
+	}
+	require.Nil(t, Ledger(&commonpb.LedgerInfo{}).GetMirrorSyncProgress())
+	require.Nil(t, Ledger(&commonpb.LedgerInfo{MirrorSyncProgress: &commonpb.MirrorSyncProgress{}}).GetMirrorSyncProgress().GetError())
+	require.Nil(t, SinkStatus(&commonpb.SinkStatus{}).GetError())
+}
+
+func TestRedactURL(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name string
+		kind urlKind
+		raw  string
+		want string
+	}{
+		{"empty", urlHTTP, "", ""},
+		{"marker", urlHTTP, "[redacted]", "[redacted]"},
+		{"unchanged exact URL", urlHTTP, "https://host/a%2Fb?empty&another=", "https://host/a%2Fb?empty&another="},
+		{"HTTP password", urlHTTP, "https://user:secret@host/path", "https://%5Bredacted%5D@host/path"},
+		{"HTTP token", urlHTTP, "https://token@host/path", "https://%5Bredacted%5D@host/path"},
+		{"HTTP empty userinfo", urlHTTP, "https://:@host/path", "https://:@host/path"},
+		{"HTTP arbitrary queries", urlHTTP, "https://host/path?k=first&k=second&empty=&other=third", "https://host/path?empty=&k=%5Bredacted%5D&k=%5Bredacted%5D&other=%5Bredacted%5D"},
+		{"postgres userinfo", urlPostgres, "postgres://reader:secret@host:5432/ledger?sslmode=require", "postgres://reader:%5Bredacted%5D@host:5432/ledger?sslmode=require"},
+		{"postgres query", urlPostgres, "postgresql://reader@host/ledger?password=one&password=two&sslpassword=three&sslmode=require", "postgresql://reader@host/ledger?password=%5Bredacted%5D&password=%5Bredacted%5D&sslmode=require&sslpassword=%5Bredacted%5D"},
+		{"postgres Unix socket", urlPostgres, "postgres:///ledger?host=%2Fvar%2Frun%2Fpostgresql&password=secret&sslmode=disable", "postgres:///ledger?host=%2Fvar%2Frun%2Fpostgresql&password=%5Bredacted%5D&sslmode=disable"},
+		{"postgres multiple hosts", urlPostgres, "postgres://reader:secret@host1:5432,host2:5433/ledger?options=-c+search_path%3Dledger&sslmode=require", "postgres://reader:%5Bredacted%5D@host1:5432,host2:5433/ledger?options=-c+search_path%3Dledger&sslmode=require"},
+		{"postgres empty password", urlPostgres, "postgres://reader:@host/db?password=&sslpassword=", "postgres://reader:@host/db?password=&sslpassword="},
+		{"unchanged DB operational query", urlPostgres, "postgres://reader@host/db?sslmode=require&sslkey=%2Fkey&connect_timeout=10", "postgres://reader@host/db?sslmode=require&sslkey=%2Fkey&connect_timeout=10"},
+		{"clickhouse userinfo", urlClickHouse, "clickhouse://writer:secret@host/db?secure=true", "clickhouse://writer:%5Bredacted%5D@host/db?secure=true"},
+		{"clickhouse query", urlClickHouse, "clickhouse://host/db?password=one&secure=true", "clickhouse://host/db?password=%5Bredacted%5D&secure=true"},
+		{"invalid escape", urlHTTP, "https://user:%zz@host", "[redacted]"},
+		{"invalid query", urlHTTP, "https://host?key=%xx", "[redacted]"},
+		{"invalid query semicolon", urlHTTP, "https://host?key=one;other=two", "[redacted]"},
+		{"opaque URL", urlHTTP, "https:secret", "[redacted]"},
+		{"missing scheme", urlHTTP, "user:secret@host", "[redacted]"},
+		{"unsupported scheme", urlHTTP, "ftp://user:secret@host", "[redacted]"},
+		{"fragment", urlHTTP, "https://host/path#secret", "https://host/path#%5Bredacted%5D"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := redactURL(test.raw, test.kind)
+			require.Equal(t, test.want, got)
+			require.Equal(t, got, redactURL(got, test.kind))
+		})
+	}
+}
+
+func TestClickHouseProxy(t *testing.T) {
+	t.Parallel()
+	for _, proxy := range []string{"https://user:proxySentinel@proxy:8080/path?custom=querySentinel", "https://proxy/path?token=querySentinel", "socks5://user:proxySentinel@proxy:1080", "socks5h://user:proxySentinel@proxy:1080", "invalid proxySentinel"} {
+		t.Run(proxy, func(t *testing.T) {
+			t.Parallel()
+			raw := "clickhouse://reader@db/events?http_proxy=" + url.QueryEscape(proxy) + "&secure=true"
+			got := redactURL(raw, urlClickHouse)
+			require.NotContains(t, got, "proxySentinel")
+			require.NotContains(t, got, "querySentinel")
+			parsed, err := url.Parse(got)
+			require.NoError(t, err)
+			require.Equal(t, "db", parsed.Host)
+			require.Equal(t, "/events", parsed.Path)
+			require.Equal(t, "true", parsed.Query().Get("secure"))
+			require.Equal(t, got, redactURL(got, urlClickHouse))
+		})
+	}
+}
+
+func TestRedactNATS(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct{ raw, want string }{
+		{"", ""},
+		{"[redacted]", "[redacted]"},
+		{"nats://host:4222, other:4222", "nats://host:4222, other:4222"},
+		{"nats://token@host:4222", "nats://%5Bredacted%5D@host:4222"},
+		{"token@host:4222", "%5Bredacted%5D@host:4222"},
+		{"user:password@host:4222", "%5Bredacted%5D@host:4222"},
+		{"nats://user:password@one:4222, token@two:4222 ,tls://user:password@three:4222", "nats://%5Bredacted%5D@one:4222, %5Bredacted%5D@two:4222 ,tls://%5Bredacted%5D@three:4222"},
+		{"wss://user:password@host/path?token=value", "wss://%5Bredacted%5D@host/path?token=%5Bredacted%5D"},
+		{"nats://host:4222,", "[redacted]"},
+		{"nats://user:%zz@host:4222", "[redacted]"},
+	} {
+		t.Run(test.raw, func(t *testing.T) {
+			t.Parallel()
+			got := redactNATS(test.raw)
+			require.Equal(t, test.want, got)
+			require.Equal(t, got, redactNATS(got))
+		})
+	}
+}
+
+func TestRedactPostgresKeywords(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct{ raw, want string }{
+		{"", ""},
+		{"[redacted]", "[redacted]"},
+		{"host=database dbname=ledger user=reader sslmode=require", "host=database dbname=ledger user=reader sslmode=require"},
+		{"host=database password=secret   \t\n", "host=database password=[redacted]   \t\n"},
+		{"host=database dbname=ledger   \t", "host=database dbname=ledger   \t"},
+		{"host = database password = secret dbname = ledger", "host = database password = [redacted] dbname = ledger"},
+		{"host=database password='with spaces' dbname='ledger space'", "host=database password='[redacted]' dbname='ledger space'"},
+		{`host=database password='with \'quote and \\slash' dbname=ledger`, `host=database password='[redacted]' dbname=ledger`},
+		{`host=database password=escaped\ space dbname=ledger`, `host=database password=[redacted] dbname=ledger`},
+		{"password=one\tsslpassword='two'\npassword=three", "password=[redacted]\tsslpassword='[redacted]'\npassword=[redacted]"},
+		{"password='' host=database sslpassword=", "password='' host=database sslpassword="},
+		{"password='[redacted]' host=database", "password='[redacted]' host=database"},
+		{"password=[redacted] host=database", "password=[redacted] host=database"},
+		{"password='one'host=database", "password='[redacted]'host=database"},
+		{"host=database password='unterminated", "[redacted]"},
+		{"host=database password=trailing\\", "[redacted]"},
+		{"host=database password='trailing\\", "[redacted]"},
+		{"host=database password=secret invalid", "[redacted]"},
+		{"=secret", "[redacted]"},
+		{"unknown://user:secret@host", "[redacted]"},
+		{"https://host?password=secret", "[redacted]"},
+	} {
+		t.Run(test.raw, func(t *testing.T) {
+			t.Parallel()
+			got := redactPostgresKeywords(test.raw)
+			require.Equal(t, test.want, got)
+			require.Equal(t, got, redactPostgresKeywords(got))
+		})
+	}
+}
+
+func TestEmptySecretsPreserveBytes(t *testing.T) {
+	t.Parallel()
+	for _, config := range []*commonpb.SinkConfig{
+		{Type: &commonpb.SinkConfig_Kafka{Kafka: &commonpb.KafkaSinkConfig{SaslUsername: "writer"}}},
+		{Type: &commonpb.SinkConfig_Http{Http: &commonpb.HttpSinkConfig{Endpoint: "https://host/path?empty="}}},
+		{Type: &commonpb.SinkConfig_Databricks{Databricks: &commonpb.DatabricksSinkConfig{Auth: &commonpb.DatabricksSinkConfig_Token{}}}},
+		{Type: &commonpb.SinkConfig_Databricks{Databricks: &commonpb.DatabricksSinkConfig{Auth: &commonpb.DatabricksSinkConfig_OauthM2M{OauthM2M: &commonpb.DatabricksOAuthM2M{ClientId: "client"}}}}},
+	} {
+		before, err := proto.Marshal(config)
+		require.NoError(t, err)
+		require.False(t, redactSink(config))
+		after, err := proto.Marshal(config)
+		require.NoError(t, err)
+		require.Equal(t, before, after)
+	}
+	mirror := &commonpb.MirrorSourceConfig{Type: &commonpb.MirrorSourceConfig_Http{Http: &commonpb.HttpMirrorSourceConfig{BaseUrl: "https://host", Oauth2ClientCredentials: &commonpb.OAuth2ClientCredentials{ClientId: "client", TokenEndpoint: "https://host/token"}}}}
+	require.False(t, redactMirror(mirror))
+}
+
+func TestConfigVariantCoverage(t *testing.T) {
+	t.Parallel()
+	// Changing a sensitive union requires deliberately extending this package's
+	// redactor and fixtures, rather than accidentally introducing a fail-open arm.
+	for _, test := range []struct {
+		message proto.Message
+		oneof   string
+		fields  []string
+	}{
+		{&commonpb.SinkConfig{}, "type", []string{"nats", "clickhouse", "kafka", "http", "databricks"}},
+		{&commonpb.DatabricksSinkConfig{}, "auth", []string{"token", "oauth_m2m"}},
+		{&commonpb.MirrorSourceConfig{}, "type", []string{"http", "postgres"}},
+	} {
+		fields := test.message.ProtoReflect().Descriptor().Oneofs().Get(0).Fields()
+		var names []string
+		for i := range fields.Len() {
+			names = append(names, string(fields.Get(i).Name()))
+		}
+		require.Equal(t, test.fields, names, test.oneof)
+	}
+}
+
+func assertNoSecrets(t *testing.T, message proto.Message, secrets []string) {
+	t.Helper()
+	wire, err := proto.Marshal(message)
+	require.NoError(t, err)
+	json, err := protojson.Marshal(message)
+	require.NoError(t, err)
+	for _, secret := range secrets {
+		require.NotContains(t, string(wire), secret)
+		require.NotContains(t, string(json), secret)
+	}
+}

--- a/internal/adapter/readprojection/wire.go
+++ b/internal/adapter/readprojection/wire.go
@@ -1,0 +1,167 @@
+package readprojection
+
+import (
+	"errors"
+	"slices"
+
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+// validateCredentialWire protects opaque evidence from protobuf's last-value
+// semantics. An earlier credential can disappear from the decoded message
+// while remaining in its original bytes. Reject conflicting occurrences only
+// when one contains a value the ordinary credential policy would redact.
+// Unrelated duplicate fields and noncanonical encodings remain byte-exact.
+func validateCredentialWire(data []byte, message proto.Message) error {
+	descriptor := message.ProtoReflect().Descriptor()
+	relevant := credentialWireAncestors(descriptor)
+	_, err := walkCredentialWire(data, descriptor, relevant, credentialWirePath{}, 0)
+
+	return err
+}
+
+// Derive the relevant schema paths, rather than maintaining another list of
+// request/order/log variants beside the generated schema. Cycles in unrelated
+// query and business messages are visited once and are not walked on the wire.
+func credentialWireAncestors(root protoreflect.MessageDescriptor) map[protoreflect.FullName]bool {
+	reverse := map[protoreflect.FullName][]protoreflect.FullName{}
+	seen := map[protoreflect.FullName]bool{}
+	var visit func(protoreflect.MessageDescriptor)
+	visit = func(desc protoreflect.MessageDescriptor) {
+		if seen[desc.FullName()] {
+			return
+		}
+		seen[desc.FullName()] = true
+		for i := range desc.Fields().Len() {
+			if child := desc.Fields().Get(i).Message(); child != nil {
+				reverse[child.FullName()] = append(reverse[child.FullName()], desc.FullName())
+				visit(child)
+			}
+		}
+	}
+	visit(root)
+	relevant := map[protoreflect.FullName]bool{}
+	queue := []protoreflect.FullName{"common.SinkConfig", "common.MirrorSourceConfig"}
+	for len(queue) > 0 {
+		name := queue[0]
+		queue = queue[1:]
+		if relevant[name] {
+			continue
+		}
+		relevant[name] = true
+		queue = append(queue, reverse[name]...)
+	}
+
+	return relevant
+}
+
+type credentialWirePath struct {
+	root   protoreflect.FullName
+	fields []protowire.Number
+}
+
+type credentialWireOccurrence struct {
+	count     int
+	sensitive bool
+}
+
+func walkCredentialWire(data []byte, desc protoreflect.MessageDescriptor, relevant map[protoreflect.FullName]bool, path credentialWirePath, depth int) (bool, error) {
+	// Credential configurations have shallow schemas. Bound malformed or
+	// recursively encoded input independently of the decoder's recursion limit.
+	if depth > 100 {
+		return false, errors.New("credential container exceeds wire nesting limit")
+	}
+	if desc.FullName() == "common.SinkConfig" || desc.FullName() == "common.MirrorSourceConfig" {
+		path = credentialWirePath{root: desc.FullName()}
+	}
+	fields := map[protoreflect.FieldNumber]credentialWireOccurrence{}
+	oneofs := map[protoreflect.FullName]credentialWireOccurrence{}
+	anySensitive := false
+	for len(data) > 0 {
+		number, kind, tagSize := protowire.ConsumeTag(data)
+		if tagSize < 0 {
+			return false, errors.New("invalid credential container wire tag")
+		}
+		valueSize := protowire.ConsumeFieldValue(number, kind, data[tagSize:])
+		if valueSize < 0 {
+			return false, errors.New("invalid credential container wire value")
+		}
+		raw := data[:tagSize+valueSize]
+		value := data[tagSize : tagSize+valueSize]
+		data = data[tagSize+valueSize:]
+		field := desc.Fields().ByNumber(number)
+		if field == nil {
+			continue // Unknown fields are not credential fields in this contract.
+		}
+		sensitive := false
+		if child := field.Message(); child != nil && (path.root != "" || relevant[child.FullName()]) {
+			if kind != protowire.BytesType {
+				return false, errors.New("invalid credential message wire type")
+			}
+			body, n := protowire.ConsumeBytes(value)
+			if n < 0 {
+				return false, errors.New("invalid credential message wire bytes")
+			}
+			childPath := credentialWirePath{root: path.root, fields: append(append([]protowire.Number(nil), path.fields...), number)}
+			var err error
+			sensitive, err = walkCredentialWire(body, child, relevant, childPath, depth+1)
+			if err != nil {
+				return false, err
+			}
+		} else if path.root != "" && field.Message() == nil {
+			var err error
+			sensitive, err = credentialWireLeafChanges(raw, path)
+			if err != nil {
+				return false, err
+			}
+		}
+		anySensitive = anySensitive || sensitive
+		if !field.IsList() && !field.IsMap() {
+			previous := fields[number]
+			if previous.count > 0 && (previous.sensitive || sensitive) {
+				return false, errors.New("shadowed credential in repeated singular protobuf field")
+			}
+			fields[number] = credentialWireOccurrence{count: previous.count + 1, sensitive: previous.sensitive || sensitive}
+		}
+		if oneof := field.ContainingOneof(); oneof != nil {
+			previous := oneofs[oneof.FullName()]
+			if previous.count > 0 && (previous.sensitive || sensitive) {
+				return false, errors.New("shadowed credential in repeated protobuf oneof")
+			}
+			oneofs[oneof.FullName()] = credentialWireOccurrence{count: previous.count + 1, sensitive: previous.sensitive || sensitive}
+		}
+	}
+
+	return anySensitive, nil
+}
+
+// Rebuild only the wrappers leading to this occurrence. Running the existing
+// configuration policy on that leaf reveals shadowed values without duplicating
+// the URL, DSN, OAuth, or sink credential rules in a second implementation.
+func credentialWireLeafChanges(raw []byte, path credentialWirePath) (bool, error) {
+	for _, v := range slices.Backward(path.fields) {
+		raw = protowire.AppendBytes(protowire.AppendTag(nil, v, protowire.BytesType), raw)
+	}
+	switch path.root {
+	case "common.SinkConfig":
+		config := &commonpb.SinkConfig{}
+		if err := config.UnmarshalVT(raw); err != nil {
+			return false, errors.New("invalid sink credential wire field")
+		}
+
+		return redactSink(config), nil
+	case "common.MirrorSourceConfig":
+		config := &commonpb.MirrorSourceConfig{}
+		if err := config.UnmarshalVT(raw); err != nil {
+			return false, errors.New("invalid mirror credential wire field")
+		}
+
+		return redactMirror(config), nil
+	default:
+		return false, errors.New("unknown credential wire container")
+	}
+}

--- a/internal/adapter/readprojection/wire_test.go
+++ b/internal/adapter/readprojection/wire_test.go
@@ -1,0 +1,160 @@
+package readprojection
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/formancehq/ledger/v3/internal/proto/auditpb"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/internal/proto/signaturepb"
+)
+
+func TestCredentialWireRejectsShadowedRequestVariants(t *testing.T) {
+	t.Parallel()
+	sinks, _ := secretBearingSinkConfigs()
+	mirrors, _ := secretBearingMirrorSources()
+	var requests []*servicepb.Request
+	for _, sink := range sinks {
+		requests = append(requests, &servicepb.Request{Type: &servicepb.Request_AddEventsSink{
+			AddEventsSink: &servicepb.AddEventsSinkRequest{Config: sink},
+		}})
+	}
+	for _, mirror := range mirrors {
+		requests = append(requests, &servicepb.Request{Type: &servicepb.Request_CreateLedger{
+			CreateLedger: &servicepb.CreateLedgerRequest{MirrorSource: mirror},
+		}})
+	}
+	last := wireMarshal(t, &servicepb.Request{Type: &servicepb.Request_RemoveEventsSink{
+		RemoveEventsSink: &servicepb.RemoveEventsSinkRequest{Name: "sink"},
+	}})
+	for _, request := range requests {
+		first := wireMarshal(t, request)
+		payload := wireMessage(1, append(first, last...))
+		original := bytes.Clone(payload)
+		decoded := &servicepb.ApplyBatch{}
+		require.NoError(t, decoded.UnmarshalVT(payload), "fixture must be accepted protobuf")
+		require.NotNil(t, decoded.GetRequests()[0].GetRemoveEventsSink(), "prove secret branch is shadowed")
+		require.ErrorContains(t, validateCredentialWire(payload, &servicepb.ApplyBatch{}), "shadowed credential")
+		result, err := Audit(&auditpb.AuditEntry{Signature: &signaturepb.SignedApplyBatch{Payload: payload}})
+		require.ErrorContains(t, err, "shadowed credential")
+		require.Nil(t, result, "public projection must not return shadowed bytes")
+		require.Equal(t, original, payload, "wire validation must preserve authoritative bytes")
+	}
+}
+
+func TestCredentialWireRejectsShadowedScalarAndConfigOneof(t *testing.T) {
+	t.Parallel()
+
+	// A repeated secret with an empty final value is invisible after decoding.
+	doubledSecret := append(wireString(2, "hidden-webhook-key"), wireString(2, "")...)
+	sink := wireMessage(5, doubledSecret) // SinkConfig.http
+	decodedSink := &commonpb.SinkConfig{}
+	require.NoError(t, decodedSink.UnmarshalVT(sink))
+	require.Empty(t, decodedSink.GetHttp().GetSecret())
+	require.ErrorContains(t, validateCredentialWire(sink, decodedSink), "shadowed credential")
+
+	// The same shape through MirrorSourceConfig.http.oauth2_client_credentials.
+	oauth := append(wireString(2, "hidden-oauth-key"), wireString(2, "")...)
+	mirror := wireMessage(2, wireMessage(2, oauth))
+	decodedMirror := &commonpb.MirrorSourceConfig{}
+	require.NoError(t, decodedMirror.UnmarshalVT(mirror))
+	require.Empty(t, decodedMirror.GetHttp().GetOauth2ClientCredentials().GetClientSecret())
+	require.ErrorContains(t, validateCredentialWire(mirror, decodedMirror), "shadowed credential")
+
+	// A different config oneof arm can hide an entire credential subtree.
+	sink = append(wireMessage(5, wireString(2, "hidden-webhook-key")), wireMessage(4, nil)...)
+	require.NoError(t, decodedSink.UnmarshalVT(sink))
+	require.NotNil(t, decodedSink.GetKafka())
+	require.ErrorContains(t, validateCredentialWire(sink, decodedSink), "shadowed credential")
+
+	// And a parent singular message can carry the hidden occurrence.
+	firstHTTP := wireMessage(2, wireString(2, "hidden-oauth-key"))
+	lastHTTP := wireMessage(2, wireString(2, ""))
+	mirror = append(wireMessage(2, firstHTTP), wireMessage(2, lastHTTP)...)
+	require.ErrorContains(t, validateCredentialWire(mirror, &commonpb.MirrorSourceConfig{}), "shadowed credential")
+}
+
+func TestCredentialWireCoversOrdersAndSignedLogPayloads(t *testing.T) {
+	t.Parallel()
+	config := &commonpb.SinkConfig{Type: &commonpb.SinkConfig_Http{
+		Http: &commonpb.HttpSinkConfig{Secret: "hidden-key"},
+	}}
+	order := wireMarshal(t, addSinkOrder(config))
+	// Order.system_scoped followed by Order.ledger_scoped loses the system arm.
+	order = append(order, wireMessage(1, wireString(1, "ledger"))...)
+	require.ErrorContains(t, validateCredentialWire(order, &raftcmdpb.Order{}), "shadowed credential")
+	entry, err := Audit(&auditpb.AuditEntry{Items: []*auditpb.AuditItem{{SerializedOrder: order}}})
+	require.ErrorContains(t, err, "shadowed credential")
+	require.Nil(t, entry)
+
+	logPayload := append(wireMessage(7, wireMessage(1, wireMarshal(t, config))), wireMessage(2, nil)...)
+	log := wireMessage(2, logPayload)
+	decoded := &commonpb.Log{}
+	require.NoError(t, decoded.UnmarshalVT(log))
+	require.NotNil(t, decoded.GetPayload().GetDeleteLedger())
+	require.ErrorContains(t, validateCredentialWire(log, decoded), "shadowed credential")
+	projected, err := Log(&commonpb.Log{ResponseSignature: &signaturepb.SignedLog{Payload: log}})
+	require.ErrorContains(t, err, "shadowed credential")
+	require.Nil(t, projected)
+}
+
+func TestCredentialWirePreservesUnrelatedDuplicateFields(t *testing.T) {
+	t.Parallel()
+	for _, secret := range []string{"", "visible-key"} {
+		t.Run(secret, func(t *testing.T) {
+			t.Parallel()
+			// Duplicate endpoint-free name fields do not obscure the secret.
+			sink := append(wireString(1, "first"), wireString(1, "last")...)
+			sink = append(sink, wireMessage(5, wireString(2, secret))...)
+			request := wireMessage(7, wireMessage(1, sink))
+			payload := wireMessage(1, request)
+			// Duplicate unrelated batch identity also remains supported.
+			payload = append(payload, wireString(2, "first-id")...)
+			payload = append(payload, wireString(2, "last-id")...)
+			original := bytes.Clone(payload)
+			require.NoError(t, validateCredentialWire(payload, &servicepb.ApplyBatch{}))
+			require.Equal(t, original, payload)
+		})
+	}
+	// Even duplicate request oneofs are safe when neither arm has credentials.
+	first := wireMessage(7, wireMessage(1, wireMessage(5, nil)))
+	last := wireMessage(8, wireString(1, "sink"))
+	require.NoError(t, validateCredentialWire(wireMessage(1, append(first, last...)), &servicepb.ApplyBatch{}))
+	unchanged := &auditpb.AuditEntry{Signature: &signaturepb.SignedApplyBatch{Payload: wireMessage(1, append(first, last...)), Signature: []byte("unchanged-proof")}}
+	projected, err := Audit(unchanged)
+	require.NoError(t, err)
+	require.True(t, proto.Equal(unchanged, projected), "non-secret duplicate encodings retain exact evidence")
+
+	// Repeated requests are legitimate, including credential-bearing requests.
+	request := wireMessage(1, wireMessage(7, wireMessage(1, wireMessage(5, wireString(2, "key")))))
+	require.NoError(t, validateCredentialWire(append(bytes.Clone(request), request...), &servicepb.ApplyBatch{}))
+}
+
+func TestCredentialWireRejectsMalformedContainersWithoutEchoingBytes(t *testing.T) {
+	t.Parallel()
+	for _, payload := range [][]byte{{0xff}, {0x0a, 0xff}, wireMessage(1, []byte{0xff})} {
+		require.Error(t, validateCredentialWire(payload, &servicepb.ApplyBatch{}))
+	}
+}
+
+func wireMarshal(t *testing.T, message proto.Message) []byte {
+	t.Helper()
+	raw, err := proto.Marshal(message)
+	require.NoError(t, err)
+
+	return raw
+}
+
+func wireMessage(number protowire.Number, body []byte) []byte {
+	return protowire.AppendBytes(protowire.AppendTag(nil, number, protowire.BytesType), body)
+}
+
+func wireString(number protowire.Number, value string) []byte {
+	return wireMessage(number, []byte(value))
+}

--- a/openapi.yml
+++ b/openapi.yml
@@ -2248,7 +2248,10 @@ paths:
       summary: Get a single system log by bucket-wide sequence
       description: |
         Returns the system log entry with the given bucket-wide sequence number.
-        Requires `ledger:OpsRead` scope.
+        Requires `ledger:OpsRead` scope. Sink and mirror credentials in creation
+        payloads are masked on deep clones; stored logs remain unchanged. A
+        modified signed response payload is a display projection and omits its
+        cryptographic signature.
       operationId: getLog
       tags:
         - Logs
@@ -2295,7 +2298,9 @@ paths:
       summary: List configured event sinks
       description: |
         Returns every event sink configured on the cluster. Requires
-        `ledger:OpsRead` scope.
+        `ledger:OpsRead` scope. Reusable credentials are masked in deep-cloned
+        display configurations. Sink error messages are masked because driver
+        diagnostics can contain credentials; error timestamps and cursors remain.
       operationId: getEventsSinks
       tags:
         - Ops
@@ -2322,14 +2327,14 @@ paths:
                         type: array
                         items:
                           type: object
-                          description: SinkConfig (protobuf JSON representation)
+                          description: SinkConfig display projection (protobuf JSON), with reusable credentials masked
                       sinkStatuses:
                         type: array
                         items:
                           type: object
                           description: >
                             SinkStatus (protobuf JSON representation): per-sink
-                            error status and last-emitted cursor.
+                            error status and last-emitted cursor. Error messages are masked; timestamps remain.
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':
@@ -3278,11 +3283,11 @@ components:
 
     MirrorSyncError:
       type: object
-      description: Most recent mirror sync error (null if healthy)
+      description: Most recent mirror sync error (null if healthy); diagnostic message is masked in read responses
       properties:
         message:
           type: string
-          description: Error message
+          description: Masked transport diagnostic; preserves error presence without exposing credentials
         occurredAt:
           type: string
           format: date-time
@@ -4388,7 +4393,11 @@ components:
 
     MirrorSourceConfig:
       type: object
-      description: Configuration for the mirror source (required when mode is MIRROR)
+      description: >
+        Configuration for the mirror source (required when mode is MIRROR).
+        Write requests accept credentials; read responses mask OAuth secrets,
+        URL userinfo/query values, and PostgreSQL passwords. Read connection
+        strings are display projections, not reusable configuration.
       required:
         - ledgerName
       properties:
@@ -5450,6 +5459,8 @@ components:
     AuditEntry:
       type: object
       description: |
+        Deep-cloned audit display projection. Persisted evidence is unchanged.
+        Sink/mirror credentials are masked inside order and signed batch bytes.
         A single audit trail entry for a proposal (success or failure). Exactly
         one of `success` / `failure` is set. `items` is populated only by the
         single-entry lookup, not by the list endpoint.
@@ -5486,7 +5497,9 @@ components:
             type: string
         hash:
           type: string
-          description: Hex-encoded batch integrity hash chaining audit entries
+          description: >
+            Hex-encoded integrity hash of the original stored audit entry.
+            It cannot be recomputed from a response containing redacted credentials.
         hashVersion:
           type: integer
           format: uint32
@@ -5499,7 +5512,11 @@ components:
           description: Batch identity / idempotency information (protobuf JSON)
         signature:
           type: object
-          description: Client signature over the ApplyBatch (protobuf JSON); absent for unsigned batches
+          description: >
+            Client signing envelope (protobuf JSON); absent for unsigned batches.
+            Payload credentials are redacted. Key identity remains, but signature
+            bytes are omitted when the signed payload changes. Unchanged payloads
+            and signatures retain their exact original bytes.
 
     AuditItem:
       type: object
@@ -5511,7 +5528,10 @@ components:
           description: Zero-based position of this order within the proposal
         serializedOrder:
           type: string
-          description: Hex-encoded deterministic serialized bytes of the order at apply time
+          description: >
+            Hex-encoded order bytes with sink/mirror credentials redacted.
+            Unchanged orders retain their exact original encoding; changed bytes
+            are display projections and cannot reproduce the original audit hash.
         logSequence:
           type: integer
           format: uint64

--- a/pkg/grpcprotocol/protocol.go
+++ b/pkg/grpcprotocol/protocol.go
@@ -12,7 +12,7 @@ const (
 	// Version must change when the client-facing wire format or semantics break.
 	// See docs/technical/architecture/subsystems/api/protocol-compatibility.md.
 	// A compiled constant also identifies local builds without release ldflags.
-	Version = "5"
+	Version = "6"
 	// MetadataKey carries the protocol version, not authentication credentials.
 	MetadataKey = "ledger-protocol-version"
 )

--- a/pkg/grpcprotocol/protocol.go
+++ b/pkg/grpcprotocol/protocol.go
@@ -9,10 +9,11 @@ import (
 )
 
 const (
-	// Version must change when the client-facing wire format or semantics break.
+	// Version tracks breaking changes to exposed protobuf messages and RPCs.
+	// Response-value changes alone do not require a new revision.
 	// See docs/technical/architecture/subsystems/api/protocol-compatibility.md.
 	// A compiled constant also identifies local builds without release ldflags.
-	Version = "6"
+	Version = "5"
 	// MetadataKey carries the protocol version, not authentication credentials.
 	MetadataKey = "ledger-protocol-version"
 )


### PR DESCRIPTION
## What changed

HTTP and gRPC read responses now mask sink and mirror credentials in live configuration, historical creation logs, serialized audit orders, and signed payloads. A shared deep-clone projection also hides transport diagnostics that can repeat credentials, while preserving status timestamps, pagination, and operational settings.

Unchanged audit bytes and signatures remain exact. Changed signed payloads retain key identity but omit the invalidated signature; malformed or shadowed credential fields fail the read. Service protocol revision remains 5: protobuf messages and RPC definitions are compatible. The repository policy now reserves bumps primarily for breaking protobuf/RPC changes; non-schema bumps require a concrete interoperability failure.

## Why

Fixes EN-1632, EN-1634, and EN-1635. EN-1796 was closed as a duplicate of EN-1632, with qualification evidence attached.

At base `37ccf5238ed460e0df2b9844869bdb9c7031f532`, deterministic HTTP/gRPC tests reproduced the leaks under read scopes, including decoded hex/base64 audit bytes and a transport error containing an endpoint credential. Previous PRs #1651, #1653, #1654, and #1703 were closed without merging; their proposed fixes are absent from this base.

## Product / operational motivation

Read scopes must expose status and history without granting reusable connector credentials, including credentials retained after rotation or removal. Persisted configuration, accepted orders, audit evidence, workers, and backups must retain their original bytes and behavior.

The requirement and its verification tradeoff are recorded in `docs/technical/architecture/subsystems/api/secret-redaction.md`. Regression tests cover transport boundaries, real checkpoint reads, production audit-hash computation, and Ed25519 verification.

## Technical decision

Apply one field policy immediately before HTTP serialization or gRPC stream emission, after controller/checkpoint selection. Deep clones avoid changing shared runtime objects or audit capture. A schema-aware wire guard detects credential fields hidden by protobuf last-value semantics before preserving opaque evidence.

Client-only formatting or live-configuration-only redaction leaves alternate transports and historical bytes exposed. Mutating storage would alter authoritative evidence and operational credentials. A new privileged raw-read API is outside this change.

## Risk

**MEDIUM** — deliberate read-contract change: returned credential-bearing audit payloads are display projections, and status diagnostics become a fixed marker. Existing revision-5 clients remain admitted and can decode responses; audit-verification consumers must account for redacted evidence.

## Validation

Policy follow-up (`f146fb085`): `bash scripts/agent-check`, normalization/lint, and the HTTP/gRPC/projection race tests pass. The exact merge-base `agent-check-pr` rerun fails on local timing fixtures in `tests/antithesis` and `scripts/internal/testenv`; both unchanged packages pass isolated under race (`-p 1 -parallel 1`, 32.261s and 1.394s). The version constant returns to 5 and the credential projection implementation is unchanged. Follow-up CI is pending; prior-candidate results below remain historical.

- [x] `bash scripts/agent-check`
- [ ] `AI_REVIEW_BASE_SHA=37ccf5238ed460e0df2b9844869bdb9c7031f532 bash scripts/agent-check-pr`: normalization/lint and baseline pass; full root race suite passes except the unrelated local Antithesis launcher fixture described below. Retrying with `GOFLAGS=-p=1` removes deadline failures but still exposes its early-exit polling race.
- [x] Antithesis launcher package passes independently under race, both with its default parallelism (8.458s) and `-parallel 1` (32.139s).
- [x] Standalone local `test-schemathesis`: 62 endpoints, zero failures/errors; one recovered transient network error ignored by the canonical runner (the combined gate stops at the fixture failure).
- [x] Previous candidate `d5682feca` GitHub CI: all checks passed, including root tests, E2E business/cluster, model, Schemathesis, operator, scenarios, workload, normalization, invariants, build and coverage.
- [x] HTTP/gRPC and projection regression tests, including real checkpoint reads and pagination.
- [x] Original audit hashes/signatures still verify; redacted payloads cannot authenticate as original evidence; unchanged noncanonical payloads remain byte-exact.
- [x] Base-handler mutation checks reproduce the original leaks; malformed and shadowed protobuf credentials fail closed.
- [x] Independent final review of projection and wire policy; no blocking findings.

The default concurrent full run hit the Antithesis launcher fixture's 15-second deadline. With `GOFLAGS=-p=1`, the remaining `driver_exits_before_deadline` failure misses `DRIVER EXITED EARLY` inside its two-second polling window and reports `NO VERIFIED MODEL OUTCOMES` instead. The fixture runs fake binaries from temporary repositories; both fixture and launcher are byte-identical to the base. No test assertions or deadlines were changed or skipped. CI ran the complete suite successfully on the previous candidate; the policy follow-up will rerun CI.

## Architecture / behavior impact

Public HTTP/gRPC read semantics change; protobuf fields and HTTP response shapes do not. Protocol revision remains 5; no schema or RPC compatibility break. FSM, durable writes, checker inputs, backup, and incremental restore are unchanged because projection creates no persisted effect. Current history remains in the main store; archived/cold history was removed by EN-1945.

OpenAPI, CLI, API parity, event/mirror, and signing documentation describe the public projection and verification boundary.

## Review focus

Credential URL/DSN policy, projection after checkpoint selection, and exact-byte preservation versus rejection of shadowed protobuf credentials. Review the documented distinction between returned audit identity and verification of the original stored evidence.

## Known concerns

The combined local gate has the unrelated Antithesis and synchronization-fixture timing failures above; isolated regression reruns and the previous candidate’s full clean CI pass. This is retained as a validation concern rather than changing unrelated harness behavior in this credentials PR.

This policy covers connector credential fields and their public status diagnostics. Arbitrary business metadata, URL paths, write-response echoes, and protected operator diagnostics retain their existing semantics. Original evidence requires the protected store/backup workflow; read scopes do not provide a raw bypass.
