### PR TITLE
fix(operator): preserve backup scheduling after history pruning (EN-2000)

### DIFF
--- a/docs/ops/backup-restore.md
+++ b/docs/ops/backup-restore.md
@@ -48,6 +48,18 @@ spec:
 
 The run history limits retain Kubernetes `BackupRun` resources only. They do
 not retain historical backup artifacts or restore points in object storage.
+Setting either limit to zero removes all terminal runs of that outcome without
+resetting the cron schedule, including after an operator restart. The first run
+is immediate; subsequent runs follow the cron expression after the latest
+completed run of that type, whether it succeeded or failed. A failed run does
+not trigger an immediate retry outside the schedule.
+
+Completion cursors and successful-result summaries persist in `Backup.status`
+before history is deleted. Incremental scheduling remains enabled after the
+last successful full run is pruned. Pending or Running runs still block another
+scheduled run of the same type. See the
+[scheduling contract](../technical/architecture/subsystems/backup/operator-scheduling.md)
+for failure ordering and status field semantics.
 
 ### Long-Term Retention
 

--- a/docs/technical/architecture/subsystems/backup/README.md
+++ b/docs/technical/architecture/subsystems/backup/README.md
@@ -130,6 +130,9 @@ A restore is **a node-level disaster-recovery operation**, not an in-cluster ope
 
 ## Scheduling
 
+See [Operator backup scheduling](operator-scheduling.md) for the Kubernetes
+completion cursors, zero-retention behavior, and reconciliation failure ordering.
+
 The Operator's `Backup` CRD (`misc/operator/api/v1alpha1/`) wraps backups behind a `BackupSchedule` with **two separate cron fields** — `Full` and `Incremental` — so operators can run a full checkpoint less often than the incremental segments. The Operator submits a `BackupOrder` (full) or `IncrementalBackupOrder` at each cron tick; the FSM enforces mutual exclusion; the executor on the leader does the upload. One-off backups can also be triggered manually through the same gRPC surface.
 
 `IncrementalBackupOrder` is the right primitive for tight RPO targets — it flushes the in-progress segment without taking a fresh full checkpoint.

--- a/docs/technical/architecture/subsystems/backup/operator-scheduling.md
+++ b/docs/technical/architecture/subsystems/backup/operator-scheduling.md
@@ -33,7 +33,9 @@ cron occurrence after the current reconciliation time.
 
 ## Reconciliation and failure ordering
 
-1. Read the Backup, validate the Cluster and cron expressions, then list child runs.
+1. Read the Backup directly from the API server, validate the Cluster and cron
+   expressions, then list child runs through the cached client. A failed direct
+   read stops reconciliation before any scheduling or pruning.
 2. Refresh completion cursors monotonically and successful-result summaries in
    memory from the observed children.
 3. Evaluate schedules and create due runs. A same-type Pending, Running, or
@@ -50,6 +52,11 @@ runs remain available to reconstruct the cursor on retry. If pruning fails or
 the controller stops during pruning, the status is already durable and any
 remaining excess children are retried on the next reconciliation. Restarting
 a controller after successful pruning recovers the cursor from Backup status.
+The uncached Backup read is required: the child informer may observe deletion
+before the Backup informer observes the status write. Reading a stale nil cursor
+from that cache would create a run before the eventual status conflict, even
+though the cursor is durable in the API server.
+
 This ordering protects controller-managed history deletion; it does not make
 external deletion of execution evidence transactional with reconciliation.
 
@@ -63,4 +70,5 @@ legacy-format fallback. It changes no Ledger service RPC or protocol revision.
 scheduling, zero retention, successful and failed completion, and fresh
 reconciler instances before and at the next deadline. Additional cases cover
 write/delete failures, active runs, independent incremental progress, disabled
-and changed schedules, and older retained history.
+and changed schedules, older retained history, and a parent informer lagging
+behind child deletion.

--- a/docs/technical/architecture/subsystems/backup/operator-scheduling.md
+++ b/docs/technical/architecture/subsystems/backup/operator-scheduling.md
@@ -34,7 +34,7 @@ cron occurrence after the current reconciliation time.
 ## Reconciliation and failure ordering
 
 1. Read the Backup directly from the API server, validate the Cluster and cron
-   expressions, then list child runs through the cached client. A failed direct
+   expressions, then list child runs directly from the API server. A failed direct
    read stops reconciliation before any scheduling or pruning.
 2. Refresh completion cursors monotonically and successful-result summaries in
    memory from the observed children.
@@ -55,7 +55,11 @@ a controller after successful pruning recovers the cursor from Backup status.
 The uncached Backup read is required: the child informer may observe deletion
 before the Backup informer observes the status write. Reading a stale nil cursor
 from that cache would create a run before the eventual status conflict, even
-though the cursor is durable in the API server.
+though the cursor is durable in the API server. The child list also bypasses the
+informer cache: an older successful run still visible there must not overwrite
+a newer durable result summary read from the API server. These sequential reads
+are not a cross-resource transaction; a concurrent parent status update still
+causes the final status write to conflict and retry.
 
 This ordering protects controller-managed history deletion; it does not make
 external deletion of execution evidence transactional with reconciliation.

--- a/docs/technical/architecture/subsystems/backup/operator-scheduling.md
+++ b/docs/technical/architecture/subsystems/backup/operator-scheduling.md
@@ -1,0 +1,66 @@
+# Operator backup scheduling
+
+The Kubernetes `Backup` controller schedules `BackupRun` resources; the
+`BackupRun` controller executes them through Jobs. This is control-plane
+operational state, outside Ledger's audited store and exported backup data.
+Restoring Ledger data into another cluster does not restore these Kubernetes
+objects or their scheduling cursors.
+
+## Retention must not reset the schedule (EN-2000)
+
+History limits control retained Kubernetes execution records. Deleting those
+records must not cause an early execution or disable an incremental schedule.
+Previously the scheduler derived its only execution cursor from retained
+terminal children. Zero successful or failed retention erased that cursor,
+so the next reconciliation, including after restart, ran immediately.
+
+`Backup.status.lastFullRunCompletionTime` and
+`Backup.status.lastIncrementalRunCompletionTime` retain the greatest observed
+terminal completion time per type, for both successful and failed runs,
+including manual runs. They never move backwards when the remaining history
+contains only older completions. They advance even when a schedule is disabled.
+The first execution is immediate when no completion has been observed; later
+executions use the first cron occurrence strictly after the completion cursor.
+A changed cron expression is evaluated against the same cursor.
+
+`lastFullBackup` and `lastIncrementalBackup` remain successful-result summaries;
+failed runs never manufacture those summaries. Incremental scheduling requires
+a successful full summary, which survives pruning. `nextFullBackupTime` and
+`nextIncrementalBackupTime` remain derived next-deadline information, cleared
+when their schedule is absent (or the incremental prerequisite is missing).
+They are not scheduling cursors: while a run is active they describe the next
+cron occurrence after the current reconciliation time.
+
+## Reconciliation and failure ordering
+
+1. Read the Backup, validate the Cluster and cron expressions, then list child runs.
+2. Refresh completion cursors monotonically and successful-result summaries in
+   memory from the observed children.
+3. Evaluate schedules and create due runs. A same-type Pending, Running, or
+   not-yet-initialized child prevents another scheduled run. The BackupRun
+   controller separately gates execution on Running siblings across both types.
+4. Persist the complete Backup status, including cursors, summaries, next
+   deadlines, phase and conditions.
+5. Only after that write succeeds, prune terminal children exceeding the
+   configured history limits.
+
+If scheduling or the status write fails, no history is pruned. Already-created
+runs remain in Kubernetes and block duplicate scheduling while active; completed
+runs remain available to reconstruct the cursor on retry. If pruning fails or
+the controller stops during pruning, the status is already durable and any
+remaining excess children are retried on the next reconciliation. Restarting
+a controller after successful pruning recovers the cursor from Backup status.
+This ordering protects controller-managed history deletion; it does not make
+external deletion of execution evidence transactional with reconciliation.
+
+The CRD schema and generated deepcopy code must carry both cursor fields,
+including the Helm CRD copy. This pre-release API change has no migration or
+legacy-format fallback. It changes no Ledger service RPC or protocol revision.
+
+## Regression evidence
+
+`misc/operator/internal/controller/backup_scheduling_test.go` combines daily
+scheduling, zero retention, successful and failed completion, and fresh
+reconciler instances before and at the next deadline. Additional cases cover
+write/delete failures, active runs, independent incremental progress, disabled
+and changed schedules, and older retained history.

--- a/misc/operator/README.md
+++ b/misc/operator/README.md
@@ -54,6 +54,13 @@ ownership entries are retained: replacement of a previously tracked index and
 recovery after a lost successful create response or status update remain
 separate ownership concerns.
 
+## Backup scheduling
+
+Backup schedules preserve their completion cursors in `Backup.status` before
+pruning run history. Zero retention therefore preserves scheduling across
+operator restarts. See the [scheduling contract](../../docs/technical/architecture/subsystems/backup/operator-scheduling.md)
+and [backup operations guide](../../docs/ops/backup-restore.md#scheduling-with-the-kubernetes-operator).
+
 ## Custom Resources
 
 | Resource | Scope | Description |

--- a/misc/operator/api/v1alpha1/backup_types.go
+++ b/misc/operator/api/v1alpha1/backup_types.go
@@ -190,6 +190,16 @@ type BackupStatus struct {
 	// +optional
 	LastIncrementalBackup *IncrementalBackupStatus `json:"lastIncrementalBackup,omitempty"`
 
+	// LastFullRunCompletionTime is the latest observed terminal full run completion,
+	// successful or failed. It is preserved independently of run history retention.
+	// +optional
+	LastFullRunCompletionTime *metav1.Time `json:"lastFullRunCompletionTime,omitempty"`
+
+	// LastIncrementalRunCompletionTime is the latest observed terminal incremental
+	// run completion, successful or failed, independent of run history retention.
+	// +optional
+	LastIncrementalRunCompletionTime *metav1.Time `json:"lastIncrementalRunCompletionTime,omitempty"`
+
 	// NextFullBackupTime is the next scheduled time for a full backup.
 	// +optional
 	NextFullBackupTime *metav1.Time `json:"nextFullBackupTime,omitempty"`

--- a/misc/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/misc/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -382,6 +382,14 @@ func (in *BackupStatus) DeepCopyInto(out *BackupStatus) {
 		*out = new(IncrementalBackupStatus)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.LastFullRunCompletionTime != nil {
+		in, out := &in.LastFullRunCompletionTime, &out.LastFullRunCompletionTime
+		*out = (*in).DeepCopy()
+	}
+	if in.LastIncrementalRunCompletionTime != nil {
+		in, out := &in.LastIncrementalRunCompletionTime, &out.LastIncrementalRunCompletionTime
+		*out = (*in).DeepCopy()
+	}
 	if in.NextFullBackupTime != nil {
 		in, out := &in.NextFullBackupTime, &out.NextFullBackupTime
 		*out = (*in).DeepCopy()

--- a/misc/operator/cmd/operator/main.go
+++ b/misc/operator/cmd/operator/main.go
@@ -126,6 +126,7 @@ func main() {
 	}
 
 	if err = (&controller.BackupReconciler{
+		APIReader: mgr.GetAPIReader(),
 		Client:    mgr.GetClient(),
 		Scheme:    mgr.GetScheme(),
 		Config:    cfg,

--- a/misc/operator/config/crd/bases/ledger.formance.com_backups.yaml
+++ b/misc/operator/config/crd/bases/ledger.formance.com_backups.yaml
@@ -256,6 +256,12 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              lastFullRunCompletionTime:
+                description: |-
+                  LastFullRunCompletionTime is the latest observed terminal full run completion,
+                  successful or failed. It is preserved independently of run history retention.
+                format: date-time
+                type: string
               lastIncrementalBackup:
                 description: LastIncrementalBackup holds the result of the last incremental
                   backup.
@@ -299,6 +305,12 @@ spec:
                     format: date-time
                     type: string
                 type: object
+              lastIncrementalRunCompletionTime:
+                description: |-
+                  LastIncrementalRunCompletionTime is the latest observed terminal incremental
+                  run completion, successful or failed, independent of run history retention.
+                format: date-time
+                type: string
               message:
                 description: Message contains human-readable status information.
                 type: string

--- a/misc/operator/helm/crds/templates/ledger.formance.com_backups.yaml
+++ b/misc/operator/helm/crds/templates/ledger.formance.com_backups.yaml
@@ -256,6 +256,12 @@ spec:
                     format: int32
                     type: integer
                 type: object
+              lastFullRunCompletionTime:
+                description: |-
+                  LastFullRunCompletionTime is the latest observed terminal full run completion,
+                  successful or failed. It is preserved independently of run history retention.
+                format: date-time
+                type: string
               lastIncrementalBackup:
                 description: LastIncrementalBackup holds the result of the last incremental
                   backup.
@@ -299,6 +305,12 @@ spec:
                     format: date-time
                     type: string
                 type: object
+              lastIncrementalRunCompletionTime:
+                description: |-
+                  LastIncrementalRunCompletionTime is the latest observed terminal incremental
+                  run completion, successful or failed, independent of run history retention.
+                format: date-time
+                type: string
               message:
                 description: Message contains human-readable status information.
                 type: string

--- a/misc/operator/internal/controller/backup_controller.go
+++ b/misc/operator/internal/controller/backup_controller.go
@@ -38,12 +38,13 @@ const (
 // When a cron schedule fires, it creates a BackupRun whose own reconciler
 // performs the actual ledgerctl invocation. It also maintains Backup status
 // summaries from the latest Succeeded child runs and prunes runs in excess of the
-// configured history limits.
+// configured history limits. Completion cursors survive pruning; parent and child
+// reads bypass informer caches to avoid restoring stale scheduling/status data.
 type BackupReconciler struct {
 	client.Client
 
-	// APIReader reads Backup status directly from the API server. Child deletion
-	// events can reach the cache before the status write that preserved its cursor.
+	// APIReader reads Backups and child runs directly from the API server.
+	// Independent informer lag must not rewind durable cursors or summaries.
 	APIReader client.Reader
 
 	Scheme    *runtime.Scheme
@@ -340,7 +341,7 @@ func (r *BackupReconciler) listChildRuns(
 	backup *ledgerv1alpha1.Backup,
 ) ([]ledgerv1alpha1.BackupRun, error) {
 	var list ledgerv1alpha1.BackupRunList
-	if err := r.List(ctx, &list,
+	if err := r.APIReader.List(ctx, &list,
 		client.InNamespace(backup.Namespace),
 		client.MatchingLabels{ledgerv1alpha1.LabelBackup: backup.Name},
 	); err != nil {

--- a/misc/operator/internal/controller/backup_controller.go
+++ b/misc/operator/internal/controller/backup_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -41,6 +42,10 @@ const (
 type BackupReconciler struct {
 	client.Client
 
+	// APIReader reads Backup status directly from the API server. Child deletion
+	// events can reach the cache before the status write that preserved its cursor.
+	APIReader client.Reader
+
 	Scheme    *runtime.Scheme
 	Config    *rest.Config
 	Clientset kubernetes.Interface
@@ -53,8 +58,12 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 func (r *BackupReconciler) reconcile(ctx context.Context, req ctrl.Request, now time.Time) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
+	if r.APIReader == nil {
+		return ctrl.Result{}, errors.New("APIReader not configured")
+	}
+
 	var backup ledgerv1alpha1.Backup
-	if err := r.Get(ctx, req.NamespacedName, &backup); err != nil {
+	if err := r.APIReader.Get(ctx, req.NamespacedName, &backup); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 

--- a/misc/operator/internal/controller/backup_controller.go
+++ b/misc/operator/internal/controller/backup_controller.go
@@ -47,6 +47,10 @@ type BackupReconciler struct {
 }
 
 func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	return r.reconcile(ctx, req, time.Now())
+}
+
+func (r *BackupReconciler) reconcile(ctx context.Context, req ctrl.Request, now time.Time) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	var backup ledgerv1alpha1.Backup
@@ -99,7 +103,11 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, fmt.Errorf("listing child runs: %w", err)
 	}
 
-	now := time.Now()
+	// Capture terminal progress before history can be pruned, even with schedules
+	// disabled. Successful summaries remain distinct from scheduling cursors.
+	r.refreshCompletionCursors(&backup, runs)
+	r.refreshStatusSummaries(&backup, runs)
+
 	var nextRequeue time.Duration
 
 	if fullSched != nil {
@@ -108,20 +116,20 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			return ctrl.Result{}, err
 		}
 		backup.Status.NextFullBackupTime = &metav1.Time{Time: next}
-		nextRequeue = minDuration(nextRequeue, time.Until(next))
+		nextRequeue = minDuration(nextRequeue, next.Sub(now))
 	} else {
 		backup.Status.NextFullBackupTime = nil
 	}
 
 	if incrSched != nil {
 		// An incremental backup is only meaningful after at least one Succeeded Full run.
-		if hasSucceededRun(runs, ledgerv1alpha1.BackupRunTypeFull) {
+		if backup.Status.LastFullBackup != nil {
 			next, err := r.scheduleType(ctx, &backup, runs, ledgerv1alpha1.BackupRunTypeIncremental, incrSched, now)
 			if err != nil {
 				return ctrl.Result{}, err
 			}
 			backup.Status.NextIncrementalBackupTime = &metav1.Time{Time: next}
-			nextRequeue = minDuration(nextRequeue, time.Until(next))
+			nextRequeue = minDuration(nextRequeue, next.Sub(now))
 		} else {
 			logger.V(1).Info("skipping incremental schedule: no successful full backup yet")
 			backup.Status.NextIncrementalBackupTime = nil
@@ -130,18 +138,16 @@ func (r *BackupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		backup.Status.NextIncrementalBackupTime = nil
 	}
 
-	// Refresh status summaries from the latest Succeeded run of each type.
-	r.refreshStatusSummaries(&backup, runs)
-
-	// Prune runs in excess of history limits.
-	if err := r.pruneRuns(ctx, &backup, runs); err != nil {
-		return ctrl.Result{}, fmt.Errorf("pruning runs: %w", err)
-	}
-
 	backup.Status.Phase = ledgerv1alpha1.BackupPhaseReady
 	backup.Status.Message = ""
 	if err := r.Status().Update(ctx, &backup); err != nil {
 		return ctrl.Result{}, err
+	}
+
+	// Persist cursors and summaries before deleting their source evidence. If
+	// the status write fails, terminal children must remain available on retry.
+	if err := r.pruneRuns(ctx, &backup, runs); err != nil {
+		return ctrl.Result{}, fmt.Errorf("pruning runs: %w", err)
 	}
 
 	if nextRequeue > 0 {
@@ -168,7 +174,15 @@ func (r *BackupReconciler) scheduleType(
 		return sched.Next(now), nil
 	}
 
-	lastTime := lastRunTime(runs, runType)
+	var lastTime *metav1.Time
+	switch runType {
+	case ledgerv1alpha1.BackupRunTypeFull:
+		lastTime = backup.Status.LastFullRunCompletionTime
+	case ledgerv1alpha1.BackupRunTypeIncremental:
+		lastTime = backup.Status.LastIncrementalRunCompletionTime
+	default:
+		return time.Time{}, fmt.Errorf("unsupported backup run type %q", runType)
+	}
 	nextTime := nextRunTime(sched, lastTime)
 
 	if now.Before(nextTime) {
@@ -218,6 +232,22 @@ func (r *BackupReconciler) createRun(
 	}
 
 	return r.Create(ctx, run)
+}
+
+// refreshCompletionCursors preserves the latest observed terminal completion of
+// each type, including failures. Older retained runs must not rewind progress.
+func (r *BackupReconciler) refreshCompletionCursors(backup *ledgerv1alpha1.Backup, runs []ledgerv1alpha1.BackupRun) {
+	for _, entry := range []struct {
+		runType ledgerv1alpha1.BackupRunType
+		cursor  **metav1.Time
+	}{
+		{ledgerv1alpha1.BackupRunTypeFull, &backup.Status.LastFullRunCompletionTime},
+		{ledgerv1alpha1.BackupRunTypeIncremental, &backup.Status.LastIncrementalRunCompletionTime},
+	} {
+		if latest := lastRunTime(runs, entry.runType); latest != nil && (*entry.cursor == nil || latest.After((*entry.cursor).Time)) {
+			*entry.cursor = latest.DeepCopy()
+		}
+	}
 }
 
 // refreshStatusSummaries updates LastFullBackup / LastIncrementalBackup from the latest Succeeded run.
@@ -355,16 +385,6 @@ func hasRunningRun(runs []ledgerv1alpha1.BackupRun, runType ledgerv1alpha1.Backu
 		}
 		switch runs[i].Status.Phase {
 		case ledgerv1alpha1.BackupRunPhaseRunning, ledgerv1alpha1.BackupRunPhasePending, "":
-			return true
-		}
-	}
-
-	return false
-}
-
-func hasSucceededRun(runs []ledgerv1alpha1.BackupRun, runType ledgerv1alpha1.BackupRunType) bool {
-	for i := range runs {
-		if runs[i].Spec.Type == runType && runs[i].Status.Phase == ledgerv1alpha1.BackupRunPhaseSucceeded {
 			return true
 		}
 	}

--- a/misc/operator/internal/controller/backup_scheduling_test.go
+++ b/misc/operator/internal/controller/backup_scheduling_test.go
@@ -380,3 +380,47 @@ func TestBackupScheduling_ManualRunAdvancesCursor(t *testing.T) {
 		})
 	}
 }
+
+func TestBackupScheduling_StaleChildCacheDoesNotRewindSummaries(t *testing.T) {
+	t.Parallel()
+	for _, runType := range []ledgerv1alpha1.BackupRunType{ledgerv1alpha1.BackupRunTypeFull, ledgerv1alpha1.BackupRunTypeIncremental} {
+		t.Run(string(runType), func(t *testing.T) {
+			t.Parallel()
+			f := newBackupSchedulingFixture(t)
+			now := time.Date(2026, 9, 10, 2, 0, 0, 0, time.UTC)
+			older := metav1.NewTime(now.Add(-24 * time.Hour))
+			latest := metav1.NewTime(now)
+			backup := f.backup(t)
+			backup.Spec.Schedule = ledgerv1alpha1.BackupSchedule{}
+			require.NoError(t, f.client.Update(context.Background(), backup))
+			backup.Status.LastFullBackup = &ledgerv1alpha1.FullBackupStatus{Time: &latest, FilesUploaded: 7}
+			backup.Status.LastIncrementalBackup = &ledgerv1alpha1.IncrementalBackupStatus{Time: &latest}
+			require.NoError(t, f.client.Status().Update(context.Background(), backup))
+			stale := ledgerv1alpha1.BackupRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "already-pruned", Namespace: f.key.Namespace},
+				Spec:       ledgerv1alpha1.BackupRunSpec{Type: runType},
+				Status: ledgerv1alpha1.BackupRunStatus{Phase: ledgerv1alpha1.BackupRunPhaseSucceeded, CompletionTime: &older,
+					Full:        &ledgerv1alpha1.FullBackupStatus{Time: &older, FilesUploaded: 1},
+					Incremental: &ledgerv1alpha1.IncrementalBackupStatus{Time: &older}},
+			}
+			cached := interceptor.NewClient(f.client, interceptor.Funcs{
+				List: func(ctx context.Context, c client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+					if runs, ok := list.(*ledgerv1alpha1.BackupRunList); ok {
+						runs.Items = []ledgerv1alpha1.BackupRun{stale}
+
+						return nil
+					}
+
+					return c.List(ctx, list, opts...)
+				},
+			})
+			r := &BackupReconciler{Client: cached, APIReader: f.client, Scheme: f.scheme}
+			_, err := r.reconcile(context.Background(), ctrl.Request{NamespacedName: f.key}, now.Add(time.Minute))
+			require.NoError(t, err)
+			persisted := f.backup(t)
+			require.True(t, latest.Equal(persisted.Status.LastFullBackup.Time), "full summary must retain its latest timestamp")
+			require.Equal(t, int64(7), int64(persisted.Status.LastFullBackup.FilesUploaded))
+			require.True(t, latest.Equal(persisted.Status.LastIncrementalBackup.Time), "incremental summary must retain its latest timestamp")
+		})
+	}
+}

--- a/misc/operator/internal/controller/backup_scheduling_test.go
+++ b/misc/operator/internal/controller/backup_scheduling_test.go
@@ -49,7 +49,7 @@ func newBackupSchedulingFixture(t *testing.T) *backupSchedulingFixture {
 
 func (f *backupSchedulingFixture) reconcile(t *testing.T, now time.Time) {
 	t.Helper()
-	r := &BackupReconciler{Client: f.client, Scheme: f.scheme}
+	r := &BackupReconciler{Client: f.client, APIReader: f.client, Scheme: f.scheme}
 	_, err := r.reconcile(context.Background(), ctrl.Request{NamespacedName: f.key}, now)
 	require.NoError(t, err)
 }
@@ -157,7 +157,7 @@ func TestBackupScheduling_PersistBeforePruning(t *testing.T) {
 					return c.Delete(ctx, obj, opts...)
 				},
 			})
-			r := &BackupReconciler{Client: f.client, Scheme: f.scheme}
+			r := &BackupReconciler{Client: f.client, APIReader: f.client, Scheme: f.scheme}
 			_, err := r.reconcile(context.Background(), ctrl.Request{NamespacedName: f.key}, now.Add(2*time.Minute))
 			require.ErrorIs(t, err, failure)
 			require.Len(t, f.runs(t), 1, "failed status/pruning attempt preserves the terminal child")
@@ -287,4 +287,63 @@ func TestBackupScheduling_DisabledScheduleAndOlderHistory(t *testing.T) {
 	require.True(t, now.Add(time.Minute).Equal(backup.Status.LastFullRunCompletionTime.Time))
 	f.reconcile(t, now.Add(2*time.Hour))
 	require.Len(t, f.runs(t), 2, "new cron deadline must create a run alongside retained history")
+}
+
+func TestBackupScheduling_StaleParentCacheAfterPruning(t *testing.T) {
+	t.Parallel()
+	for _, phase := range []ledgerv1alpha1.BackupRunPhase{ledgerv1alpha1.BackupRunPhaseSucceeded, ledgerv1alpha1.BackupRunPhaseFailed} {
+		t.Run(string(phase), func(t *testing.T) {
+			t.Parallel()
+			f := newBackupSchedulingFixture(t)
+			now := time.Date(2026, 9, 10, 2, 0, 0, 0, time.UTC)
+			f.reconcile(t, now)
+			staleBackup := f.backup(t)
+			f.complete(t, f.runs(t)[0], phase, now.Add(time.Minute))
+			f.reconcile(t, now.Add(2*time.Minute))
+			require.Empty(t, f.runs(t))
+			// Child deletion has reached its informer, but the Backup informer still
+			// exposes the object from before the completion cursor was persisted.
+			staleClient := interceptor.NewClient(f.client, interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if backup, ok := obj.(*ledgerv1alpha1.Backup); ok {
+						*backup = *staleBackup.DeepCopy()
+
+						return nil
+					}
+
+					return c.Get(ctx, key, obj, opts...)
+				},
+			})
+			r := &BackupReconciler{Client: staleClient, APIReader: f.client, Scheme: f.scheme}
+			_, err := r.reconcile(context.Background(), ctrl.Request{NamespacedName: f.key}, now.Add(3*time.Minute))
+			require.Empty(t, f.runs(t), "a stale parent cache must not create a run before discovering the status conflict")
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestBackupScheduling_APIReadFailureDoesNotSchedule(t *testing.T) {
+	t.Parallel()
+	f := newBackupSchedulingFixture(t)
+	failure := errors.New("injected uncached read failure")
+	attempts := 0
+	reader := interceptor.NewClient(f.client, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			attempts++
+			if attempts == 1 {
+				return failure
+			}
+
+			return c.Get(ctx, key, obj, opts...)
+		},
+	})
+	r := &BackupReconciler{Client: f.client, APIReader: reader, Scheme: f.scheme}
+	now := time.Date(2026, 9, 10, 2, 0, 0, 0, time.UTC)
+	_, err := r.reconcile(context.Background(), ctrl.Request{NamespacedName: f.key}, now)
+	require.ErrorIs(t, err, failure)
+	require.Empty(t, f.runs(t), "must not fall back to cached state on an API read failure")
+	_, err = r.reconcile(context.Background(), ctrl.Request{NamespacedName: f.key}, now)
+	require.NoError(t, err)
+	require.Equal(t, 2, attempts)
+	require.Len(t, f.runs(t), 1)
 }

--- a/misc/operator/internal/controller/backup_scheduling_test.go
+++ b/misc/operator/internal/controller/backup_scheduling_test.go
@@ -347,3 +347,36 @@ func TestBackupScheduling_APIReadFailureDoesNotSchedule(t *testing.T) {
 	require.Equal(t, 2, attempts)
 	require.Len(t, f.runs(t), 1)
 }
+
+func TestBackupScheduling_ManualRunAdvancesCursor(t *testing.T) {
+	t.Parallel()
+	for _, phase := range []ledgerv1alpha1.BackupRunPhase{ledgerv1alpha1.BackupRunPhaseSucceeded, ledgerv1alpha1.BackupRunPhaseFailed} {
+		t.Run(string(phase), func(t *testing.T) {
+			t.Parallel()
+			f := newBackupSchedulingFixture(t)
+			now := time.Date(2026, 9, 10, 3, 0, 0, 0, time.UTC)
+			// Match kubectl-ledger backup trigger: the parent label and BackupRef
+			// associate the run; a scheduler-created owner reference is not required.
+			manual := &ledgerv1alpha1.BackupRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "manual-full", Namespace: f.key.Namespace, Labels: map[string]string{
+					ledgerv1alpha1.LabelBackup:        f.key.Name,
+					ledgerv1alpha1.LabelBackupRunType: string(ledgerv1alpha1.BackupRunTypeFull),
+				}},
+				Spec: ledgerv1alpha1.BackupRunSpec{BackupRef: f.key.Name, Type: ledgerv1alpha1.BackupRunTypeFull},
+			}
+			require.NoError(t, f.client.Create(context.Background(), manual))
+			f.complete(t, *manual, phase, now)
+			f.reconcile(t, now.Add(time.Minute))
+			require.Empty(t, f.runs(t), "manual terminal run is pruned without scheduling another run")
+			backup := f.backup(t)
+			require.NotNil(t, backup.Status.LastFullRunCompletionTime)
+			require.True(t, now.Equal(backup.Status.LastFullRunCompletionTime.Time))
+			next := time.Date(2026, 9, 11, 2, 0, 0, 0, time.UTC)
+			require.True(t, next.Equal(backup.Status.NextFullBackupTime.Time))
+			f.reconcile(t, next.Add(-time.Second))
+			require.Empty(t, f.runs(t), "manual completion survives pruning and restart")
+			f.reconcile(t, next)
+			require.Len(t, f.runs(t), 1, "next scheduled execution remains due at the cron deadline")
+		})
+	}
+}

--- a/misc/operator/internal/controller/backup_scheduling_test.go
+++ b/misc/operator/internal/controller/backup_scheduling_test.go
@@ -1,0 +1,290 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	ledgerv1alpha1 "github.com/formancehq/ledger/misc/operator/api/v1alpha1"
+)
+
+// Each fixture owns its API state and supplies reconciliation time explicitly.
+// A fresh reconciler must recover exclusively from the persisted objects.
+type backupSchedulingFixture struct {
+	client client.WithWatch
+	scheme *runtime.Scheme
+	key    types.NamespacedName
+}
+
+func newBackupSchedulingFixture(t *testing.T) *backupSchedulingFixture {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, ledgerv1alpha1.AddToScheme(scheme))
+	zero := int32(0)
+	backup := &ledgerv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "daily", Namespace: "test", UID: "backup-uid"},
+		Spec: ledgerv1alpha1.BackupSpec{
+			ClusterRef:                 "ledger",
+			Schedule:                   ledgerv1alpha1.BackupSchedule{Full: "CRON_TZ=UTC 0 2 * * *"},
+			SuccessfulRunsHistoryLimit: &zero,
+			FailedRunsHistoryLimit:     &zero,
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).
+		WithStatusSubresource(&ledgerv1alpha1.Backup{}, &ledgerv1alpha1.BackupRun{}).
+		WithObjects(backup, &ledgerv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "ledger", Namespace: "test"}}).Build()
+
+	return &backupSchedulingFixture{client: c, scheme: scheme, key: client.ObjectKeyFromObject(backup)}
+}
+
+func (f *backupSchedulingFixture) reconcile(t *testing.T, now time.Time) {
+	t.Helper()
+	r := &BackupReconciler{Client: f.client, Scheme: f.scheme}
+	_, err := r.reconcile(context.Background(), ctrl.Request{NamespacedName: f.key}, now)
+	require.NoError(t, err)
+}
+
+func (f *backupSchedulingFixture) runs(t *testing.T) []ledgerv1alpha1.BackupRun {
+	t.Helper()
+	var runs ledgerv1alpha1.BackupRunList
+	require.NoError(t, f.client.List(context.Background(), &runs, client.InNamespace(f.key.Namespace)))
+
+	return runs.Items
+}
+
+func (f *backupSchedulingFixture) backup(t *testing.T) *ledgerv1alpha1.Backup {
+	t.Helper()
+	var backup ledgerv1alpha1.Backup
+	require.NoError(t, f.client.Get(context.Background(), f.key, &backup))
+
+	return &backup
+}
+
+func (f *backupSchedulingFixture) complete(t *testing.T, run ledgerv1alpha1.BackupRun, phase ledgerv1alpha1.BackupRunPhase, at time.Time) {
+	t.Helper()
+	completion := metav1.NewTime(at)
+	run.Status.Phase = phase
+	run.Status.CompletionTime = &completion
+	if phase == ledgerv1alpha1.BackupRunPhaseSucceeded {
+		if run.Spec.Type == ledgerv1alpha1.BackupRunTypeFull {
+			run.Status.Full = &ledgerv1alpha1.FullBackupStatus{Time: &completion, FilesUploaded: 7}
+		} else {
+			run.Status.Incremental = &ledgerv1alpha1.IncrementalBackupStatus{Time: &completion}
+		}
+	}
+	require.NoError(t, f.client.Status().Update(context.Background(), &run))
+}
+
+func TestBackupScheduling_ZeroRetentionRestart(t *testing.T) {
+	t.Parallel()
+	for _, phase := range []ledgerv1alpha1.BackupRunPhase{ledgerv1alpha1.BackupRunPhaseSucceeded, ledgerv1alpha1.BackupRunPhaseFailed} {
+		t.Run(string(phase), func(t *testing.T) {
+			t.Parallel()
+			f := newBackupSchedulingFixture(t)
+			now := time.Date(2026, 9, 10, 2, 0, 0, 0, time.UTC)
+			for range 2 {
+				f.reconcile(t, now)
+				runs := f.runs(t)
+				require.Len(t, runs, 1, "initial execution or due cron must create exactly one run")
+				f.complete(t, runs[0], phase, now.Add(time.Minute))
+				f.reconcile(t, now.Add(2*time.Minute))
+				require.Empty(t, f.runs(t), "zero retention must prune the terminal run")
+				backup := f.backup(t)
+				next := now.Add(24 * time.Hour)
+				require.NotNil(t, backup.Status.NextFullBackupTime)
+				require.True(t, next.Equal(backup.Status.NextFullBackupTime.Time))
+				if phase == ledgerv1alpha1.BackupRunPhaseSucceeded {
+					require.NotNil(t, backup.Status.LastFullBackup)
+					require.EqualValues(t, 7, backup.Status.LastFullBackup.FilesUploaded)
+				} else {
+					require.Nil(t, backup.Status.LastFullBackup, "failed-only runs must not fabricate a success summary")
+				}
+				f.reconcile(t, now.Add(3*time.Minute))
+				require.Empty(t, f.runs(t), "restart after pruning must not recreate a run before the persisted deadline")
+				f.reconcile(t, next.Add(-time.Second))
+				require.Empty(t, f.runs(t))
+				now = next
+			}
+		})
+	}
+}
+
+func TestBackupScheduling_PersistBeforePruning(t *testing.T) {
+	t.Parallel()
+	for _, operation := range []string{"status", "delete"} {
+		t.Run(operation, func(t *testing.T) {
+			t.Parallel()
+			f := newBackupSchedulingFixture(t)
+			now := time.Date(2026, 9, 10, 2, 0, 0, 0, time.UTC)
+			f.reconcile(t, now)
+			run := f.runs(t)[0]
+			completion := now.Add(time.Minute)
+			f.complete(t, run, ledgerv1alpha1.BackupRunPhaseSucceeded, completion)
+			failure := errors.New("injected API failure")
+			statusAttempts, deleteAttempts := 0, 0
+			f.client = interceptor.NewClient(f.client, interceptor.Funcs{
+				SubResourceUpdate: func(ctx context.Context, c client.Client, subResource string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+					if _, ok := obj.(*ledgerv1alpha1.Backup); ok && subResource == "status" {
+						statusAttempts++
+						if operation == "status" && statusAttempts == 1 {
+							return failure
+						}
+					}
+
+					return c.SubResource(subResource).Update(ctx, obj, opts...)
+				},
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					deleteAttempts++
+					// Every delete must follow a durable status write, never just an in-memory update.
+					backup := f.backup(t)
+					require.NotNil(t, backup.Status.LastFullRunCompletionTime)
+					require.True(t, completion.Equal(backup.Status.LastFullRunCompletionTime.Time))
+					require.NotNil(t, backup.Status.LastFullBackup)
+					if operation == "delete" && deleteAttempts == 1 {
+						return failure
+					}
+
+					return c.Delete(ctx, obj, opts...)
+				},
+			})
+			r := &BackupReconciler{Client: f.client, Scheme: f.scheme}
+			_, err := r.reconcile(context.Background(), ctrl.Request{NamespacedName: f.key}, now.Add(2*time.Minute))
+			require.ErrorIs(t, err, failure)
+			require.Len(t, f.runs(t), 1, "failed status/pruning attempt preserves the terminal child")
+			if operation == "status" {
+				require.Zero(t, deleteAttempts)
+				require.Nil(t, f.backup(t).Status.LastFullRunCompletionTime)
+				require.Nil(t, f.backup(t).Status.LastFullBackup)
+			} else {
+				require.Equal(t, 1, deleteAttempts)
+				require.NotNil(t, f.backup(t).Status.LastFullRunCompletionTime)
+			}
+			f.reconcile(t, now.Add(3*time.Minute))
+			require.Equal(t, 2, statusAttempts, "retry must persist status successfully")
+			expectedDeletes := 1
+			if operation == "delete" {
+				expectedDeletes = 2
+			}
+			require.Equal(t, expectedDeletes, deleteAttempts)
+			require.Empty(t, f.runs(t))
+			f.reconcile(t, now.Add(4*time.Minute))
+			require.Empty(t, f.runs(t), "restart after retry/pruning must retain scheduling progress")
+		})
+	}
+}
+
+func TestBackupScheduling_ActiveRunBlocksAfterRestart(t *testing.T) {
+	t.Parallel()
+	for _, phase := range []ledgerv1alpha1.BackupRunPhase{"", ledgerv1alpha1.BackupRunPhasePending, ledgerv1alpha1.BackupRunPhaseRunning} {
+		t.Run(string(phase), func(t *testing.T) {
+			t.Parallel()
+			f := newBackupSchedulingFixture(t)
+			now := time.Date(2026, 9, 10, 2, 0, 0, 0, time.UTC)
+			f.reconcile(t, now)
+			run := f.runs(t)[0]
+			f.complete(t, run, ledgerv1alpha1.BackupRunPhaseSucceeded, now.Add(time.Minute))
+			f.reconcile(t, now.Add(2*time.Minute))
+			require.Empty(t, f.runs(t))
+			f.reconcile(t, now.Add(24*time.Hour))
+			runs := f.runs(t)
+			require.Len(t, runs, 1)
+			run = runs[0]
+			run.Status.Phase = phase
+			require.NoError(t, f.client.Status().Update(context.Background(), &run))
+			// The completion cursor is overdue, but this active run still forbids another.
+			f.reconcile(t, now.Add(48*time.Hour))
+			runs = f.runs(t)
+			require.Len(t, runs, 1)
+			require.Equal(t, run.Name, runs[0].Name)
+			require.True(t, now.Add(time.Minute).Equal(f.backup(t).Status.LastFullRunCompletionTime.Time))
+		})
+	}
+}
+
+func TestBackupScheduling_IncrementalZeroRetentionRestart(t *testing.T) {
+	t.Parallel()
+	for _, phase := range []ledgerv1alpha1.BackupRunPhase{ledgerv1alpha1.BackupRunPhaseSucceeded, ledgerv1alpha1.BackupRunPhaseFailed} {
+		t.Run(string(phase), func(t *testing.T) {
+			t.Parallel()
+			f := newBackupSchedulingFixture(t)
+			backup := f.backup(t)
+			backup.Spec.Schedule.Incremental = "CRON_TZ=UTC 0 * * * *"
+			require.NoError(t, f.client.Update(context.Background(), backup))
+			now := time.Date(2026, 9, 10, 2, 0, 0, 0, time.UTC)
+			f.reconcile(t, now)
+			runs := f.runs(t)
+			require.Len(t, runs, 1, "incremental requires a successful full")
+			require.Equal(t, ledgerv1alpha1.BackupRunTypeFull, runs[0].Spec.Type)
+			f.complete(t, runs[0], ledgerv1alpha1.BackupRunPhaseSucceeded, now.Add(time.Minute))
+			f.reconcile(t, now.Add(2*time.Minute))
+			runs = f.runs(t)
+			require.Len(t, runs, 1, "full is pruned while first incremental starts")
+			require.Equal(t, ledgerv1alpha1.BackupRunTypeIncremental, runs[0].Spec.Type)
+			f.complete(t, runs[0], phase, now.Add(3*time.Minute))
+			f.reconcile(t, now.Add(4*time.Minute))
+			require.Empty(t, f.runs(t))
+			f.reconcile(t, now.Add(5*time.Minute))
+			require.Empty(t, f.runs(t))
+			backup = f.backup(t)
+			require.NotNil(t, backup.Status.NextIncrementalBackupTime, "pruning full must not disable incrementals")
+			require.True(t, now.Add(time.Hour).Equal(backup.Status.NextIncrementalBackupTime.Time))
+			require.True(t, now.Add(time.Minute).Equal(backup.Status.LastFullRunCompletionTime.Time))
+			require.True(t, now.Add(3*time.Minute).Equal(backup.Status.LastIncrementalRunCompletionTime.Time))
+			if phase == ledgerv1alpha1.BackupRunPhaseFailed {
+				require.Nil(t, backup.Status.LastIncrementalBackup)
+			} else {
+				require.NotNil(t, backup.Status.LastIncrementalBackup)
+			}
+			f.reconcile(t, now.Add(time.Hour))
+			runs = f.runs(t)
+			require.Len(t, runs, 1)
+			require.Equal(t, ledgerv1alpha1.BackupRunTypeIncremental, runs[0].Spec.Type)
+		})
+	}
+}
+
+func TestBackupScheduling_DisabledScheduleAndOlderHistory(t *testing.T) {
+	t.Parallel()
+	f := newBackupSchedulingFixture(t)
+	now := time.Date(2026, 9, 10, 2, 0, 0, 0, time.UTC)
+	f.reconcile(t, now)
+	runs := f.runs(t)
+	require.Len(t, runs, 1)
+	// Keep an older successful child while pruning the latest failed child.
+	older := runs[0].DeepCopy()
+	older.Name = "older-success"
+	older.ResourceVersion = ""
+	require.NoError(t, f.client.Create(context.Background(), older))
+	f.complete(t, *older, ledgerv1alpha1.BackupRunPhaseSucceeded, now.Add(-24*time.Hour))
+	f.complete(t, runs[0], ledgerv1alpha1.BackupRunPhaseFailed, now.Add(time.Minute))
+	backup := f.backup(t)
+	one := int32(1)
+	backup.Spec.SuccessfulRunsHistoryLimit = &one
+	backup.Spec.Schedule.Full = ""
+	require.NoError(t, f.client.Update(context.Background(), backup))
+	f.reconcile(t, now.Add(2*time.Minute))
+	backup = f.backup(t)
+	require.Nil(t, backup.Status.NextFullBackupTime)
+	require.True(t, now.Add(time.Minute).Equal(backup.Status.LastFullRunCompletionTime.Time))
+	require.Len(t, f.runs(t), 1)
+	// Changing/enabling the schedule uses the completion cursor, not a stored next deadline.
+	backup.Spec.Schedule.Full = "CRON_TZ=UTC 0 4 * * *"
+	require.NoError(t, f.client.Update(context.Background(), backup))
+	f.reconcile(t, now.Add(3*time.Minute))
+	require.Len(t, f.runs(t), 1, "older retained success must not rewind the failure cursor")
+	backup = f.backup(t)
+	require.True(t, now.Add(2*time.Hour).Equal(backup.Status.NextFullBackupTime.Time))
+	require.True(t, now.Add(time.Minute).Equal(backup.Status.LastFullRunCompletionTime.Time))
+	f.reconcile(t, now.Add(2*time.Hour))
+	require.Len(t, f.runs(t), 2, "new cron deadline must create a run alongside retained history")
+}

--- a/misc/operator/internal/controller/suite_test.go
+++ b/misc/operator/internal/controller/suite_test.go
@@ -102,8 +102,9 @@ func TestMain(m *testing.M) {
 	}
 
 	if err := (&BackupReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		APIReader: mgr.GetAPIReader(),
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		panic(fmt.Sprintf("setting up Backup controller: %v", err))
 	}


### PR DESCRIPTION
## What changed

Preserve per-type terminal completion cursors in `Backup.status`, independently of retained `BackupRun` resources. Persist cursors and successful-result summaries before pruning history, and read the parent status uncached so informer lag cannot erase the observed cursor. Incremental scheduling uses the durable successful full summary, so pruning that full run does not disable incrementals.

## Why

Fixes [EN-2000](https://formance-team.atlassian.net/browse/EN-2000). With a daily full schedule and zero history retention, completing and pruning a run caused a fresh controller to create another run immediately, before the next cron deadline. This affected both successful-only and failed-only history.

## Product / operational motivation

History limits must affect Kubernetes record retention without changing execution timing. The regression reproduced an extra run at 02:03 despite a next deadline of 02:00 the following day. The durable requirement and failure ordering are recorded in `docs/technical/architecture/subsystems/backup/operator-scheduling.md`.

## Technical decision

Store the greatest observed terminal completion time separately for full and incremental runs, including failures and manual executions. Evaluate the current cron expression against that cursor and retain existing Pending/Running/uninitialized concurrency guards. Write complete status before pruning so a failed status write preserves the child evidence needed on retry.

Using success summaries as cursors would miss failed-only history and conflate results with scheduling. Using next-deadline fields as cursors would conflate cron-derived output with execution progress, especially during active runs and schedule changes.

## Risk

**LOW** — scoped to Kubernetes backup scheduling and retention; deterministic failure/restart regressions cover the changed ordering.

## Validation

- [x] Current-code reproduction: both successful and failed zero-retention cases failed on an early run after restart.
- [x] `bash scripts/agent-check`
- [x] `AI_REVIEW_BASE_SHA=8d38782c44b012101961cfb732322729a5163208 bash scripts/agent-check-pr`
- [x] Operator unit tests with `-race` under Nix.
- [x] Backup controller integration tests with `-race -tags integration` under Nix.
- [x] Independent review and self-review of code, tests, docs, CRD and deepcopy diff.

Deterministic regressions also reproduce stale parent informer reads after child deletion for both success and failure, and verify uncached API read fail-then-success recovery. They exercise two daily success/failure cycles, restart before and at the deadline, status/delete fail-then-success recovery, active-run exclusion, independent incremental progress, disabled/changed schedules and older retained history.

## Architecture / behavior impact

Adds optional `lastFullRunCompletionTime` and `lastIncrementalRunCompletionTime` status fields to the Backup CRD; regenerated deepcopy and both standalone/Helm CRDs. Successful-result summaries and next-deadline fields retain their meanings. Kubernetes operational state only: no service gRPC contract, protocol revision, Ledger storage or restore-format changes. Pre-release change requires no migration or compatibility fallback.

## Review focus

Uncached parent reads across child informer deletion events, persist-before-prune ordering, monotonic cursors across failed runs and restart, and incremental eligibility after successful full history is removed.

## Known concerns

None. No merge requested.


[EN-2000]: https://formance-team.atlassian.net/browse/EN-2000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Bugfix evidence

DISCOVERY: NO_EXISTING_WORK — EN-2000 and existing branches/PRs checked before implementation.
BEFORE_FIX: BUG_REPRODUCED — deterministic daily schedule tests for Succeeded and Failed both created a run at 02:03 after pruning/restart, before the next 02:00 deadline; original scheduler logic with an explicit reconciliation clock.
AFTER_FIX: PASS — zero-retention restart regressions, operator race suite, Backup integration suite, agent-check and exact-base agent-check-pr passed.

The post-review cache-lag regression failed against commit `04a1263e6` for both outcomes before switching parent reads to the API server.
