### PR TITLE
fix(operator): recover backup Jobs after lost creation responses (EN-2001)

### DIFF
--- a/docs/ops/backup-restore.md
+++ b/docs/ops/backup-restore.md
@@ -59,7 +59,14 @@ siblings continue waiting. Reconciliation retries the same name and accepts an
 existing Job only when its controller owner UID matches the run. `AlreadyExists`
 (including while the read cache catches up) is retryable; it never causes creation
 under another name. A foreign or unowned Job is left untouched and reported as a
-retryable ownership error. Definitive local construction errors and API
+retryable ownership error in `BackupRun.status.message`. The run remains Running
+and keeps siblings waiting; an operator must resolve the conflicting Job's
+ownership or remove that Job before provisioning can resume. The controller never
+adopts or deletes a foreign Job automatically. Retryable provisioning errors are
+persisted in the message without rewriting unchanged diagnostics. If that status
+write fails, the run stays nonterminal and reconciliation retries. The message is
+cleared after the owned Job becomes available, before processing its outcome.
+Definitive local construction errors and API
 `Invalid`/`BadRequest` creation rejections mark the run Failed; other provisioning
 errors retry. Transient reads of the parent Backup or Cluster also retry rather
 than ending the run during recovery. Once the owned Job completes, its outcome

--- a/docs/ops/backup-restore.md
+++ b/docs/ops/backup-restore.md
@@ -46,6 +46,26 @@ spec:
   failedRunsHistoryLimit: 1
 ```
 
+Each `BackupRun` uses one deterministic Job name and a controller owner reference
+bound to the run UID. To keep a run attached to its actual outcome (EN-2001), the
+controller first checks for a Running sibling, then persists this run as Running
+before attempting Job creation. If that status write fails, it does not submit
+Create. Running therefore includes provisioning and reserves the execution slot
+while a creation outcome is unknown.
+
+A timeout or connection failure after Create may mean the API server committed
+the Job but its response was lost. The run remains nonterminal and Running, so
+siblings continue waiting. Reconciliation retries the same name and accepts an
+existing Job only when its controller owner UID matches the run. `AlreadyExists`
+(including while the read cache catches up) is retryable; it never causes creation
+under another name. A foreign or unowned Job is left untouched and reported as a
+retryable ownership error. Definitive local construction errors and API
+`Invalid`/`BadRequest` creation rejections mark the run Failed; other provisioning
+errors retry. Transient reads of the parent Backup or Cluster also retry rather
+than ending the run during recovery. Once the owned Job completes, its outcome
+and valid result payload are persisted on the run, including after a controller
+restart.
+
 The run history limits retain Kubernetes `BackupRun` resources only. They do
 not retain historical backup artifacts or restore points in object storage.
 

--- a/misc/operator/README.md
+++ b/misc/operator/README.md
@@ -10,7 +10,7 @@ The Ledger Operator manages `Cluster` custom resources to automate the lifecycle
 - **Persistent storage** for WAL and data volumes
 - **Observability** with OpenTelemetry traces, Prometheus metrics, and Pyroscope profiling
 - **Security** with TLS, OIDC authentication, and Ed25519 response signing
-- **Backups** to S3-compatible backends
+- **Backups** to S3-compatible backends, with [recoverable Job provisioning](../../docs/ops/backup-restore.md#scheduling-with-the-kubernetes-operator) and sibling-run exclusion
 - **Credentials** for application-level access control
 
 During StatefulSet scale-down, every removed ordinal must satisfy the Raft

--- a/misc/operator/internal/controller/backuprun_controller.go
+++ b/misc/operator/internal/controller/backuprun_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -77,6 +78,10 @@ func (r *BackupRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		Name:      run.Spec.BackupRef,
 		Namespace: run.Namespace,
 	}, &backup); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("reading Backup %q: %w", run.Spec.BackupRef, err)
+		}
+
 		return r.setRunFailed(ctx, &run, fmt.Sprintf("Backup %q not found: %v", run.Spec.BackupRef, err))
 	}
 
@@ -85,6 +90,10 @@ func (r *BackupRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		Name:      backup.Spec.ClusterRef,
 		Namespace: backup.Namespace,
 	}, &cluster); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("reading Cluster %q: %w", backup.Spec.ClusterRef, err)
+		}
+
 		return r.setRunFailed(ctx, &run, fmt.Sprintf("Cluster %q not found: %v", backup.Spec.ClusterRef, err))
 	}
 
@@ -103,13 +112,8 @@ func (r *BackupRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{RequeueAfter: concurrencyRequeue}, nil
 	}
 
-	// Ensure the backing Job exists.
-	job, err := r.ensureBackupJob(ctx, &run, &backup, &cluster)
-	if err != nil {
-		return r.setRunFailed(ctx, &run, fmt.Sprintf("provisioning backup Job: %v", err))
-	}
-
-	// Transition to Running on the first reconcile after Job creation.
+	// Reserve this run before creating the Job. A lost Create response must
+	// still exclude siblings even when the Job is not yet visible in the cache.
 	if run.Status.Phase != ledgerv1alpha1.BackupRunPhaseRunning {
 		now := metav1.Now()
 		run.Status.Phase = ledgerv1alpha1.BackupRunPhaseRunning
@@ -121,6 +125,17 @@ func (r *BackupRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if err := r.Status().Update(ctx, &run); err != nil {
 			return ctrl.Result{}, err
 		}
+	}
+
+	// Ensure the backing Job exists.
+	job, err := r.ensureBackupJob(ctx, &run, &backup, &cluster)
+	if err != nil {
+		if _, ok := errors.AsType[*permanentBackupJobError](err); ok {
+			return r.setRunFailed(ctx, &run, fmt.Sprintf("provisioning backup Job: %v", err))
+		}
+		// A transport error does not prove Create failed. Keep the reservation
+		// and retry the deterministic name, including after AlreadyExists.
+		return ctrl.Result{}, fmt.Errorf("provisioning backup Job: %w", err)
 	}
 
 	succeeded, terminal, jobMsg := jobTerminalCondition(job)
@@ -161,6 +176,12 @@ func (r *BackupRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	return ctrl.Result{}, nil
 }
 
+// permanentBackupJobError identifies a definitive validation failure before
+// execution, rather than an unknown outcome of an API operation.
+type permanentBackupJobError struct {
+	error
+}
+
 // ensureBackupJob creates the Job for the run on first reconcile and returns
 // the live Job afterwards. The Job is owner-referenced by the BackupRun
 // so deletion cascades.
@@ -173,6 +194,10 @@ func (r *BackupRunReconciler) ensureBackupJob(
 	existing := &batchv1.Job{}
 	err := r.Get(ctx, types.NamespacedName{Name: backupJobName(run), Namespace: run.Namespace}, existing)
 	if err == nil {
+		if !metav1.IsControlledBy(existing, run) {
+			return nil, fmt.Errorf("job %q is not controlled by BackupRun %q (UID %s)", existing.Name, run.Name, run.UID)
+		}
+
 		return existing, nil
 	}
 
@@ -187,14 +212,18 @@ func (r *BackupRunReconciler) ensureBackupJob(
 
 	desired, err := buildBackupJob(run, backup, ls, tlsMode)
 	if err != nil {
-		return nil, err
+		return nil, &permanentBackupJobError{err}
 	}
 
 	if err := controllerutil.SetControllerReference(run, desired, r.Scheme); err != nil {
-		return nil, fmt.Errorf("setting owner reference on Job: %w", err)
+		return nil, &permanentBackupJobError{fmt.Errorf("setting owner reference on Job: %w", err)}
 	}
 
 	if err := r.Create(ctx, desired); err != nil {
+		if apierrors.IsInvalid(err) || apierrors.IsBadRequest(err) {
+			return nil, &permanentBackupJobError{fmt.Errorf("creating Job: %w", err)}
+		}
+
 		return nil, fmt.Errorf("creating Job: %w", err)
 	}
 

--- a/misc/operator/internal/controller/backuprun_controller.go
+++ b/misc/operator/internal/controller/backuprun_controller.go
@@ -135,7 +135,23 @@ func (r *BackupRunReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 		// A transport error does not prove Create failed. Keep the reservation
 		// and retry the deterministic name, including after AlreadyExists.
-		return ctrl.Result{}, fmt.Errorf("provisioning backup Job: %w", err)
+		provisioningErr := fmt.Errorf("provisioning backup Job: %w", err)
+		if run.Status.Message != provisioningErr.Error() {
+			run.Status.Message = provisioningErr.Error()
+			if err := r.Status().Update(ctx, &run); err != nil {
+				return ctrl.Result{}, errors.Join(provisioningErr, fmt.Errorf("recording provisioning error: %w", err))
+			}
+		}
+
+		return ctrl.Result{}, provisioningErr
+	}
+
+	// Clear a previous provisioning diagnostic once the owned Job is available.
+	if run.Status.Message != "" {
+		run.Status.Message = ""
+		if err := r.Status().Update(ctx, &run); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	succeeded, terminal, jobMsg := jobTerminalCondition(job)

--- a/misc/operator/internal/controller/backuprun_recovery_integration_test.go
+++ b/misc/operator/internal/controller/backuprun_recovery_integration_test.go
@@ -1,0 +1,163 @@
+//go:build integration
+
+package controller
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	ledgerv1alpha1 "github.com/formancehq/ledger/misc/operator/api/v1alpha1"
+)
+
+func TestBackupRunCommittedCreateLostResponseIntegration(t *testing.T) {
+	t.Parallel()
+	testCtx, cancelTest := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancelTest()
+	namespace := createTestNamespace(t)
+	c, err := client.NewWithWatch(testEnv.Config, client.Options{Scheme: k8sClient.Scheme()})
+	require.NoError(t, err)
+	clientset := newTestClientset(t)
+
+	cluster := newCluster("recovery-cluster", namespace)
+	cluster.Spec.Image = ledgerv1alpha1.ImageSpec{Repository: "ghcr.io/formancehq/ledger", Tag: "test"}
+	require.NoError(t, c.Create(testCtx, cluster))
+	backup := &ledgerv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "recovery-backup", Namespace: namespace},
+		Spec: ledgerv1alpha1.BackupSpec{
+			ClusterRef: cluster.Name,
+			Destination: ledgerv1alpha1.BackupDestination{
+				Driver: "s3",
+				S3:     &ledgerv1alpha1.S3Config{Bucket: "recovery-bucket"},
+			},
+			// Empty schedules keep the wired Backup controller from creating runs.
+		},
+	}
+	require.NoError(t, c.Create(testCtx, backup))
+	run := &ledgerv1alpha1.BackupRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "recovery-run", Namespace: namespace,
+			Labels: map[string]string{ledgerv1alpha1.LabelBackup: backup.Name},
+		},
+		Spec: ledgerv1alpha1.BackupRunSpec{BackupRef: backup.Name, Type: ledgerv1alpha1.BackupRunTypeFull},
+	}
+	require.NoError(t, c.Create(testCtx, run))
+	req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)}
+	creates := 0
+	wrapped := interceptor.NewClient(c, interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, ok := obj.(*batchv1.Job); !ok {
+				return c.Create(ctx, obj, opts...)
+			}
+			creates++
+			// The reservation must really be durable before a Job can start.
+			var reserved ledgerv1alpha1.BackupRun
+			require.NoError(t, c.Get(ctx, req.NamespacedName, &reserved))
+			require.Equal(t, ledgerv1alpha1.BackupRunPhaseRunning, reserved.Status.Phase)
+			if err := c.Create(ctx, obj, opts...); err != nil {
+				return err
+			}
+			if creates == 1 {
+				// The real API server committed the Job; only its response is lost.
+				return context.DeadlineExceeded
+			}
+			return nil
+		},
+	})
+	reconciler := &BackupRunReconciler{Client: wrapped, Scheme: c.Scheme(), Clientset: clientset}
+	_, err = reconciler.Reconcile(testCtx, req)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.NoError(t, c.Get(testCtx, req.NamespacedName, run))
+	require.Equal(t, ledgerv1alpha1.BackupRunPhaseRunning, run.Status.Phase)
+	require.Nil(t, run.Status.CompletionTime)
+	require.NotNil(t, run.Status.StartTime)
+	reservedStart := run.Status.StartTime.DeepCopy()
+
+	var job batchv1.Job
+	jobKey := client.ObjectKey{Namespace: namespace, Name: backupJobName(run)}
+	require.NoError(t, c.Get(testCtx, jobKey, &job))
+	require.True(t, metav1.IsControlledBy(&job, run))
+	committedUID := job.UID
+	require.NotEmpty(t, committedUID)
+
+	sibling := &ledgerv1alpha1.BackupRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "waiting-run", Namespace: namespace,
+			Labels: map[string]string{ledgerv1alpha1.LabelBackup: backup.Name},
+		},
+		Spec: run.Spec,
+	}
+	require.NoError(t, c.Create(testCtx, sibling))
+	// A fresh controller has no memory of the timed-out request.
+	reconciler = &BackupRunReconciler{Client: wrapped, Scheme: c.Scheme(), Clientset: clientset}
+	result, err := reconciler.Reconcile(testCtx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(sibling)})
+	require.NoError(t, err)
+	require.Equal(t, concurrencyRequeue, result.RequeueAfter)
+	require.NoError(t, c.Get(testCtx, client.ObjectKeyFromObject(sibling), sibling))
+	require.Equal(t, ledgerv1alpha1.BackupRunPhasePending, sibling.Status.Phase)
+	require.Contains(t, sibling.Status.Message, run.Name)
+	require.True(t, apierrors.IsNotFound(c.Get(testCtx, client.ObjectKey{Namespace: namespace, Name: backupJobName(sibling)}, &batchv1.Job{})))
+	require.Equal(t, 1, creates)
+
+	// envtest has no Job controller or kubelet: publish their completed result
+	// through the real Pod and Job status subresources.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "recovery-result", Namespace: namespace,
+			Labels:          map[string]string{"batch.kubernetes.io/job-name": job.Name},
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(&job, batchv1.SchemeGroupVersion.WithKind("Job"))},
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy: corev1.RestartPolicyNever,
+			Containers:    []corev1.Container{{Name: backupJobContainerName, Image: "ghcr.io/formancehq/ledger:test"}},
+		},
+	}
+	pod, err = clientset.CoreV1().Pods(namespace).Create(testCtx, pod, metav1.CreateOptions{})
+	require.NoError(t, err)
+	now := metav1.Now()
+	pod.Status = corev1.PodStatus{
+		Phase: corev1.PodSucceeded,
+		ContainerStatuses: []corev1.ContainerStatus{{
+			Name: backupJobContainerName,
+			State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+				ExitCode: 0, StartedAt: now, FinishedAt: now,
+				Message: `{"filesUploaded":7,"totalFiles":7,"lastAppliedIndex":42,"lastLogSequence":40,"lastAuditSequence":41}`,
+			}},
+		}},
+	}
+	_, err = clientset.CoreV1().Pods(namespace).UpdateStatus(testCtx, pod, metav1.UpdateOptions{})
+	require.NoError(t, err)
+	job.Status = batchv1.JobStatus{
+		StartTime: &now, CompletionTime: &now, Succeeded: 1,
+		Conditions: []batchv1.JobCondition{
+			{Type: batchv1.JobSuccessCriteriaMet, Status: corev1.ConditionTrue, LastTransitionTime: now},
+			{Type: batchv1.JobComplete, Status: corev1.ConditionTrue, LastTransitionTime: now},
+		},
+	}
+	require.NoError(t, c.Status().Update(testCtx, &job))
+	_, err = reconciler.Reconcile(testCtx, req)
+	require.NoError(t, err)
+	require.NoError(t, c.Get(testCtx, req.NamespacedName, run))
+	require.Equal(t, ledgerv1alpha1.BackupRunPhaseSucceeded, run.Status.Phase)
+	require.NotNil(t, run.Status.CompletionTime)
+	require.Equal(t, reservedStart, run.Status.StartTime)
+	require.NotNil(t, run.Status.Full)
+	require.Equal(t, uint32(7), run.Status.Full.FilesUploaded)
+	require.Equal(t, uint64(42), run.Status.Full.LastAppliedIndex)
+	require.Equal(t, uint64(40), run.Status.Full.LastLogSequence)
+	require.Equal(t, uint64(41), run.Status.Full.LastAuditSequence)
+	var jobs batchv1.JobList
+	require.NoError(t, c.List(testCtx, &jobs, client.InNamespace(namespace)))
+	require.Len(t, jobs.Items, 1)
+	require.Equal(t, committedUID, jobs.Items[0].UID)
+	require.Equal(t, 1, creates, "recovery must reuse the committed Job without another Create")
+}

--- a/misc/operator/internal/controller/backuprun_recovery_test.go
+++ b/misc/operator/internal/controller/backuprun_recovery_test.go
@@ -1,0 +1,326 @@
+package controller
+
+import (
+	"context"
+	"errors"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	ledgerv1alpha1 "github.com/formancehq/ledger/misc/operator/api/v1alpha1"
+)
+
+func backupRunRecoveryFixture(t *testing.T) (client.WithWatch, *ledgerv1alpha1.BackupRun) {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, ledgerv1alpha1.AddToScheme(scheme))
+	run := &ledgerv1alpha1.BackupRun{
+		ObjectMeta: metav1.ObjectMeta{Name: "run", Namespace: "test", UID: "run-uid", Labels: map[string]string{ledgerv1alpha1.LabelBackup: "backup"}},
+		Spec:       ledgerv1alpha1.BackupRunSpec{BackupRef: "backup", Type: ledgerv1alpha1.BackupRunTypeFull},
+	}
+	backup := &ledgerv1alpha1.Backup{
+		ObjectMeta: metav1.ObjectMeta{Name: "backup", Namespace: run.Namespace},
+		Spec:       ledgerv1alpha1.BackupSpec{ClusterRef: "cluster", Destination: ledgerv1alpha1.BackupDestination{Driver: "s3", S3: &ledgerv1alpha1.S3Config{Bucket: "bucket"}}},
+	}
+	cluster := &ledgerv1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: run.Namespace}}
+
+	return fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(run, &batchv1.Job{}).WithObjects(run, backup, cluster).Build(), run
+}
+
+func TestBackupRunCommittedCreateLostResponse(t *testing.T) {
+	t.Parallel()
+	for _, dependency := range []string{"none", "Backup", "Cluster"} {
+		t.Run(dependency, func(t *testing.T) {
+			t.Parallel()
+			testBackupRunCommittedCreateLostResponse(t, dependency)
+		})
+	}
+}
+
+func testBackupRunCommittedCreateLostResponse(t *testing.T, dependency string) {
+	t.Helper()
+	ctx := t.Context()
+	c, run := backupRunRecoveryFixture(t)
+	creates, failedWrites := 0, 0
+	dependencyFailures := 0
+	wrapped := interceptor.NewClient(c, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			_, isBackup := obj.(*ledgerv1alpha1.Backup)
+			_, isCluster := obj.(*ledgerv1alpha1.Cluster)
+			if creates == 1 && dependencyFailures == 0 && ((dependency == "Backup" && isBackup) || (dependency == "Cluster" && isCluster)) {
+				dependencyFailures++
+
+				return context.DeadlineExceeded
+			}
+
+			return c.Get(ctx, key, obj, opts...)
+		},
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, ok := obj.(*batchv1.Job); !ok {
+				return c.Create(ctx, obj, opts...)
+			}
+			creates++
+			if err := c.Create(ctx, obj, opts...); err != nil {
+				return err
+			}
+			if creates == 1 {
+				return context.DeadlineExceeded
+			}
+
+			return nil
+		},
+		SubResourceUpdate: func(ctx context.Context, c client.Client, name string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+			err := c.SubResource(name).Update(ctx, obj, opts...)
+			if r, ok := obj.(*ledgerv1alpha1.BackupRun); ok && r.Status.Phase == ledgerv1alpha1.BackupRunPhaseFailed && err == nil {
+				failedWrites++
+			}
+
+			return err
+		},
+	})
+	req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)}
+	r := &BackupRunReconciler{Client: wrapped, Scheme: c.Scheme()}
+	_, err := r.Reconcile(ctx, req)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	require.NoError(t, c.Get(ctx, req.NamespacedName, run))
+	require.Zero(t, failedWrites)
+	require.Equal(t, ledgerv1alpha1.BackupRunPhaseRunning, run.Status.Phase)
+	require.Nil(t, run.Status.CompletionTime)
+	if dependency != "none" {
+		_, err = r.Reconcile(ctx, req)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.Equal(t, 1, dependencyFailures)
+		require.NoError(t, c.Get(ctx, req.NamespacedName, run))
+		require.Equal(t, ledgerv1alpha1.BackupRunPhaseRunning, run.Status.Phase)
+		require.Nil(t, run.Status.CompletionTime)
+		require.Zero(t, failedWrites)
+	}
+	job := &batchv1.Job{}
+	require.NoError(t, c.Get(ctx, client.ObjectKey{Namespace: run.Namespace, Name: backupJobName(run)}, job))
+	require.True(t, metav1.IsControlledBy(job, run))
+	job.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
+	require.NoError(t, c.Status().Update(ctx, job))
+	pods := k8sfake.NewClientset(&corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "result", Namespace: run.Namespace, Labels: map[string]string{"batch.kubernetes.io/job-name": job.Name}},
+		Status:     corev1.PodStatus{ContainerStatuses: []corev1.ContainerStatus{{Name: backupJobContainerName, State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Message: `{"filesUploaded":7,"totalFiles":7,"lastAppliedIndex":42}`}}}}},
+	})
+	r = &BackupRunReconciler{Client: wrapped, Scheme: c.Scheme(), Clientset: pods}
+	_, err = r.Reconcile(ctx, req)
+	require.NoError(t, err)
+	require.NoError(t, c.Get(ctx, req.NamespacedName, run))
+	require.Equal(t, ledgerv1alpha1.BackupRunPhaseSucceeded, run.Status.Phase)
+	require.NotNil(t, run.Status.CompletionTime)
+	require.NotNil(t, run.Status.Full)
+	require.EqualValues(t, 7, run.Status.Full.FilesUploaded)
+	require.EqualValues(t, 42, run.Status.Full.LastAppliedIndex)
+	var jobs batchv1.JobList
+	require.NoError(t, c.List(ctx, &jobs))
+	require.Len(t, jobs.Items, 1)
+	require.Equal(t, 1, creates)
+}
+
+func TestBackupRunCreateFailureClassification(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name     string
+		err      error
+		terminal bool
+	}{
+		{"timeout", context.DeadlineExceeded, false},
+		{"lost connection", io.EOF, false},
+		{"server timeout", apierrors.NewServerTimeout(schema.GroupResource{Group: "batch", Resource: "jobs"}, "create", 1), false},
+		{"quota or RBAC", apierrors.NewForbidden(schema.GroupResource{Group: "batch", Resource: "jobs"}, "run", errors.New("temporarily denied")), false},
+		{"invalid", apierrors.NewInvalid(schema.GroupKind{Group: "batch", Kind: "Job"}, "run", field.ErrorList{field.Invalid(field.NewPath("spec"), "bad", "invalid spec")}), true},
+		{"bad request", apierrors.NewBadRequest("invalid request"), true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			c, run := backupRunRecoveryFixture(t)
+			attempts := 0
+			wrapped := interceptor.NewClient(c, interceptor.Funcs{Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				attempts++
+				if attempts == 1 {
+					return tt.err
+				}
+
+				return c.Create(ctx, obj, opts...)
+			}})
+			r := &BackupRunReconciler{Client: wrapped, Scheme: c.Scheme()}
+			req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)}
+			_, err := r.Reconcile(ctx, req)
+			if tt.terminal {
+				require.NoError(t, err)
+			} else {
+				require.ErrorIs(t, err, tt.err)
+			}
+			require.NoError(t, c.Get(ctx, req.NamespacedName, run))
+			require.Equal(t, tt.terminal, run.IsTerminal())
+			var jobs batchv1.JobList
+			require.NoError(t, c.List(ctx, &jobs))
+			require.Empty(t, jobs.Items)
+			_, err = r.Reconcile(ctx, req)
+			require.NoError(t, err)
+			require.NoError(t, c.List(ctx, &jobs))
+			if tt.terminal {
+				require.Equal(t, ledgerv1alpha1.BackupRunPhaseFailed, run.Status.Phase)
+				require.NotNil(t, run.Status.CompletionTime)
+				require.Equal(t, 1, attempts)
+				require.Empty(t, jobs.Items)
+			} else {
+				require.Equal(t, 2, attempts)
+				require.Len(t, jobs.Items, 1)
+				require.True(t, metav1.IsControlledBy(&jobs.Items[0], run))
+				require.NoError(t, c.Get(ctx, req.NamespacedName, run))
+				require.Equal(t, ledgerv1alpha1.BackupRunPhaseRunning, run.Status.Phase)
+			}
+		})
+	}
+}
+
+func TestBackupRunReservationMustPersistBeforeCreate(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	c, run := backupRunRecoveryFixture(t)
+	attempts := 0
+	wrapped := interceptor.NewClient(c, interceptor.Funcs{SubResourceUpdate: func(ctx context.Context, c client.Client, name string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+		attempts++
+		if attempts == 1 {
+			return context.DeadlineExceeded
+		}
+
+		return c.SubResource(name).Update(ctx, obj, opts...)
+	}})
+	r := &BackupRunReconciler{Client: wrapped, Scheme: c.Scheme()}
+	req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)}
+	_, err := r.Reconcile(ctx, req)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	var jobs batchv1.JobList
+	require.NoError(t, c.List(ctx, &jobs))
+	require.Empty(t, jobs.Items)
+	_, err = r.Reconcile(ctx, req)
+	require.NoError(t, err)
+	require.Equal(t, 2, attempts)
+	require.NoError(t, c.List(ctx, &jobs))
+	require.Len(t, jobs.Items, 1)
+}
+
+func TestBackupRunRejectsForeignJob(t *testing.T) {
+	t.Parallel()
+	for _, owner := range []string{"", "previous-run-uid"} {
+		t.Run("owner="+owner, func(t *testing.T) {
+			t.Parallel()
+			ctx := t.Context()
+			c, run := backupRunRecoveryFixture(t)
+			job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: backupJobName(run), Namespace: run.Namespace}}
+			if owner != "" {
+				other := run.DeepCopy()
+				other.UID = types.UID(owner)
+				job.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(other, ledgerv1alpha1.GroupVersion.WithKind("BackupRun"))}
+			}
+			job.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
+			require.NoError(t, c.Create(ctx, job))
+			r := &BackupRunReconciler{Client: c, Scheme: c.Scheme()}
+			_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)})
+			require.ErrorContains(t, err, "is not controlled by BackupRun")
+			require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(run), run))
+			require.False(t, run.IsTerminal())
+			require.Nil(t, run.Status.Full)
+			var jobs batchv1.JobList
+			require.NoError(t, c.List(ctx, &jobs))
+			require.Len(t, jobs.Items, 1)
+			require.Equal(t, job.OwnerReferences, jobs.Items[0].OwnerReferences)
+		})
+	}
+}
+
+func TestBackupRunInvalidTypeIsTerminal(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	c, run := backupRunRecoveryFixture(t)
+	run.Spec.Type = "invalid"
+	require.NoError(t, c.Update(ctx, run))
+	r := &BackupRunReconciler{Client: c, Scheme: c.Scheme()}
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)})
+	require.NoError(t, err)
+	require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(run), run))
+	require.Equal(t, ledgerv1alpha1.BackupRunPhaseFailed, run.Status.Phase)
+	require.Contains(t, run.Status.Message, "unsupported backup type")
+	var jobs batchv1.JobList
+	require.NoError(t, c.List(ctx, &jobs))
+	require.Empty(t, jobs.Items)
+}
+
+func TestBackupRunCommittedCreateCacheLag(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	c, run := backupRunRecoveryFixture(t)
+	creates, commits, jobReads := 0, 0, 0
+	wrapped := interceptor.NewClient(c, interceptor.Funcs{
+		Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, ok := obj.(*batchv1.Job); ok {
+				jobReads++
+				if jobReads == 2 {
+					return apierrors.NewNotFound(schema.GroupResource{Group: "batch", Resource: "jobs"}, key.Name)
+				}
+			}
+
+			return c.Get(ctx, key, obj, opts...)
+		},
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, ok := obj.(*batchv1.Job); !ok {
+				return c.Create(ctx, obj, opts...)
+			}
+			creates++
+			if err := c.Create(ctx, obj, opts...); err != nil {
+				return err
+			}
+			commits++
+			if creates == 1 {
+				return context.DeadlineExceeded
+			}
+
+			return nil
+		},
+	})
+	r := &BackupRunReconciler{Client: wrapped, Scheme: c.Scheme()}
+	req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)}
+	_, err := r.Reconcile(ctx, req)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+	sibling := run.DeepCopy()
+	sibling.Name, sibling.UID = "sibling", "sibling-uid"
+	sibling.ResourceVersion = ""
+	require.NoError(t, c.Create(ctx, sibling))
+	result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(sibling)})
+	require.NoError(t, err)
+	require.Equal(t, concurrencyRequeue, result.RequeueAfter)
+	require.Equal(t, 1, creates)
+	_, err = r.Reconcile(ctx, req)
+	require.True(t, apierrors.IsAlreadyExists(err), "stale NotFound must encounter the committed deterministic Job: %v", err)
+	_, err = r.Reconcile(ctx, req)
+	require.NoError(t, err)
+	require.NoError(t, c.Get(ctx, req.NamespacedName, run))
+	require.Equal(t, ledgerv1alpha1.BackupRunPhaseRunning, run.Status.Phase)
+	require.Equal(t, 2, creates)
+	require.Equal(t, 1, commits)
+	var jobs batchv1.JobList
+	require.NoError(t, c.List(ctx, &jobs))
+	require.Len(t, jobs.Items, 1)
+	require.True(t, metav1.IsControlledBy(&jobs.Items[0], run))
+}

--- a/misc/operator/internal/controller/backuprun_recovery_test.go
+++ b/misc/operator/internal/controller/backuprun_recovery_test.go
@@ -241,11 +241,31 @@ func TestBackupRunRejectsForeignJob(t *testing.T) {
 			require.ErrorContains(t, err, "is not controlled by BackupRun")
 			require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(run), run))
 			require.False(t, run.IsTerminal())
+			require.Contains(t, run.Status.Message, "is not controlled by BackupRun")
 			require.Nil(t, run.Status.Full)
 			var jobs batchv1.JobList
 			require.NoError(t, c.List(ctx, &jobs))
 			require.Len(t, jobs.Items, 1)
 			require.Equal(t, job.OwnerReferences, jobs.Items[0].OwnerReferences)
+			// Repeating the same error must not continuously update status.
+			version := run.ResourceVersion
+			_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)})
+			require.ErrorContains(t, err, "is not controlled by BackupRun")
+			require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(run), run))
+			require.Equal(t, version, run.ResourceVersion)
+
+			// An operator clears the conflict; reconciliation creates our Job
+			// and removes the stale diagnostic while retaining the reservation.
+			require.NoError(t, c.Delete(ctx, job))
+			_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)})
+			require.NoError(t, err)
+			require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(run), run))
+			require.Empty(t, run.Status.Message)
+			require.Equal(t, ledgerv1alpha1.BackupRunPhaseRunning, run.Status.Phase)
+			require.Nil(t, run.Status.Full)
+			require.NoError(t, c.List(ctx, &jobs))
+			require.Len(t, jobs.Items, 1)
+			require.True(t, metav1.IsControlledBy(&jobs.Items[0], run))
 		})
 	}
 }
@@ -323,4 +343,43 @@ func TestBackupRunCommittedCreateCacheLag(t *testing.T) {
 	require.NoError(t, c.List(ctx, &jobs))
 	require.Len(t, jobs.Items, 1)
 	require.True(t, metav1.IsControlledBy(&jobs.Items[0], run))
+}
+
+func TestBackupRunProvisioningMessageWriteRetry(t *testing.T) {
+	t.Parallel()
+	ctx := t.Context()
+	c, run := backupRunRecoveryFixture(t)
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: backupJobName(run), Namespace: run.Namespace}}
+	require.NoError(t, c.Create(ctx, job))
+	writes := 0
+	wrapped := interceptor.NewClient(c, interceptor.Funcs{
+		SubResourceUpdate: func(ctx context.Context, c client.Client, name string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+			if r, ok := obj.(*ledgerv1alpha1.BackupRun); ok && r.Status.Message != "" {
+				writes++
+				if writes == 1 {
+					return io.ErrUnexpectedEOF
+				}
+			}
+
+			return c.SubResource(name).Update(ctx, obj, opts...)
+		},
+	})
+	r := &BackupRunReconciler{Client: wrapped, Scheme: c.Scheme()}
+	req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(run)}
+	_, err := r.Reconcile(ctx, req)
+	require.ErrorContains(t, err, "is not controlled by BackupRun")
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+	require.NoError(t, c.Get(ctx, req.NamespacedName, run))
+	require.Equal(t, ledgerv1alpha1.BackupRunPhaseRunning, run.Status.Phase)
+	require.Empty(t, run.Status.Message)
+	_, err = r.Reconcile(ctx, req)
+	require.ErrorContains(t, err, "is not controlled by BackupRun")
+	require.NoError(t, c.Get(ctx, req.NamespacedName, run))
+	require.Contains(t, run.Status.Message, "is not controlled by BackupRun")
+	require.Equal(t, 2, writes)
+	require.False(t, run.IsTerminal())
+	var jobs batchv1.JobList
+	require.NoError(t, c.List(ctx, &jobs))
+	require.Len(t, jobs.Items, 1)
+	require.Empty(t, jobs.Items[0].OwnerReferences)
 }


### PR DESCRIPTION
## What changed

Retryable provisioning errors, including foreign/unowned Job conflicts, are now visible in `BackupRun.status.message`. Identical diagnostics do not rewrite status; the message clears when the owned Job becomes available. Status-write failures preserve both the provisioning cause and write error for retry.

BackupRun now persists its Running reservation before creating a Job and retries ambiguous provisioning errors. Recovery uses the deterministic Job name and verifies the controller owner UID before consuming its outcome. Definitive construction and API validation errors remain terminal; transient Backup/Cluster reads remain retryable during recovery.

## Why

Fixes [EN-2001](https://formance-team.atlassian.net/browse/EN-2001). When the API server committed Job creation but its response was lost, the controller persisted Failed and its terminal guard ignored the eventual successful Job result.

## Product / operational motivation

A run must remain attached to the outcome of a potentially committed Job, and waiting sibling runs must stay excluded while that outcome is unknown. The regression reproduces commit, timeout, successful Failed-status persistence, and ignored completion on the original controller. The recovery contract and execution order are documented in `docs/ops/backup-restore.md` and linked from `misc/operator/README.md`.

## Technical decision

Persist Running before Create so the execution slot survives lost responses and controller restart. Retry the same deterministic Job identity, including AlreadyExists while the cache catches up, and require the current BackupRun controller UID. Only local construction failures and Create Invalid/BadRequest responses prove a definitive provisioning failure. Keeping the terminal guard preserves final outcomes; removing it would leave the underlying false failure and sibling-admission window unresolved.

## Risk

**LOW** — confined to BackupRun provisioning and recovery. Running now includes provisioning; persistent transient errors retain the sibling exclusion until recovery. No service protocol, storage format, FSM, or dependency changes.

## Validation

- Original behavior reproduced: committed owned Job, lost response, successful Failed status, valid completed Job ignored by a fresh controller.
- Mutation check: the recovery regression fails with the original controller restored.
- `bash scripts/agent-check`
- `AI_REVIEW_BASE_SHA=fada86bcfc1c7f228ede10151fd5f718c2a0beb8 bash scripts/agent-check-pr`
- `go -C misc/operator test -race ./internal/controller -count=1`
- `go -C misc/operator test -race -tags=integration ./internal/controller -run '^TestBackupRunCommittedCreateLostResponseIntegration$' -count=1`

The integration test uses a real API server for Job creation and Pod/Job status writes. It proves sibling exclusion, recovery after controller replacement, preserved result fields and Job UID, and exactly one Job creation. Additional tests cover a stale read followed by AlreadyExists, a failed reservation write, wrong/missing owners, transient dependency reads, and definitive versus retryable creation errors. Tests retain parallel execution.

## Architecture / behavior impact

Running is persisted before the external Job effect. Unknown effects remain reconcilable; existing Jobs are accepted only for their owning run. Final outcomes remain terminal.

## Review focus

Error classification, reservation-before-Create ordering, and recovery without consuming a foreign Job or creating a duplicate.

## Known concerns

None.


[EN-2001]: https://formance-team.atlassian.net/browse/EN-2001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Bugfix evidence

```text
DISCOVERY: PARTIAL_FIX — the EN-2001 implementation was already present; Shipfox identified missing status diagnostics for foreign Jobs.
BEFORE_FIX: BUG_REPRODUCED — on 8d38782c44b012101961cfb732322729a5163208, committed Job Create followed by DeadlineExceeded and successful Failed status leaves completed Job result ignored by a fresh reconciler.
AFTER_FIX: PASS — original recovery regressions, additive diagnostic/recovery and fail-once status-write tests, controller race suite, real API-server integration, agent-check and exact-base agent-check-pr passed for 193c05691. The new tests failed before the follow-up fix because status.message remained empty.
```

