### PR TITLE
fix(EN-1999): verify membership for replacement pods during scale-down

### DIFF
--- a/docs/ops/cluster-operations.md
+++ b/docs/ops/cluster-operations.md
@@ -444,7 +444,7 @@ ledgerctl cluster status
 - The removed node should be stopped by the operator after the removal is confirmed
 - Retrying an already-committed removal returns gRPC `NotFound` with reason `RAFT_NODE_NOT_IN_CLUSTER`; verify `cluster status` and treat absence as the successful postcondition
 - If the caller stops waiting after the ConfChange commits but before its FSM batch is durable, the RPC returns `Unavailable` with reason `RAFT_NODE_REMOVAL_COMMITTED` and the committed Raft index. A removed member with an instance ID remains blocked from rejoining while apply catches up.
-- During Kubernetes scale-down, the operator checks structured `cluster status --json` before removal and again after any removal error. It continues when the node is absent and never relies on CLI error-message substrings.
+- During Kubernetes scale-down, the operator checks structured `cluster status --json` for every removed ordinal, including Pending or missing replacement Pods, and again after any removal error. Pod state never proves that a stable node ID is absent. Replicas are reduced and PVC deletions are issued only after each ordinal is already absent or its removal succeeds; an unresolved membership check/removal retains replicas and PVCs. Earlier removals may already have committed and are recognized on retry. See the [operator scale-down contract](../../misc/operator/README.md#overview).
 - Removing a voter reduces the cluster quorum size; ensure the remaining cluster can still form a majority
 - For a 3-node cluster, removing one voter leaves a 2-node cluster where both nodes must be available for writes
 

--- a/misc/operator/README.md
+++ b/misc/operator/README.md
@@ -13,7 +13,33 @@ The Ledger Operator manages `Cluster` custom resources to automate the lifecycle
 - **Backups** to S3-compatible backends
 - **Credentials** for application-level access control
 
-During StatefulSet scale-down, the operator queries `ledgerctl cluster status --json` before each Raft removal. An already-absent node satisfies the postcondition and is not removed again. If `remove-node` fails after its Raft change committed—even with an opaque or sanitized CLI error—the operator queries membership again and continues when the target is absent; it does not match human-readable error substrings.
+During StatefulSet scale-down, every removed ordinal must satisfy the Raft
+membership removal postcondition (EN-1999). A replacement Pod can be Pending,
+missing, or have no container status while its stable node ID is still a voter;
+none of those Pod states proves absence from Raft. Skipping such an ordinal can
+leave a one-replica StatefulSet with a two-voter membership and no write quorum.
+
+The operator first updates the StatefulSet template while retaining the current
+replica count, then transfers leadership to node 1 (pod-0). Pod health selects
+only the removal mode: crashed or missing Pods use the existing force-removal
+path first. Other Pods, including Pending or running Pods without a crash
+indicator, use normal consensus removal in descending ordinal order. Before
+**each** removal it queries structured
+`ledgerctl cluster status --json` and requires a leader response. Force removal
+uses `--node-id 1` to read the retained leader's local membership without a
+quorum-backed route. An already-absent node is not removed again. A present node
+must be removed successfully; if `remove-node` returns an error, the operator
+queries membership again and continues only when the target is absent. This
+recovers committed removals whose response was lost, without matching CLI error
+substrings.
+
+Only after all removed ordinals satisfy that postcondition does the operator
+persist the reduced StatefulSet replica count and issue PVC deletions. The
+StatefulSet update requests Pod termination; it does not wait for termination to
+finish. If a membership check or removal fails, replicas and PVCs are retained,
+although the template update and earlier membership removals may already have
+succeeded. A later reconciliation checks membership again and skips ordinals
+already removed.
 
 ## Custom Resources
 

--- a/misc/operator/internal/controller/raft_scaledown.go
+++ b/misc/operator/internal/controller/raft_scaledown.go
@@ -92,7 +92,8 @@ func podExecWithTimeout(ctx context.Context, cfg *rest.Config, clientset kuberne
 }
 
 // raftScaleDown removes Raft nodes before StatefulSet scale-down.
-// It removes nodes from highest ordinal to desired, sequentially.
+// Every removed ordinal must pass the Raft membership check, regardless of
+// its current Pod incarnation. Nodes are removed sequentially within each group.
 // Leadership is transferred to node 1 (pod-0) first to ensure the leader isn't being removed.
 //
 // Crashed pods are force-removed first (bypassing Raft consensus) to restore
@@ -103,7 +104,7 @@ func podExecWithTimeout(ctx context.Context, cfg *rest.Config, clientset kuberne
 // configured accordingly so its connection matches what the pod's gRPC server
 // expects.
 func raftScaleDown(ctx context.Context, cfg *rest.Config, clientset kubernetes.Interface,
-	ledger *ledgerv1alpha1.Cluster, currentReplicas, desiredReplicas int32, tlsMode string,
+	ledger *ledgerv1alpha1.Cluster, currentReplicas, desiredReplicas int32, tlsMode string, exec ledgerctlExec,
 ) error {
 	logger := log.FromContext(ctx)
 	grpcPort := ledger.Spec.GrpcPort
@@ -113,7 +114,7 @@ func raftScaleDown(ctx context.Context, cfg *rest.Config, clientset kubernetes.I
 
 	// Transfer leadership to node 1 (pod-0) so the leader is never among the removed nodes.
 	logger.Info("transferring Raft leadership to node 1 before scale-down")
-	result, err := podExecWithTimeout(ctx, cfg, clientset, ledger.Namespace, pod0, container,
+	result, err := exec(ctx, cfg, clientset, ledger.Namespace, pod0, container,
 		ledgerctlCommand(serverAddr, tlsMode, "cluster", "transfer-leader", strconv.Itoa(int(scaleDownLeaderNodeID))),
 	)
 	if err != nil {
@@ -125,8 +126,9 @@ func raftScaleDown(ctx context.Context, cfg *rest.Config, clientset kubernetes.I
 		}
 	}
 
-	// Partition nodes-to-remove into never-joined, crashed (force), and alive (normal).
-	// Never-joined nodes (Pending, not scheduled) are skipped entirely.
+	// Partition nodes-to-remove into crashed (force) and alive (normal).
+	// Pod status selects the removal mode; only Raft membership can establish
+	// absence. A missing or Pending replacement may reuse a joined ordinal.
 	// Force-removing crashed nodes first restores quorum for subsequent
 	// consensus-based removals.
 	type nodeToRemove struct {
@@ -142,15 +144,6 @@ func raftScaleDown(ctx context.Context, cfg *rest.Config, clientset kubernetes.I
 	for ordinal := currentReplicas - 1; ordinal >= desiredReplicas; ordinal-- {
 		nodeID := ordinal + 1
 		pod := podName(ledger.Name, int(ordinal))
-
-		if neverJoined := isPodNeverReady(ctx, clientset, ledger.Namespace, pod); neverJoined {
-			logger.Info("pod was never ready, skipping Raft removal (node never joined cluster)",
-				"nodeID", nodeID,
-				"podOrdinal", ordinal,
-			)
-
-			continue
-		}
 
 		crashed := isPodCrashed(ctx, clientset, ledger.Namespace, pod)
 		n := nodeToRemove{ordinal: ordinal, nodeID: nodeID, crashed: crashed}
@@ -168,14 +161,14 @@ func raftScaleDown(ctx context.Context, cfg *rest.Config, clientset kubernetes.I
 
 	// Remove crashed nodes first with --force.
 	for _, n := range crashedNodes {
-		if err := removeNode(ctx, cfg, clientset, ledger.Namespace, pod0, container, serverAddr, tlsMode, n.nodeID, true); err != nil {
+		if err := removeNodeWithExec(ctx, cfg, clientset, ledger.Namespace, pod0, container, serverAddr, tlsMode, n.nodeID, true, exec); err != nil {
 			return err
 		}
 	}
 
 	// Remove alive nodes normally (highest ordinal first, already sorted).
 	for _, n := range aliveNodes {
-		if err := removeNode(ctx, cfg, clientset, ledger.Namespace, pod0, container, serverAddr, tlsMode, n.nodeID, false); err != nil {
+		if err := removeNodeWithExec(ctx, cfg, clientset, ledger.Namespace, pod0, container, serverAddr, tlsMode, n.nodeID, false, exec); err != nil {
 			return err
 		}
 	}
@@ -183,18 +176,8 @@ func raftScaleDown(ctx context.Context, cfg *rest.Config, clientset kubernetes.I
 	return nil
 }
 
-// removeNode executes ledgerctl cluster remove-node via pod exec. If force is
-// true, --force is appended to bypass Raft consensus.
-func removeNode(ctx context.Context, cfg *rest.Config, clientset kubernetes.Interface,
-	namespace, pod0, container, serverAddr, tlsMode string, nodeID int32, force bool,
-) error {
-	return removeNodeWithExec(
-		ctx, cfg, clientset,
-		namespace, pod0, container, serverAddr, tlsMode, nodeID, force,
-		podExecWithTimeout,
-	)
-}
-
+// removeNodeWithExec executes ledgerctl cluster remove-node via pod exec. If force
+// is true, --force is appended to bypass Raft consensus.
 func removeNodeWithExec(ctx context.Context, cfg *rest.Config, clientset kubernetes.Interface,
 	namespace, pod0, container, serverAddr, tlsMode string, nodeID int32, force bool,
 	exec ledgerctlExec,
@@ -422,35 +405,10 @@ func ledgerctlTLSFlag(tlsMode string) string {
 	return "--insecure"
 }
 
-// isPodNeverReady returns true if the pod has never been ready: not found,
-// still Pending (not scheduled), or no container has ever started.
-// These pods could never have joined the Raft cluster.
-func isPodNeverReady(ctx context.Context, clientset kubernetes.Interface, namespace, podName string) bool {
-	pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
-	if err != nil {
-		// Not found → never existed, never joined.
-		return kerrors.IsNotFound(err)
-	}
-
-	// Pending pods have never started.
-	if pod.Status.Phase == corev1.PodPending {
-		return true
-	}
-
-	// If the pod exists but no container has ever started, it never joined.
-	for _, cs := range pod.Status.ContainerStatuses {
-		if cs.RestartCount > 0 || cs.Ready || cs.State.Running != nil || cs.State.Terminated != nil || cs.LastTerminationState.Running != nil || cs.LastTerminationState.Terminated != nil {
-			return false
-		}
-	}
-
-	// No container statuses at all means the pod was never scheduled.
-	return len(pod.Status.ContainerStatuses) == 0
-}
-
 // isPodCrashed returns true if the pod is permanently unreachable: not found,
 // in Failed phase, or has a container in CrashLoopBackOff/Error/OOMKilled state.
-// Pending and Running pods are considered alive (they may recover).
+// Pending and Running pods without a crash indicator are considered alive
+// (they may recover).
 func isPodCrashed(ctx context.Context, clientset kubernetes.Interface, namespace, podName string) bool {
 	pod, err := clientset.CoreV1().Pods(namespace).Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {

--- a/misc/operator/internal/controller/raft_scaledown_reconcile_integration_test.go
+++ b/misc/operator/internal/controller/raft_scaledown_reconcile_integration_test.go
@@ -1,0 +1,218 @@
+//go:build integration
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+// Kubernetes state is real envtest state; only ledgerctl's Raft boundary is
+// modeled. Establish membership before replacing the Pod so the replacement's
+// Pending phase cannot be mistaken for evidence that its ordinal never joined.
+func TestReconcileScaleDownReplacementMembership(t *testing.T) {
+	t.Parallel()
+
+	for _, replacement := range []string{"pending", "missing"} {
+		for _, outcome := range []string{"success", "failure_then_retry", "later_failure_then_retry", "committed_response_lost"} {
+			t.Run(replacement+"/"+outcome, func(t *testing.T) {
+				t.Parallel()
+
+				namespace := createTestNamespace(t)
+				ledger := newCluster("membership", namespace)
+				// Do not create this CR: the background manager must not race the
+				// direct reconciler or try to run a real ledgerctl process.
+				ledger.UID = types.UID(namespace + "-cluster")
+				applyDefaults(ledger)
+				ledger.Spec.Persistence.DeletionProtection = new(false)
+				clientset, err := kubernetes.NewForConfig(testEnv.Config)
+				require.NoError(t, err)
+				reconciler := &ClusterReconciler{
+					Client: k8sClient, Scheme: k8sClient.Scheme(),
+					Config: testEnv.Config, Clientset: clientset,
+				}
+				fixture := &scaleDownReconcileMembership{
+					t: t, namespace: namespace, pod0: podName(ledger.Name, 0),
+					members: map[int]bool{1: true, 2: true, 3: true},
+					outcome: outcome, forceThird: replacement == "missing",
+				}
+				_, err = reconciler.reconcileStatefulSetWithExec(ctx, ledger, "initial", nil, fixture.exec)
+				require.NoError(t, err)
+				require.Empty(t, fixture.commands, "initial creation must not remove established members")
+
+				for ordinal := range 3 {
+					createScaleDownReconcilePod(t, clientset, namespace, podName(ledger.Name, ordinal), corev1.PodRunning)
+					for _, volume := range []string{"wal", "data"} {
+						_, err := clientset.CoreV1().PersistentVolumeClaims(namespace).Create(ctx, &corev1.PersistentVolumeClaim{
+							ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("%s-%s-%d", volume, resourceName(ledger.Name), ordinal)},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+								Resources:   corev1.VolumeResourceRequirements{Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Gi")}},
+							},
+						}, metav1.CreateOptions{})
+						require.NoError(t, err)
+					}
+				}
+				oldPod, err := clientset.CoreV1().Pods(namespace).Get(ctx, podName(ledger.Name, 2), metav1.GetOptions{})
+				require.NoError(t, err)
+				require.NoError(t, clientset.CoreV1().Pods(namespace).Delete(ctx, oldPod.Name, metav1.DeleteOptions{GracePeriodSeconds: new(int64(0))}))
+				if replacement == "pending" {
+					createScaleDownReconcilePod(t, clientset, namespace, oldPod.Name, corev1.PodPending)
+					newPod, err := clientset.CoreV1().Pods(namespace).Get(ctx, oldPod.Name, metav1.GetOptions{})
+					require.NoError(t, err)
+					require.NotEqual(t, oldPod.UID, newPod.UID, "same ordinal must have a new Pod incarnation")
+				}
+				require.Equal(t, map[int]bool{1: true, 2: true, 3: true}, fixture.members)
+				ledger.Spec.Replicas = new(int32(1))
+				_, err = reconciler.reconcileStatefulSetWithExec(ctx, ledger, "scaled", nil, fixture.exec)
+				if outcome == "failure_then_retry" || outcome == "later_failure_then_retry" {
+					require.ErrorContains(t, err, "injected removal failure")
+					requireScaleDownReconcileState(t, clientset, namespace, resourceName(ledger.Name), 3)
+					t.Logf("failed removal preserved replicas=3 and all PVCs; membership=%v; removal attempts=%v", fixture.members, fixture.removals)
+					if outcome == "failure_then_retry" {
+						require.Equal(t, []int{3}, fixture.removals, "failure must stop before the next ordinal")
+						require.Equal(t, map[int]bool{1: true, 2: true, 3: true}, fixture.members)
+					} else {
+						require.Equal(t, []int{3, 2}, fixture.removals)
+						require.Equal(t, map[int]bool{1: true, 2: true}, fixture.members)
+					}
+					// A new controller has no memory of the successful removal;
+					// retry must recover progress from authoritative membership.
+					reconciler = &ClusterReconciler{
+						Client: k8sClient, Scheme: k8sClient.Scheme(),
+						Config: testEnv.Config, Clientset: clientset,
+					}
+					fixture.transferred = false
+					_, err = reconciler.reconcileStatefulSetWithExec(ctx, ledger, "scaled", nil, fixture.exec)
+				}
+				require.NoError(t, err)
+				requireScaleDownReconcileState(t, clientset, namespace, resourceName(ledger.Name), 1)
+				t.Logf("successful reconcile persisted replicas=1 and requested PVC deletion for ordinals 1 and 2; membership=%v; removal attempts=%v", fixture.members, fixture.removals)
+				require.Equal(t, map[int]bool{1: true}, fixture.members, "every removed ordinal must be absent before replicas decrease")
+				expectedRemovals := []int{3, 2}
+				if outcome == "failure_then_retry" {
+					expectedRemovals = []int{3, 3, 2}
+				} else if outcome == "later_failure_then_retry" {
+					expectedRemovals = []int{3, 2, 2}
+				}
+				require.Equal(t, expectedRemovals, fixture.removals)
+			})
+		}
+	}
+}
+
+type scaleDownReconcileMembership struct {
+	t           *testing.T
+	namespace   string
+	pod0        string
+	members     map[int]bool
+	outcome     string
+	forceThird  bool
+	transferred bool
+	injected    bool
+	commands    []string
+	removals    []int
+}
+
+func (f *scaleDownReconcileMembership) exec(_ context.Context, _ *rest.Config, _ kubernetes.Interface,
+	namespace, pod, container string, command []string,
+) (*execResult, error) {
+	f.t.Helper()
+	require.Equal(f.t, f.namespace, namespace)
+	require.Equal(f.t, f.pod0, pod)
+	require.Equal(f.t, "ledger", container)
+	require.Len(f.t, command, 3)
+	shell := command[2]
+	f.commands = append(f.commands, shell)
+	if strings.Contains(shell, "'cluster' 'transfer-leader' '1'") {
+		f.transferred = true
+		return &execResult{}, nil
+	}
+	require.True(f.t, f.transferred, "leadership transfer must precede membership checks and removal")
+	if strings.Contains(shell, "'cluster' 'status'") {
+		nodes := make([]map[string]int, 0, len(f.members))
+		for _, id := range []int{1, 2, 3} {
+			if f.members[id] {
+				nodes = append(nodes, map[string]int{"id": id})
+			}
+		}
+		encoded, err := json.Marshal(map[string]any{"state": "Leader", "nodes": nodes})
+		require.NoError(f.t, err)
+		return &execResult{Stdout: string(encoded)}, nil
+	}
+	for _, id := range []int{3, 2} {
+		if !strings.Contains(shell, fmt.Sprintf("'cluster' 'remove-node' '%d'", id)) {
+			continue
+		}
+		require.Equal(f.t, id == 3 && f.forceThird, strings.Contains(shell, "'--force'"))
+		require.True(f.t, f.members[id], "a removed member must not be removed a second time")
+		f.removals = append(f.removals, id)
+		inject := f.outcome == "failure_then_retry" ||
+			(f.outcome == "later_failure_then_retry" && id == 2) ||
+			(f.outcome == "committed_response_lost" && id == 3)
+		if !f.injected && inject {
+			f.injected = true
+			if f.outcome == "committed_response_lost" {
+				delete(f.members, id)
+			}
+			return &execResult{Stderr: "opaque CLI failure"}, errors.New("injected removal failure")
+		}
+		delete(f.members, id)
+		return &execResult{}, nil
+	}
+	f.t.Fatalf("unexpected ledgerctl invocation: %s", shell)
+	return nil, errors.New("unexpected ledgerctl invocation")
+}
+
+func createScaleDownReconcilePod(t *testing.T, clientset kubernetes.Interface, namespace, name string, phase corev1.PodPhase) {
+	t.Helper()
+	pod, err := clientset.CoreV1().Pods(namespace).Create(ctx, &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "ledger", Image: "ledger:test"}}},
+	}, metav1.CreateOptions{})
+	require.NoError(t, err)
+	pod.Status.Phase = phase
+	if phase == corev1.PodRunning {
+		pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
+			Name: "ledger", Ready: true, Image: "ledger:test", ImageID: "ledger:test",
+			State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+		}}
+	}
+	_, err = clientset.CoreV1().Pods(namespace).UpdateStatus(ctx, pod, metav1.UpdateOptions{})
+	require.NoError(t, err)
+}
+
+func requireScaleDownReconcileState(t *testing.T, clientset kubernetes.Interface, namespace, name string, replicas int32) {
+	t.Helper()
+	sts := &appsv1.StatefulSet{}
+	require.NoError(t, k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, sts))
+	require.Equal(t, replicas, *sts.Spec.Replicas)
+	for ordinal := range 3 {
+		for _, volume := range []string{"wal", "data"} {
+			pvc, err := clientset.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, fmt.Sprintf("%s-%s-%d", volume, name, ordinal), metav1.GetOptions{})
+			if int32(ordinal) < replicas {
+				require.NoError(t, err)
+				require.Nil(t, pvc.DeletionTimestamp, "retained replicas must keep their PVCs")
+			} else if !kerrors.IsNotFound(err) {
+				require.NoError(t, err)
+				// envtest has no PVC-protection controller to clear finalizers;
+				// a deletion timestamp proves the real API accepted the DELETE.
+				require.NotNil(t, pvc.DeletionTimestamp, "removed replicas must have their PVCs deleted")
+			}
+		}
+	}
+}

--- a/misc/operator/internal/controller/raft_scaledown_replacement_test.go
+++ b/misc/operator/internal/controller/raft_scaledown_replacement_test.go
@@ -1,0 +1,139 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+
+	ledgerv1alpha1 "github.com/formancehq/ledger/misc/operator/api/v1alpha1"
+)
+
+// A Pod incarnation's status says nothing about its ordinal's membership.
+// Start from three established voters even when node 3's replacement cannot run.
+func TestRaftScaleDownReplacementMembership(t *testing.T) {
+	t.Parallel()
+
+	for _, podState := range []string{"pending", "missing", "no-container-status", "running", "pending-image-pull-backoff"} {
+		for _, outcome := range []string{"success", "removal-fails", "response-lost", "already-absent", "status-fails", "transfer-fails"} {
+			t.Run(podState+"/"+outcome, func(t *testing.T) {
+				t.Parallel()
+				ctx := context.Background()
+				cluster := &ledgerv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "replacement", Namespace: "ns"}}
+				objects := []runtime.Object{}
+				for ordinal := range 3 {
+					if ordinal == 2 && podState == "missing" {
+						continue
+					}
+					pod := &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: podName(cluster.Name, ordinal), Namespace: cluster.Namespace},
+						Status: corev1.PodStatus{Phase: corev1.PodRunning, ContainerStatuses: []corev1.ContainerStatus{{
+							Name: "ledger", Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+						}}},
+					}
+					if ordinal == 2 && (podState == "pending" || podState == "no-container-status") {
+						pod.Status.ContainerStatuses = nil
+						if podState == "pending" {
+							pod.Status.Phase = corev1.PodPending
+						}
+					}
+					if ordinal == 2 && podState == "pending-image-pull-backoff" {
+						pod.Status = corev1.PodStatus{Phase: corev1.PodPending, ContainerStatuses: []corev1.ContainerStatus{{
+							Name: "ledger", State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"}},
+						}}}
+					}
+					objects = append(objects, pod)
+				}
+				clientset := fake.NewClientset(objects...)
+				members := map[int]bool{1: true, 2: true, 3: true}
+				if outcome == "already-absent" {
+					delete(members, 3)
+				}
+				var removals []int
+				var calls []string
+				injectedErr := errors.New("injected exec failure")
+				exec := ledgerctlExec(func(_ context.Context, _ *rest.Config, _ kubernetes.Interface,
+					namespace, pod, container string, command []string,
+				) (*execResult, error) {
+					require.Equal(t, cluster.Namespace, namespace)
+					require.Equal(t, podName(cluster.Name, 0), pod)
+					require.Equal(t, "ledger", container)
+					cmd := command[2]
+					calls = append(calls, cmd)
+					switch {
+					case strings.Contains(cmd, "'transfer-leader' '1'"):
+						require.Len(t, calls, 1)
+						if outcome == "transfer-fails" {
+							return nil, injectedErr
+						}
+
+						return &execResult{}, nil
+					case strings.Contains(cmd, "'status'"):
+						if outcome == "status-fails" {
+							return nil, injectedErr
+						}
+						var nodes []string
+						for id := 1; id <= 3; id++ {
+							if members[id] {
+								nodes = append(nodes, fmt.Sprintf(`{"id":%d}`, id))
+							}
+						}
+
+						return &execResult{Stdout: `{"state":"Leader","nodes":[` + strings.Join(nodes, ",") + `]}`}, nil
+					case strings.Contains(cmd, "'remove-node'"):
+						id := 2
+						if strings.Contains(cmd, "'remove-node' '3'") {
+							id = 3
+						}
+						removals = append(removals, id)
+						require.Equal(t, id == 3 && (podState == "missing" || podState == "pending-image-pull-backoff"), strings.Contains(cmd, "'--force'"))
+						if outcome == "removal-fails" {
+							return nil, injectedErr
+						}
+						delete(members, id)
+						if outcome == "response-lost" {
+							return nil, injectedErr
+						}
+
+						return &execResult{}, nil
+					default:
+						t.Fatalf("unexpected command %s", cmd)
+
+						return nil, nil
+					}
+				})
+
+				err := raftScaleDown(ctx, nil, clientset, cluster, 3, 1, "disabled", exec)
+				t.Logf("outcome=%s removals=%v remainingMembership=%v error=%v", outcome, removals, members, err)
+				switch outcome {
+				case "transfer-fails", "status-fails":
+					require.ErrorIs(t, err, injectedErr)
+					require.Empty(t, removals)
+					require.Len(t, members, 3)
+				case "removal-fails":
+					require.ErrorIs(t, err, injectedErr)
+					require.Equal(t, []int{3}, removals, "failure must stop before removing the healthy voter")
+					require.Len(t, members, 3)
+				default:
+					require.NoError(t, err)
+					require.Equal(t, map[int]bool{1: true}, members, "every removed ordinal needs authoritative absence")
+					if outcome == "already-absent" {
+						require.Equal(t, []int{2}, removals)
+						require.Len(t, calls, 4, "both ordinals must be checked, including the absent replacement")
+					} else {
+						require.Equal(t, []int{3, 2}, removals)
+					}
+				}
+			})
+		}
+	}
+}

--- a/misc/operator/internal/controller/reconcile_statefulset.go
+++ b/misc/operator/internal/controller/reconcile_statefulset.go
@@ -30,6 +30,10 @@ import (
 const volumeBindRequeueInterval = 10 * time.Second
 
 func (r *ClusterReconciler) reconcileStatefulSet(ctx context.Context, ledger *ledgerv1alpha1.Cluster, specHash string, credentials []credentialsKeyInfo) (ctrl.Result, error) {
+	return r.reconcileStatefulSetWithExec(ctx, ledger, specHash, credentials, podExecWithTimeout)
+}
+
+func (r *ClusterReconciler) reconcileStatefulSetWithExec(ctx context.Context, ledger *ledgerv1alpha1.Cluster, specHash string, credentials []credentialsKeyInfo, exec ledgerctlExec) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	name := resourceName(ledger.Name)
 
@@ -111,7 +115,7 @@ func (r *ClusterReconciler) reconcileStatefulSet(ctx context.Context, ledger *le
 			// taken before the CreateOrUpdate above): the rolling update has not yet
 			// started, so pod-0's gRPC server is still on the old TLS_MODE.
 			runningTLSMode := currentTLSModeFromStatefulSet(existingForTLS)
-			if err := raftScaleDown(ctx, r.Config, r.Clientset, ledger, previousReplicas, desiredReplicas, runningTLSMode); err != nil {
+			if err := raftScaleDown(ctx, r.Config, r.Clientset, ledger, previousReplicas, desiredReplicas, runningTLSMode, exec); err != nil {
 				return ctrl.Result{}, fmt.Errorf("removing Raft nodes before scale-down: %w", err)
 			}
 		}


### PR DESCRIPTION
## What changed

Require Raft membership verification for every ordinal removed during operator scale-down, including a Pending, missing, or unstarted replacement Pod. Preserve leadership transfer, existing force/consensus selection, and recovery when a removal commits but its response is lost.

## Why

Fixes [EN-1999](https://formance-team.atlassian.net/browse/EN-1999). With established voters `{1,2,3}`, the previous Pod-lifecycle shortcut skipped node 3 and removed node 2, allowing replicas to decrease to one and PVC deletion to be requested while membership remained `{1,3}`.

## Product / operational motivation

Scale-down must preserve a usable membership and retain Kubernetes resources when removal cannot be established. A replacement Pod's lifecycle cannot prove that its stable ordinal never joined Raft. The durable requirement, execution order and residual state after failure are documented in `misc/operator/README.md` and `docs/ops/cluster-operations.md`.

## Technical decision

Remove the Pod-based membership bypass and route every ordinal through the existing membership/removal postcondition. This reuses the current retry and leader-status checks without adding persisted operator state or changing the service protocol. Pod health continues to select force versus consensus removal.

PR #1799 / EN-1874 was inspected: it addresses service-side member identity and discovery, while this change uses the existing raw Raft status. Its branch and changes are excluded.

## Risk

**MEDIUM** — changes the membership gate for replacement Pods during destructive scale-down. No API, protobuf or storage-format changes.

## Validation

- [x] `bash scripts/agent-check`
- [x] `AI_REVIEW_BASE_SHA=8d38782c44b012101961cfb732322729a5163208 bash scripts/agent-check-pr`
- [x] Full operator module: `go -C misc/operator test -race ./... -count=1 -timeout 10m` under the pinned Nix environment.
- [x] Focused operator regressions with `-race -tags integration`: 30 unit cases and eight envtest scenarios, plus existing removal/leadership/classification tests.
- [x] Regression sensitivity: restored the previous Pod skip and observed both unit and integration failures. Real Kubernetes API state showed replicas `1`, PVC deletion requests, and modeled membership `{1,3}`; the separate removal-error path kept replicas `3` and all PVCs.
- [x] Recovery after first/later removal failure uses a fresh reconciler and a real fail-then-success sequence, including skipping an already-removed ordinal.

## Architecture / behavior impact

Every removed ordinal must be already absent or successfully removed before replicas decrease. If removal errors, leader membership must confirm absence; otherwise reconciliation retains replicas and PVCs. Earlier removals may have committed and are recovered on retry.

## Review focus

The removal of the Pod-lifecycle shortcut and the StatefulSet/PVC assertions around failed versus committed-but-unacknowledged removal.

## Known concerns

Envtest exercises the real Kubernetes API; ledgerctl/Raft responses are deterministic fixtures. This does not add a live multi-node Raft/Kubernetes E2E run.


[EN-1999]: https://formance-team.atlassian.net/browse/EN-1999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Native bugfix evidence

DISCOVERY: RELATED_BUT_DIFFERENT — PR #1799 / EN-1874 addresses member identity; EN-1999 fixes the operator Pod-lifecycle bypass.
BEFORE_FIX: BUG_REPRODUCED — deterministic unit and envtest regressions demonstrated membership {1,3} with replicas=1 and PVC deletion requests.
AFTER_FIX: PASS — focused race regressions, full operator race suite, agent-check and exact-base agent-check-pr passed.
