### PR TITLE
fix(indexes): reject duplicate creations (EN-2009)

### DIFF
--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -721,7 +721,8 @@ ledgerctl indexes create [flags]
 **Behavior:**
 - The index starts building in the background immediately
 - Queries using the index will be rejected until the index reaches READY status
-- Creating an index that already exists and is READY is idempotent (no error)
+- Creating an index that already exists fails with `INDEX_ALREADY_EXISTS` (gRPC `AlreadyExists`), whether it is building, ready, or being retyped. The existing registry row and build progress remain unchanged.
+- Replaying an identical batch with its retained idempotency key returns the original result; a new create request or a different key is subject to the existence check.
 - `--target` and `--key` are only valid with `--type metadata`; passing them with any other type is rejected. In particular, there is no builtin address index scoped to accounts — `address`, `source-address`, and `destination-address` all index transactions.
 
 **Example:**

--- a/docs/technical/architecture/subsystems/api/http-api.md
+++ b/docs/technical/architecture/subsystems/api/http-api.md
@@ -646,7 +646,7 @@ Content-Type: application/json
 }
 ```
 
-Returns `201 Created` once the FSM has queued the backfill. Poll `GET /v3/{ledgerName}/indexes/{canonicalId}/status` and wait for `currentVersion > 0` with `pendingVersion == 0` before running queries that need it. After a *retype*, the pre-retype keyspace stays live, so capture `currentVersion` before issuing the change and wait until it has advanced past that value with `pendingVersion == 0` (per-replica version numbers are local and not comparable to `forwardEncodingVersion`).
+Returns `201 Created` once the FSM has accepted creation. If the canonical index already exists on the ledger, returns `409 Conflict` with `errorCode: "INDEX_ALREADY_EXISTS"`, including while building or retyping. The existing index remains unchanged. An identical batch replay using its retained `Idempotency-Key` returns the original result. Poll `GET /v3/{ledgerName}/indexes/{canonicalId}/status` and wait for `currentVersion > 0` with `pendingVersion == 0` before running queries that need it. After a *retype*, the pre-retype keyspace stays live, so capture `currentVersion` before issuing the change and wait until it has advanced past that value with `pendingVersion == 0` (per-replica version numbers are local and not comparable to `forwardEncodingVersion`).
 
 #### List indexes on a ledger
 

--- a/docs/technical/architecture/subsystems/api/protocol-compatibility.md
+++ b/docs/technical/architecture/subsystems/api/protocol-compatibility.md
@@ -20,7 +20,7 @@ compatibility of development revisions.
 ## Wire contract and failure behavior
 
 `pkg/grpcprotocol.Version` is the compiled service protocol revision, currently
-`"5"`. `pkg/grpcprotocol.MetadataKey` is `ledger-protocol-version`. Clients send
+`"6"`. `pkg/grpcprotocol.MetadataKey` is `ledger-protocol-version`. Clients send
 exactly one value for this metadata key on every RPC. The Go
 `grpcprotocol.ClientOption()` dial option supplies the local revision for unary
 and streaming calls. Local `dev` builds carry the same constant without release
@@ -49,6 +49,12 @@ Restore mode does not register Discovery: its service gate provides the
 compatibility error without requiring a preliminary Discovery call, while
 health and reflection remain exempt.
 
+Revision 6 (EN-2009) makes fresh `CreateIndex` requests strict: an existing
+ledger/canonical index identity returns `INDEX_ALREADY_EXISTS` (`AlreadyExists`)
+instead of overwriting the registry. Retained batch idempotency retries still
+return the frozen outcome. This incompatible semantic change requires matching
+clients and servers; apply semantics must agree across every replica.
+
 Revision 5 (EN-1623) removes internal index/coverage details from public
 error messages and ErrorInfo metadata while retaining their reasons and status
 codes. Internal read failures in restore validation retain `Internal` with a
@@ -67,10 +73,10 @@ servers or support for mixed wire-format upgrades.
 
 Every consumer of the service gRPC endpoint must declare its protocol,
 including SDKs, automation, `grpcurl`, and internal requests forwarded to a
-leader. For example, with a schema implementing revision 5:
+leader. For example, with a schema implementing revision 6:
 
 ```bash
-grpcurl -plaintext -H 'ledger-protocol-version: 5' \
+grpcurl -plaintext -H 'ledger-protocol-version: 6' \
   localhost:8888 cluster.ClusterService.GetClusterState
 ```
 

--- a/docs/technical/architecture/subsystems/indexer/README.md
+++ b/docs/technical/architecture/subsystems/indexer/README.md
@@ -13,7 +13,7 @@ version at that pin, and ignores membership events committed after it.
 
 | Document | Description |
 |----------|-------------|
-| [indexes.md](indexes.md) | Index definition (`commonpb.Index`), per-replica `IndexVersionState`, on-demand statistics, and checker coverage. |
+| [indexes.md](indexes.md) | Strict index creation, index definition (`commonpb.Index`), per-replica `IndexVersionState`, on-demand statistics, and checker coverage. |
 | [indexer.md](indexer.md) | Indexer pipeline: builder loop, two-pass commit, handlers, event-GC scheduling, read-store and field/version-first reverse-map key layouts, atomic switch, schema rewrite. |
 
 ## Related

--- a/docs/technical/architecture/subsystems/indexer/indexes.md
+++ b/docs/technical/architecture/subsystems/indexer/indexes.md
@@ -26,6 +26,30 @@ Source: `internal/proto/commonpb/common.pb.go:2527-2550`.
 
 Build progress is deliberately absent from the registry row: it is a per-replica concern. Queries consult the per-replica `IndexVersionState.CurrentVersion`, and the status API derives its display from that state next to the row's cluster-wide `forward_encoding_version`.
 
+## Strict creation
+
+[EN-2009](https://formance-team.atlassian.net/browse/EN-2009) requires a
+successful fresh creation to mean that an index was actually created. This
+keeps creation audit records unambiguous and avoids resetting a live registry
+row. Strict rejection follows named-resource creation semantics; there is no
+ensure/upsert mode or automatic skip. Operator ownership recovery and
+conditional deletion of a replaced index remain separate concerns.
+
+`CreateIndex` creates one registry entry per `(ledger, canonical IndexID)`.
+The FSM reads that entry through its declared, scoped coverage before writing;
+read or coverage failures propagate. An existing entry returns
+`INDEX_ALREADY_EXISTS` (HTTP `409`, gRPC `AlreadyExists`) regardless of local
+build progress or an in-flight schema rewrite. It does not reset `created_at`,
+`forward_encoding_version`, bindings, or per-replica state, and emits no
+`CreatedIndexLog` or new skipped-order log. A duplicate inside one atomic batch
+fails the batch, rolling back earlier orders in that batch.
+
+A retained batch idempotency key still replays the original batch result before
+executing orders. This is distinct from a new create request, including one
+with a different key. A committed drop or metadata-field removal deletes the
+registry entry and permits a later fresh creation. Recreate starts the registry
+version at 1; local version allocation retains its existing high-water guard.
+
 ## Per-Replica Version State
 
 `readstore.IndexVersionState` is the only state that decides which keyspace queries scan on this replica. It lives under `SubInternalIndexVersion` in Pebble and is **not part of the audit chain** — it is a projection (a per-replica view of cluster-wide rewrite progress).
@@ -113,7 +137,7 @@ The classification is deliberately conservative: only the same-atomic-batch-befo
 
 The index registry (the bucket-scoped `Index` rows under `SubAttrIndex`) is a persisted projection of the audited order stream, so a cross-cluster restore must reproduce it the same way the live apply path built it: the checkpoint's attribute zone carries the rows as of the checkpoint, and `RebuildDelta` (`internal/infra/backup/rebuild.go`, shared with `ledgerctl store bootstrap`) folds every post-checkpoint ledger log into them. The replay evidence is the exported logs themselves — each registry mutation is derived from a log payload alone, never from state the source cluster held outside the export:
 
-- **`CreateIndex`** writes the same fresh registry row the live `processCreateIndex` writes, at `forward_encoding_version` 1, stamped with the enclosing `LedgerLog`'s date (the apply-time effective date). A duplicate `CreateIndex` overwrites the row, matching the live handler.
+- **`CreateIndex`** writes the same fresh registry row the live `processCreateIndex` writes, at `forward_encoding_version` 1, stamped with the enclosing `LedgerLog`'s date (the apply-time effective date). The live FSM rejects duplicate creation, so a failed duplicate contributes no creation log to replay. Replay continues to fold accepted creation logs into fresh registry rows. The indexbuilder retains its guards against repeated log processing.
 - **`SetMetadataFieldType`** applies the retype cascade: when a registry row covers the retyped `(target, key)`, its `forward_encoding_version` is bumped, mirroring the live `processSetMetadataFieldType`. A field with no covering index is a registry no-op.
 - **`DropIndex`** deletes the registry row.
 - **`RemovedMetadataFieldType`** carries the removal cascade in the log itself: the payload names the index the removal dropped (`dropped_index`), and the row is deleted from the log alone — the replay never re-derives which index a removal covered.

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -621,7 +621,12 @@ See [Idempotency](../architecture/subsystems/admission/idempotency.md) for detai
 local `IndexVersionState` (`current_version`, `pending_version`), not
 by a cluster-wide flag.
 
-- `CreateIndex` registers the index at `forward_encoding_version = 1`
+- `CreateIndex` is strict: an existing `(ledger, canonical IndexID)` fails
+  with `INDEX_ALREADY_EXISTS` (HTTP `409`, gRPC `AlreadyExists`), including
+  while building or retyping. The registry and local build state remain
+  unchanged. Retained batch-idempotency replay keeps returning its original
+  result.
+- `CreateIndex` registers a new index at `forward_encoding_version = 1`
   and each replica starts a local backfill. When the backfill catches
   up to the global indexer cursor, the replica performs a local atomic
   switch (`current_version` 0 → 1) in a single Pebble batch. There is

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -13,7 +13,7 @@ This document compares the POC's API with the original Formance ledger API and d
 ### Service protocol compatibility (EN-1851)
 
 The v3 gRPC service requires one `ledger-protocol-version` metadata value per
-business RPC, equal to `pkg/grpcprotocol.Version` (currently `"4"`). Missing,
+business RPC, equal to `pkg/grpcprotocol.Version`. Missing,
 invalid, duplicate, or different revisions fail with `FailedPrecondition` before
 business handler execution. This applies to unary and streaming Bucket, Cluster,
 and Restore operations, including internal forwarding. Discovery, gRPC health,

--- a/internal/adapter/grpc/errors_test.go
+++ b/internal/adapter/grpc/errors_test.go
@@ -86,6 +86,24 @@ func TestBusinessErrorToGRPCStatus_LedgerAlreadyExists(t *testing.T) {
 	require.Equal(t, "my-ledger", info.GetMetadata()["name"])
 }
 
+func TestBusinessErrorToGRPCStatus_IndexAlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	const canonical = "metadata:TARGET_TYPE_ACCOUNT:category"
+	st := businessErrorToGRPCStatus(&domain.BusinessError{Err: &domain.ErrIndexAlreadyExists{Index: canonical}})
+	require.Equal(t, codes.AlreadyExists, st.Code())
+	info := extractErrorInfo(t, st)
+	require.Equal(t, domain.ErrReasonIndexAlreadyExists, info.GetReason())
+	require.Equal(t, errorDomain, info.GetDomain())
+	require.Equal(t, map[string]string{"index": canonical}, info.GetMetadata())
+
+	remote := grpcerr.FromStatusError(st.Err())
+	var describable interface{ Reason() string }
+	require.ErrorAs(t, remote, &describable)
+	require.Equal(t, domain.ErrReasonIndexAlreadyExists, describable.Reason())
+	require.Equal(t, codes.AlreadyExists, status.Code(remote))
+}
+
 func TestBusinessErrorToGRPCStatus_SequenceExhausted(t *testing.T) {
 	t.Parallel()
 

--- a/internal/adapter/http/handlers_create_index_test.go
+++ b/internal/adapter/http/handlers_create_index_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
@@ -193,4 +194,24 @@ func TestHandleCreateIndex_BackendError(t *testing.T) {
 	srv.handleCreateIndex(w, r)
 
 	require.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestHandleCreateIndex_AlreadyExists(t *testing.T) {
+	t.Parallel()
+
+	backend := NewMockBackend(gomock.NewController(t))
+	backend.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil,
+		&domain.ErrIndexAlreadyExists{Index: "tx_builtin:TX_BUILTIN_INDEX_TIMESTAMP"})
+	srv := newTestServer(t, backend)
+
+	w := httptest.NewRecorder()
+	body := strings.NewReader(`{"id":"tx_builtin:TX_BUILTIN_INDEX_TIMESTAMP"}`)
+	r := newRequest(t, http.MethodPost, "/ledger1/indexes", body, map[string]string{
+		"ledgerName": "ledger1",
+	})
+
+	srv.handleCreateIndex(w, r)
+
+	require.Equal(t, http.StatusConflict, w.Code)
+	require.JSONEq(t, `{"errorCode":"INDEX_ALREADY_EXISTS","errorMessage":"index already exists: tx_builtin:TX_BUILTIN_INDEX_TIMESTAMP"}`, w.Body.String())
 }

--- a/internal/application/admission/admission.go
+++ b/internal/application/admission/admission.go
@@ -1457,9 +1457,9 @@ func extractLedgerScopedNeeds(p *plan.Coverage, ls *raftcmdpb.LedgerScopedOrder,
 			}
 
 		case *raftcmdpb.LedgerApplyOrder_CreateIndex:
-			// processCreateIndex overwrites the registry row; keep the key
-			// inside the declared preload set so the cache is seeded
-			// consistently with the drop / retype paths below.
+			// processCreateIndex reads the registry to reject duplicates.
+			// Declare and preload the key for deterministic existence checks,
+			// including when another creation commits before this proposal.
 			p.Add(dal.SubAttrIndex, domain.IndexKey{LedgerName: ledgerName, Canonical: indexes.Canonical(applyData.CreateIndex.GetId())}.Bytes())
 
 		case *raftcmdpb.LedgerApplyOrder_DropIndex:

--- a/internal/application/indexbuilder/index_config.go
+++ b/internal/application/indexbuilder/index_config.go
@@ -395,7 +395,7 @@ func (b *Builder) getOrCreateLedgerConfig(ledger string) *ledgerIndexConfig {
 // declared on a born-empty ledger), there is no local history to replay — the
 // index is promoted straight to live at HighWater+1 and NO backfill is scheduled.
 //
-// Idempotency: when the same CreateIndex is replayed (or re-submitted) against
+// Log replay idempotency: when the same CreatedIndexLog is folded again against
 // an index this replica has already promoted to live, we skip the reset and
 // backfill scheduling so the builder does not redo work that has already
 // completed — and, more importantly, does not knock a live index back into
@@ -410,12 +410,12 @@ func (b *Builder) handleCreatedIndexLog(ledgerName string, log *commonpb.Created
 
 	// The per-replica readiness signal is IndexVersionState.CurrentVersion
 	// (EN-1323). If this replica has already promoted the index to live
-	// (current != 0), a repeated CreatedIndexLog — a duplicate CreateIndex
-	// re-emitted by the processor, or an apply replay — must be a no-op:
-	// allocating a new pending version and rescheduling a backfill would
+	// (current != 0), a repeated CreatedIndexLog during replay must be a no-op.
+	// Allocating a new pending version and rescheduling a backfill would
 	// flip an already-live index back to ErrIndexBuilding. This mirrors the
 	// loadIndexRegistry boot guard and covers both the EN-1564 initial fast
-	// path and the normal post-backfill live state.
+	// path and the normal post-backfill live state. Fresh duplicate requests
+	// are rejected by the FSM before emitting a log.
 	if current, pending := b.versionFor(ledgerName, indexes.Canonical(id)); current != 0 {
 		return nil
 	} else if pending != 0 {

--- a/internal/application/indexbuilder/index_config_test.go
+++ b/internal/application/indexbuilder/index_config_test.go
@@ -1504,8 +1504,9 @@ func TestHandleCreatedIndexLog_DuplicateAfterLive_IsIdempotent(t *testing.T) {
 	require.Equal(t, uint32(1), current)
 	require.Equal(t, uint32(0), pending)
 
-	// A duplicate CreateIndex — re-emitted by the processor as initial=false once
-	// the ledger is no longer born-empty — must be a no-op on this live replica.
+	// A repeated CreatedIndexLog with initial=false must be a no-op on this
+	// live replica. Fresh duplicate requests are rejected by the FSM; this
+	// regression retains the builder guard for repeated log processing.
 	second := b.readStore.NewBatch()
 	b.initBatch(second)
 	require.NoError(t, b.handleCreatedIndexLog(ledger, &commonpb.CreatedIndexLog{Id: id, Initial: false}))

--- a/internal/domain/errors.go
+++ b/internal/domain/errors.go
@@ -214,6 +214,7 @@ const (
 	ErrReasonLedgerNotInMirrorMode         = "LEDGER_NOT_IN_MIRROR_MODE"
 	ErrReasonPreparedQueryAlreadyExists    = "PREPARED_QUERY_ALREADY_EXISTS"
 	ErrReasonPreparedQueryNotFound         = "PREPARED_QUERY_NOT_FOUND"
+	ErrReasonIndexAlreadyExists            = "INDEX_ALREADY_EXISTS"
 	ErrReasonIndexNotFound                 = "INDEX_NOT_FOUND"
 	ErrReasonIndexBuilding                 = "INDEX_BUILDING"
 	ErrReasonIndexInconsistent             = "INDEX_INCONSISTENT"
@@ -933,6 +934,17 @@ func (e *ErrPreparedQueryNotFound) Error() string {
 func (*ErrPreparedQueryNotFound) Reason() string { return ErrReasonPreparedQueryNotFound }
 func (e *ErrPreparedQueryNotFound) Metadata() map[string]string {
 	return map[string]string{"ledger": e.Ledger, "name": e.Name}
+}
+
+// ErrIndexAlreadyExists — a fresh creation targets an existing index.
+type ErrIndexAlreadyExists struct {
+	Index string
+}
+
+func (e *ErrIndexAlreadyExists) Error() string { return "index already exists: " + e.Index }
+func (*ErrIndexAlreadyExists) Reason() string  { return ErrReasonIndexAlreadyExists }
+func (e *ErrIndexAlreadyExists) Metadata() map[string]string {
+	return map[string]string{"index": e.Index}
 }
 
 // ErrIndexNotFound — query references an index that does not exist.

--- a/internal/domain/errors_test.go
+++ b/internal/domain/errors_test.go
@@ -328,6 +328,7 @@ func TestEveryDomainErrorImplementsDescribable(t *testing.T) {
 		"ErrMirrorV2LogIDInvalid":          &ErrMirrorV2LogIDInvalid{},
 		"ErrPreparedQueryAlreadyExists":    &ErrPreparedQueryAlreadyExists{},
 		"ErrPreparedQueryNotFound":         &ErrPreparedQueryNotFound{},
+		"ErrIndexAlreadyExists":            &ErrIndexAlreadyExists{},
 		"ErrIndexNotFound":                 &ErrIndexNotFound{},
 		"ErrMetadataFieldNotInSchema":      &ErrMetadataFieldNotInSchema{},
 		"ErrIndexBuilding":                 &ErrIndexBuilding{},

--- a/internal/domain/processing/processor_index.go
+++ b/internal/domain/processing/processor_index.go
@@ -14,6 +14,14 @@ func processCreateIndex(ledger string, order *raftcmdpb.CreateIndexOrder, ctx *C
 	}
 
 	id := order.GetId()
+	existing, err := indexes.Find(ctx.Scope.Indexes(), ledger, id)
+	if err != nil {
+		return nil, domain.StoreFailure("loading index", err)
+	}
+	if existing != nil {
+		return nil, &domain.ErrIndexAlreadyExists{Index: indexes.Canonical(id)}
+	}
+
 	if err := validateIndexTarget(info, id); err != nil {
 		return nil, err
 	}
@@ -22,9 +30,8 @@ func processCreateIndex(ledger string, order *raftcmdpb.CreateIndexOrder, ctx *C
 	// projection's mutable name field, so a divergent LedgerInfo.name cannot
 	// redirect the write to another ledger's index keys. The Ledger field
 	// below carries the same envelope value, keeping key and payload
-	// consistent. A duplicate CreateIndex overwrites the row; the
-	// indexbuilder's handleCreatedIndexLog guards against re-scheduling a
-	// backfill by consulting its per-replica IndexVersionState.
+	// consistent. The existence check above rejects a fresh duplicate before
+	// any registry mutation or CreatedIndexLog is produced.
 	boundType, boundTypeDeclared := indexBoundType(info, id)
 
 	indexes.Put(ctx.Scope.Indexes(), ledger, &commonpb.Index{

--- a/internal/domain/processing/processor_index_strict_test.go
+++ b/internal/domain/processing/processor_index_strict_test.go
@@ -1,0 +1,88 @@
+package processing
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+)
+
+func TestProcessCreateIndex_RejectsExistingWithoutMutation(t *testing.T) {
+	t.Parallel()
+
+	for _, id := range []*commonpb.IndexID{
+		indexes.TxBuiltinID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REFERENCE),
+		indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, "score"),
+	} {
+		t.Run(indexes.Canonical(id), func(t *testing.T) {
+			t.Parallel()
+
+			scope := NewMockScope(gomock.NewController(t))
+			// A divergent projection name must not redirect the existence probe.
+			info := &commonpb.LedgerInfo{Name: "other-ledger", MetadataSchema: &commonpb.MetadataSchema{
+				AccountFields: map[string]*commonpb.MetadataFieldSchema{"score": {Type: commonpb.MetadataType_METADATA_TYPE_INT64}},
+			}}
+			expectGetLedger(scope, domain.LedgerKey{Name: "ledger"}, info.AsReader(), nil)
+			original := &commonpb.Index{Id: id, Ledger: "ledger", CreatedAt: &commonpb.Timestamp{Data: 42}, ForwardEncodingVersion: 3}
+			before := original.CloneVT()
+			stub := setupIndexesStub(scope)
+			reads := 0
+			stub.getHook = func(key domain.IndexKey) (commonpb.IndexReader, error) {
+				reads++
+				require.Equal(t, indexes.KeyFor("ledger", id), key)
+
+				return original.AsReader(), nil
+			}
+			stub.putHook = func(domain.IndexKey, *commonpb.Index) { t.Fatal("duplicate creation must not write the registry") }
+
+			payload, err := processCreateIndex("ledger", &raftcmdpb.CreateIndexOrder{Id: id}, &Context{Scope: scope})
+			require.Nil(t, payload, "duplicate must not emit CreatedIndexLog")
+			var duplicate *domain.ErrIndexAlreadyExists
+			require.ErrorAs(t, err, &duplicate)
+			require.Equal(t, indexes.Canonical(id), duplicate.Index)
+			require.Equal(t, domain.ErrReasonIndexAlreadyExists, err.Reason())
+			require.Equal(t, 1, reads)
+			require.True(t, before.EqualVT(original), "duplicate must preserve timestamp and forward encoding version")
+		})
+	}
+}
+
+func TestProcessCreateIndex_PropagatesRegistryReadFailure(t *testing.T) {
+	t.Parallel()
+
+	fault := errors.New("index registry read failed")
+	for _, tc := range []struct {
+		name   string
+		err    error
+		reason string
+	}{
+		{name: "coverage", err: coverageMissDescribable{}, reason: domain.ErrReasonCoverageMiss},
+		{name: "storage", err: fault, reason: domain.ErrReasonStorageOperation},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			scope := NewMockScope(gomock.NewController(t))
+			expectGetLedger(scope, domain.LedgerKey{Name: "ledger"}, (&commonpb.LedgerInfo{Name: "ledger"}).AsReader(), nil)
+			id := indexes.TxBuiltinID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REFERENCE)
+			stub := setupIndexesStub(scope)
+			stub.expectGet(indexes.KeyFor("ledger", id), nil, tc.err)
+			stub.putHook = func(domain.IndexKey, *commonpb.Index) { t.Fatal("failed read must not create an index") }
+
+			payload, err := processCreateIndex("ledger", &raftcmdpb.CreateIndexOrder{Id: id}, &Context{Scope: scope})
+			require.Nil(t, payload)
+			require.NotNil(t, err)
+			require.Equal(t, tc.reason, err.Reason())
+			if tc.name == "coverage" {
+				require.Equal(t, tc.err, err, "coverage identity must propagate verbatim")
+			} else {
+				require.ErrorIs(t, err, fault)
+			}
+		})
+	}
+}

--- a/internal/domain/reason.go
+++ b/internal/domain/reason.go
@@ -99,6 +99,7 @@ func KindForReason(code commonpb.ErrorReason) ErrorKind {
 		commonpb.ErrorReason_ERROR_REASON_CHECKPOINT_NOT_FOUND:
 		return KindNotFound
 	case commonpb.ErrorReason_ERROR_REASON_LEDGER_ALREADY_EXISTS,
+		commonpb.ErrorReason_ERROR_REASON_INDEX_ALREADY_EXISTS,
 		commonpb.ErrorReason_ERROR_REASON_IDEMPOTENCY_KEY_CONFLICT,
 		commonpb.ErrorReason_ERROR_REASON_TRANSACTION_REFERENCE_CONFLICT,
 		commonpb.ErrorReason_ERROR_REASON_SINK_ALREADY_EXISTS,

--- a/internal/infra/backup/rebuild.go
+++ b/internal/infra/backup/rebuild.go
@@ -728,10 +728,9 @@ func (w *attributeReplayWriter) SetMetadataFieldType(ledger string, target commo
 	return w.putIndex(ledger, id, row)
 }
 
-// CreateIndex writes the registry row the live processCreateIndex writes: a
-// fresh entry at forward-encoding version 1, stamped with the log's apply
-// date. A duplicate CreateIndex overwrites the row, matching the live
-// handler.
+// CreateIndex folds an accepted creation log into a fresh registry row at
+// forward-encoding version 1, stamped with the log's apply date. Fresh duplicate
+// orders are rejected by the live FSM and produce no creation log to replay.
 func (w *attributeReplayWriter) CreateIndex(ledger string, id *commonpb.IndexID, createdAt *commonpb.Timestamp) error {
 	return w.putIndex(ledger, id, &commonpb.Index{
 		Id:                     id,

--- a/internal/infra/state/audit_failure_test.go
+++ b/internal/infra/state/audit_failure_test.go
@@ -456,6 +456,12 @@ func auditFailureCases() []auditFailureCase {
 			wantContext: map[string]string{"ledger": "main", "name": "missing-query"},
 		},
 		{
+			name:        "IndexAlreadyExists",
+			err:         &domain.ErrIndexAlreadyExists{Index: "metadata:account:invoice"},
+			wantReason:  domain.ErrReasonIndexAlreadyExists,
+			wantContext: map[string]string{"index": "metadata:account:invoice"},
+		},
+		{
 			name:        "IndexNotFound",
 			err:         &domain.ErrIndexNotFound{Index: "main/TRANSACTION/invoice"},
 			wantReason:  domain.ErrReasonIndexNotFound,

--- a/internal/infra/state/index_creation_test.go
+++ b/internal/infra/state/index_creation_test.go
@@ -1,0 +1,215 @@
+package state
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/domain/indexes"
+	"github.com/formancehq/ledger/v3/internal/infra/attributes"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+	"github.com/formancehq/ledger/v3/internal/query"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+func indexCreationOrder(ledger string, id *commonpb.IndexID) *raftcmdpb.Order {
+	return indexApplyOrder(ledger, &raftcmdpb.LedgerApplyOrder{Data: &raftcmdpb.LedgerApplyOrder_CreateIndex{
+		CreateIndex: &raftcmdpb.CreateIndexOrder{Id: id},
+	}})
+}
+
+func indexDropOrder(ledger string, id *commonpb.IndexID) *raftcmdpb.Order {
+	return indexApplyOrder(ledger, &raftcmdpb.LedgerApplyOrder{Data: &raftcmdpb.LedgerApplyOrder_DropIndex{
+		DropIndex: &raftcmdpb.DropIndexOrder{Id: id},
+	}})
+}
+
+func indexApplyOrder(ledger string, apply *raftcmdpb.LedgerApplyOrder) *raftcmdpb.Order {
+	return &raftcmdpb.Order{Type: &raftcmdpb.Order_LedgerScoped{LedgerScoped: &raftcmdpb.LedgerScopedOrder{
+		Ledger: ledger, Payload: &raftcmdpb.LedgerScopedOrder_Apply{Apply: apply},
+	}}}
+}
+
+// Index coverage is explicit here because the generic machine fixture only
+// declares ledger, transaction and metadata keys. Values remain cache-backed.
+func indexProposal(sequence uint64, ledger string, id *commonpb.IndexID, orders ...*raftcmdpb.Order) *raftcmdpb.Proposal {
+	proposal := makeProposal(sequence, orders...)
+	key, _ := attributes.MakeKey(indexes.KeyFor(ledger, id).Bytes())
+	proposal.ExecutionPlan.Attributes = append(proposal.ExecutionPlan.Attributes, declareTestPlan(key, dal.SubAttrIndex))
+
+	return proposal
+}
+
+func TestCreateIndex_DuplicateBatchRollsBack(t *testing.T) {
+	t.Parallel()
+
+	machine, store, attrs := newTestMachine(t)
+	const ledger = "index-atomic"
+	id := indexes.TxBuiltinID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REFERENCE)
+	result, err := machine.ApplyEntries(t.Context(), store, makeEntry(t, 1, makeProposal(1, createLedgerOrder(ledger))))
+	require.NoError(t, err)
+	require.NoError(t, result.Results[0].Error)
+
+	handle, err := store.NewDirectReadHandle()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, handle.Close()) })
+	lastBefore, err := query.ReadLastLog(handle)
+	require.NoError(t, err)
+
+	result, err = machine.ApplyEntries(t.Context(), store, makeEntry(t, 2, indexProposal(2, ledger, id,
+		indexCreationOrder(ledger, id), indexCreationOrder(ledger, id))))
+	require.NoError(t, err)
+	var duplicate *domain.ErrIndexAlreadyExists
+	require.ErrorAs(t, result.Results[0].Error, &duplicate)
+	require.Equal(t, indexes.Canonical(id), duplicate.Index)
+	require.Empty(t, result.Results[0].Logs)
+	row, err := attrs.Index.Get(handle, indexes.KeyFor(ledger, id).Bytes())
+	require.NoError(t, err)
+	require.Nil(t, row, "first creation must roll back with the duplicate")
+	_, _, err = machine.Registry.Indexes.KeyStore().GetKey(indexes.KeyFor(ledger, id))
+	require.ErrorIs(t, err, domain.ErrNotFound, "rollback must also discard the cache entry")
+	lastAfter, err := query.ReadLastLog(handle)
+	require.NoError(t, err)
+	require.Equal(t, lastBefore.GetSequence(), lastAfter.GetSequence(), "failed batch must not commit a CreatedIndexLog")
+	audit := listAuditEntries(t, store, 0)
+	failure := audit[len(audit)-1].GetFailure()
+	require.Equal(t, domain.ErrReasonIndexAlreadyExists, domain.ReasonString(failure.GetReason()))
+	require.Equal(t, map[string]string{"index": indexes.Canonical(id)}, failure.GetContext())
+
+	// A new creation proves the aborted write did not survive in the FSM.
+	result, err = machine.ApplyEntries(t.Context(), store, makeEntry(t, 3, indexProposal(3, ledger, id, indexCreationOrder(ledger, id))))
+	require.NoError(t, err)
+	require.NoError(t, result.Results[0].Error)
+	require.Len(t, result.Results[0].Logs, 1)
+}
+
+func TestCreateIndex_IdempotencyReplayAndFreshDuplicate(t *testing.T) {
+	t.Parallel()
+
+	machine, store, _ := newTestMachine(t)
+	const ledger = "index-idem"
+	id := indexes.TxBuiltinID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REFERENCE)
+	apply := func(sequence uint64, key string, order *raftcmdpb.Order) ApplyResult {
+		t.Helper()
+		proposal := indexProposal(sequence, ledger, id, order)
+		if key != "" {
+			proposal.Idempotency = &commonpb.Idempotency{Key: key}
+		}
+		result, err := machine.ApplyEntries(t.Context(), store, makeEntry(t, sequence, proposal))
+		require.NoError(t, err)
+
+		return result.Results[0]
+	}
+	require.NoError(t, apply(1, "", createLedgerOrder(ledger)).Error)
+	first := apply(2, "create", indexCreationOrder(ledger, id))
+	require.NoError(t, first.Error)
+	require.Len(t, first.Logs, 1)
+	sequence := first.Logs[0].GetCreatedLog().GetSequence()
+	auditSequence := machine.State.NextAuditSequenceID
+	auditHash := append([]byte(nil), machine.State.LastAuditHash...)
+
+	replay := apply(3, "create", indexCreationOrder(ledger, id))
+	require.NoError(t, replay.Error)
+	require.Len(t, replay.Logs, 1)
+	require.Nil(t, replay.Logs[0].GetCreatedLog())
+	require.Equal(t, sequence, replay.Logs[0].GetReferenceSequence())
+	require.False(t, replay.AuditEntryWritten)
+	require.Equal(t, auditSequence, machine.State.NextAuditSequenceID)
+	require.Equal(t, auditHash, machine.State.LastAuditHash)
+
+	for offset, key := range []string{"", "fresh-key"} {
+		duplicate := apply(uint64(4+offset), key, indexCreationOrder(ledger, id))
+		var alreadyExists *domain.ErrIndexAlreadyExists
+		require.ErrorAs(t, duplicate.Error, &alreadyExists)
+		require.Empty(t, duplicate.Logs)
+	}
+
+	// Definitive duplicate failure stays frozen under its retained key even
+	// after a drop makes a fresh creation possible.
+	require.NoError(t, apply(6, "", indexDropOrder(ledger, id)).Error)
+	frozen := apply(7, "fresh-key", indexCreationOrder(ledger, id))
+	var replayed *domain.ReplayedFailure
+	require.ErrorAs(t, frozen.Error, &replayed)
+	require.Equal(t, domain.ErrReasonIndexAlreadyExists, replayed.Reason())
+	require.False(t, frozen.AuditEntryWritten)
+	require.NoError(t, apply(8, "another-key", indexCreationOrder(ledger, id)).Error)
+}
+
+func TestCreateIndex_DuplicateAfterRetypePreservesRegistry(t *testing.T) {
+	t.Parallel()
+
+	machine, store, attrs := newTestMachine(t)
+	const ledger = "index-retype"
+	id := indexes.MetadataID(commonpb.TargetType_TARGET_TYPE_ACCOUNT, "score")
+	apply := func(sequence uint64, orders ...*raftcmdpb.Order) ApplyResult {
+		t.Helper()
+		result, err := machine.ApplyEntries(t.Context(), store, makeEntry(t, sequence, indexProposal(sequence, ledger, id, orders...)))
+		require.NoError(t, err)
+
+		return result.Results[0]
+	}
+	setType := func(typ commonpb.MetadataType) *raftcmdpb.Order {
+		return indexApplyOrder(ledger, &raftcmdpb.LedgerApplyOrder{Data: &raftcmdpb.LedgerApplyOrder_SetMetadataFieldType{
+			SetMetadataFieldType: &raftcmdpb.SetMetadataFieldTypeOrder{TargetType: commonpb.TargetType_TARGET_TYPE_ACCOUNT, Key: "score", Type: typ},
+		}})
+	}
+	require.NoError(t, apply(1, createLedgerOrder(ledger)).Error)
+	require.NoError(t, apply(2, setType(commonpb.MetadataType_METADATA_TYPE_STRING), indexCreationOrder(ledger, id)).Error)
+	require.NoError(t, apply(3, setType(commonpb.MetadataType_METADATA_TYPE_INT64)).Error)
+
+	handle, err := store.NewDirectReadHandle()
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, handle.Close()) })
+	before, err := attrs.Index.Get(handle, indexes.KeyFor(ledger, id).Bytes())
+	require.NoError(t, err)
+	require.Equal(t, uint32(2), before.GetForwardEncodingVersion())
+	lastBefore, err := query.ReadLastLog(handle)
+	require.NoError(t, err)
+
+	duplicate := apply(4, indexCreationOrder(ledger, id))
+	var alreadyExists *domain.ErrIndexAlreadyExists
+	require.ErrorAs(t, duplicate.Error, &alreadyExists)
+	require.Empty(t, duplicate.Logs)
+	after, err := attrs.Index.Get(handle, indexes.KeyFor(ledger, id).Bytes())
+	require.NoError(t, err)
+	require.True(t, before.EqualVT(after), "duplicate must preserve the complete persisted registry row")
+	cached, _, err := machine.Registry.Indexes.KeyStore().GetKey(indexes.KeyFor(ledger, id))
+	require.NoError(t, err)
+	require.True(t, before.EqualVT(cached), "cache and durable row must agree after the rejected duplicate")
+	lastAfter, err := query.ReadLastLog(handle)
+	require.NoError(t, err)
+	require.Equal(t, lastBefore.GetSequence(), lastAfter.GetSequence())
+
+	// Drop/recreate in one batch observes the tombstone and creates version 1
+	// bound to the current schema, including a fresh creation timestamp.
+	recreated := apply(5, indexDropOrder(ledger, id), indexCreationOrder(ledger, id))
+	require.NoError(t, recreated.Error)
+	require.Len(t, recreated.Logs, 2)
+	rebuilt, err := attrs.Index.Get(handle, indexes.KeyFor(ledger, id).Bytes())
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), rebuilt.GetForwardEncodingVersion())
+	require.NotEqual(t, before.GetCreatedAt().GetData(), rebuilt.GetCreatedAt().GetData())
+	created := recreated.Logs[1].GetCreatedLog().GetPayload().GetApply().GetLog().GetData().GetCreateIndex()
+	require.True(t, created.GetBoundTypeDeclared())
+	require.Equal(t, commonpb.MetadataType_METADATA_TYPE_INT64, created.GetBoundType())
+}
+
+func TestCreateIndex_MissingIndexCoverageIsNotAbsence(t *testing.T) {
+	t.Parallel()
+	machine, store, _ := newTestMachine(t)
+	const ledger = "index-coverage"
+	id := indexes.TxBuiltinID(commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REFERENCE)
+	result, err := machine.ApplyEntries(t.Context(), store, makeEntry(t, 1, makeProposal(1, createLedgerOrder(ledger))))
+	require.NoError(t, err)
+	require.NoError(t, result.Results[0].Error)
+
+	// Deliberately omit the index plan: the real gate must reject the probe.
+	result, err = machine.ApplyEntries(t.Context(), store, makeEntry(t, 2, makeProposal(2, indexCreationOrder(ledger, id))))
+	require.NoError(t, err)
+	var miss *ErrCoverageMiss
+	require.ErrorAs(t, result.Results[0].Error, &miss)
+	require.Equal(t, domain.ErrReasonCoverageMiss, miss.Reason())
+	require.Empty(t, result.Results[0].Logs)
+}

--- a/internal/proto/commonpb/common.pb.go
+++ b/internal/proto/commonpb/common.pb.go
@@ -629,6 +629,8 @@ const (
 	// Permanent (Kind=ResourceExhausted): retrying cannot create another ID.
 	// See EN-1860.
 	ErrorReason_ERROR_REASON_SEQUENCE_EXHAUSTED ErrorReason = 67
+	// A fresh CreateIndex targets an existing ledger/canonical IndexID.
+	ErrorReason_ERROR_REASON_INDEX_ALREADY_EXISTS ErrorReason = 68
 )
 
 // Enum value maps for ErrorReason.
@@ -702,6 +704,7 @@ var (
 		65: "ERROR_REASON_CHECKPOINT_LIMIT_REACHED",
 		66: "ERROR_REASON_CHECKPOINT_NOT_FOUND",
 		67: "ERROR_REASON_SEQUENCE_EXHAUSTED",
+		68: "ERROR_REASON_INDEX_ALREADY_EXISTS",
 	}
 	ErrorReason_value = map[string]int32{
 		"ERROR_REASON_UNSPECIFIED":                      0,
@@ -772,6 +775,7 @@ var (
 		"ERROR_REASON_CHECKPOINT_LIMIT_REACHED":         65,
 		"ERROR_REASON_CHECKPOINT_NOT_FOUND":             66,
 		"ERROR_REASON_SEQUENCE_EXHAUSTED":               67,
+		"ERROR_REASON_INDEX_ALREADY_EXISTS":             68,
 	}
 )
 
@@ -13233,7 +13237,7 @@ const file_common_proto_rawDesc = "" +
 	"\x12LEDGER_MODE_MIRROR\x10\x01*Q\n" +
 	"\x0fMirrorSyncState\x12\x1d\n" +
 	"\x19MIRROR_SYNC_STATE_SYNCING\x10\x00\x12\x1f\n" +
-	"\x1bMIRROR_SYNC_STATE_FOLLOWING\x10\x01*\xb6\x15\n" +
+	"\x1bMIRROR_SYNC_STATE_FOLLOWING\x10\x01*\xdd\x15\n" +
 	"\vErrorReason\x12\x1c\n" +
 	"\x18ERROR_REASON_UNSPECIFIED\x10\x00\x12&\n" +
 	"\"ERROR_REASON_LEDGER_ALREADY_EXISTS\x10\x01\x12!\n" +
@@ -13303,7 +13307,8 @@ const file_common_proto_rawDesc = "" +
 	"#ERROR_REASON_CLUSTER_POLICY_INVALID\x10@\x12)\n" +
 	"%ERROR_REASON_CHECKPOINT_LIMIT_REACHED\x10A\x12%\n" +
 	"!ERROR_REASON_CHECKPOINT_NOT_FOUND\x10B\x12#\n" +
-	"\x1fERROR_REASON_SEQUENCE_EXHAUSTED\x10C*Q\n" +
+	"\x1fERROR_REASON_SEQUENCE_EXHAUSTED\x10C\x12%\n" +
+	"!ERROR_REASON_INDEX_ALREADY_EXISTS\x10D*Q\n" +
 	"\x14ChartEnforcementMode\x12\x1c\n" +
 	"\x18CHART_ENFORCEMENT_STRICT\x10\x00\x12\x1b\n" +
 	"\x17CHART_ENFORCEMENT_AUDIT\x10\x01*i\n" +

--- a/misc/operator/README.md
+++ b/misc/operator/README.md
@@ -41,6 +41,19 @@ although the template update and earlier membership removals may already have
 succeeded. A later reconciliation checks membership again and skips ordinals
 already removed.
 
+## Declarative ledger indexes
+
+For a Ledger with `spec.indexes`, reconciliation lists the current registry and
+creates only missing indexes. Creation is strict: if another writer creates the
+index after the list, `INDEX_ALREADY_EXISTS` is reported through
+`IndexesSynced=False` and reconciliation is retried. The failed creation adds
+no entry to `status.appliedIndexes`; successful earlier operations in the same
+pass remain recorded. For an identity that was not previously tracked, the next
+pass lists the registry again and leaves the external index unowned. Existing
+ownership entries are retained: replacement of a previously tracked index and
+recovery after a lost successful create response or status update remain
+separate ownership concerns.
+
 ## Custom Resources
 
 | Resource | Scope | Description |

--- a/misc/operator/internal/controller/ledger_index_reconcile.go
+++ b/misc/operator/internal/controller/ledger_index_reconcile.go
@@ -79,12 +79,9 @@ func (r *LedgerReconciler) handleIndexReconcile(ctx context.Context, ledger *led
 // Each ledgerctl invocation runs under its own exec timeout (ledgerExecTimeout)
 // since the reconcile issues several sequential commands.
 func (r *LedgerReconciler) reconcileIndexes(ctx context.Context, ledger *ledgerv1alpha1.Ledger, grpcPort int32) (bool, error) {
-	log := ctrl.LoggerFrom(ctx)
-
 	ns := ledger.Namespace
 	svc := ledger.Spec.ClusterRef
 	pod0 := podName(svc, 0)
-	ledgerName := ledger.Spec.Name
 
 	exec := func(args ...string) (string, error) {
 		execCtx, cancel := context.WithTimeout(ctx, ledgerExecTimeout)
@@ -92,6 +89,13 @@ func (r *LedgerReconciler) reconcileIndexes(ctx context.Context, ledger *ledgerv
 
 		return r.ledgerctlExecOutput(execCtx, ns, svc, pod0, grpcPort, args...)
 	}
+
+	return reconcileIndexesWithExec(ctx, ledger, exec)
+}
+
+func reconcileIndexesWithExec(ctx context.Context, ledger *ledgerv1alpha1.Ledger, exec func(...string) (string, error)) (bool, error) {
+	log := ctrl.LoggerFrom(ctx)
+	ledgerName := ledger.Spec.Name
 
 	// Persist ownership from the changes that actually succeeded, on every
 	// return path. If a create succeeds and a later command fails, the created
@@ -153,7 +157,7 @@ func (r *LedgerReconciler) reconcileIndexes(ctx context.Context, ledger *ledgerv
 	diff := diffIndexes(desired, actual, ledger.Status.AppliedIndexes)
 
 	for _, mi := range diff.toCreate {
-		if _, createErr := exec(mi.createArgs(ledgerName)...); createErr != nil && !isAlreadyExists(createErr) {
+		if _, createErr := exec(mi.createArgs(ledgerName)...); createErr != nil {
 			return false, createErr
 		}
 

--- a/misc/operator/internal/controller/ledger_index_reconcile_test.go
+++ b/misc/operator/internal/controller/ledger_index_reconcile_test.go
@@ -1,0 +1,68 @@
+package controller
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	ledgerv1alpha1 "github.com/formancehq/ledger/misc/operator/api/v1alpha1"
+)
+
+func TestReconcileIndexes_CreateConflictDoesNotAdopt(t *testing.T) {
+	t.Parallel()
+
+	for _, firstCreated := range []bool{false, true} {
+		name := "first create conflicts"
+		if firstCreated {
+			name = "preserves earlier successful create"
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ledger := &ledgerv1alpha1.Ledger{}
+			ledger.Spec.Name = "L"
+			ledger.Spec.Indexes = &ledgerv1alpha1.LedgerIndexesSpec{Transaction: []string{"timestamp"}}
+			if firstCreated {
+				ledger.Spec.Indexes.Transaction = []string{"reference", "timestamp"}
+			}
+
+			conflict := errors.New("ledgerctl indexes: index already exists: tx_builtin:TX_BUILTIN_INDEX_TIMESTAMP")
+			var commands [][]string
+			synced, err := reconcileIndexesWithExec(t.Context(), ledger, func(args ...string) (string, error) {
+				commands = append(commands, args)
+				if args[1] == "list" {
+					return "[]", nil
+				}
+				if args[len(args)-1] == "reference" {
+					return "", nil
+				}
+
+				return "", conflict
+			})
+			require.ErrorIs(t, err, conflict)
+			require.False(t, synced)
+			if firstCreated {
+				require.Equal(t, []string{"reference"}, ledger.Status.AppliedIndexes)
+				require.Len(t, commands, 3)
+			} else {
+				require.Empty(t, ledger.Status.AppliedIndexes)
+				require.Len(t, commands, 2)
+			}
+
+			// The next reconciliation observes the externally created index and
+			// converges without retrying creation or claiming it as owned.
+			commands = nil
+			synced, err = reconcileIndexesWithExec(t.Context(), ledger, func(args ...string) (string, error) {
+				commands = append(commands, args)
+				require.Equal(t, []string{"indexes", "list", "--ledger", "L", "--json"}, args)
+
+				return `[{"id":{"txBuiltin":"TX_BUILTIN_INDEX_TIMESTAMP"}}, {"id":{"txBuiltin":"TX_BUILTIN_INDEX_REFERENCE"}}]`, nil
+			})
+			require.NoError(t, err)
+			require.True(t, synced)
+			require.Len(t, commands, 1)
+			require.NotContains(t, ledger.Status.AppliedIndexes, "timestamp")
+		})
+	}
+}

--- a/misc/proto/common.proto
+++ b/misc/proto/common.proto
@@ -1240,6 +1240,8 @@ enum ErrorReason {
   // Permanent (Kind=ResourceExhausted): retrying cannot create another ID.
   // See EN-1860.
   ERROR_REASON_SEQUENCE_EXHAUSTED = 67;
+  // A fresh CreateIndex targets an existing ledger/canonical IndexID.
+  ERROR_REASON_INDEX_ALREADY_EXISTS = 68;
 }
 
 // IdempotencyFailure captures a definitive business rejection so a retried key

--- a/openapi.yml
+++ b/openapi.yml
@@ -2587,8 +2587,12 @@ paths:
     post:
       summary: Create an index on a ledger
       description: |
-        Registers a new index on the ledger. The FSM begins the backfill on
-        the next apply. The request body carries the target `IndexID` in
+        Registers a new index on the ledger. An existing canonical index on
+        this ledger is rejected with `INDEX_ALREADY_EXISTS` (HTTP 409), even
+        while building or retyping, without changing its definition or progress.
+        Replaying an identical batch with its retained `Idempotency-Key` returns
+        the original result. The indexbuilder processes the accepted creation.
+        The request body carries the target `IndexID` in
         canonical form (see `DELETE /v3/{ledgerName}/indexes/{canonicalId}`
         for the format). Requires `ledger:LedgerWrite` scope.
       operationId: createIndex
@@ -2639,7 +2643,13 @@ paths:
         '404':
           $ref: '#/components/responses/NotFound'
         '409':
-          $ref: '#/components/responses/Conflict'
+          description: |
+            Conflict: `INDEX_ALREADY_EXISTS` when the canonical index already
+            exists on this ledger, or an idempotency key conflict.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           $ref: '#/components/responses/InternalServerError'
         '503':

--- a/pkg/grpcprotocol/protocol.go
+++ b/pkg/grpcprotocol/protocol.go
@@ -12,7 +12,7 @@ const (
 	// Version must change when the client-facing wire format or semantics break.
 	// See docs/technical/architecture/subsystems/api/protocol-compatibility.md.
 	// A compiled constant also identifies local builds without release ldflags.
-	Version = "5"
+	Version = "6"
 	// MetadataKey carries the protocol version, not authentication credentials.
 	MetadataKey = "ledger-protocol-version"
 )

--- a/tests/e2e/business/index_strict_creation_test.go
+++ b/tests/e2e/business/index_strict_creation_test.go
@@ -1,0 +1,106 @@
+//go:build e2e
+
+package business
+
+import (
+	"context"
+	"time"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	"github.com/formancehq/ledger/v3/tests/e2e/testutil"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+var _ = Describe("Strict index creation", func() {
+	It("accepts only one concurrent fresh create and audits duplicates without rebuilding a ready index", func() {
+		ctx, node := testutil.SetupSingleNode()
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+		client := node.Client
+		const ledger = "strict-index-create"
+		const builtin = commonpb.TransactionBuiltinIndex_TX_BUILTIN_INDEX_REFERENCE
+		_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledger, nil)))
+		Expect(err).To(Succeed())
+
+		type outcome struct {
+			key string
+			err error
+		}
+		start := make(chan struct{})
+		results := make(chan outcome, 2)
+		for _, key := range []string{"strict-create-a", "strict-create-b"} {
+			go func() {
+				<-start
+				_, applyErr := client.Apply(ctx, servicepb.UnsignedApplyRequest(key,
+					actions.CreateBuiltinTxIndexAction(ledger, builtin)))
+				results <- outcome{key: key, err: applyErr}
+			}()
+		}
+		close(start)
+		var rejectedKeys []string
+		for range 2 {
+			var result outcome
+			Eventually(results).Should(Receive(&result))
+			if result.err != nil {
+				Expect(status.Code(result.err)).To(Equal(codes.AlreadyExists))
+				info := actions.ExtractGRPCErrorInfo(result.err)
+				Expect(info).NotTo(BeNil())
+				Expect(info.Reason).To(Equal("INDEX_ALREADY_EXISTS"))
+				rejectedKeys = append(rejectedKeys, result.key)
+			}
+		}
+		Expect(rejectedKeys).To(HaveLen(1), "exactly one fresh request must win")
+		Expect(actions.WaitForBuiltinIndexReady(ctx, client, ledger, builtin)).To(Succeed())
+
+		before, err := client.GetIndexStatus(ctx, &servicepb.GetIndexStatusRequest{Ledger: ledger})
+		Expect(err).To(Succeed())
+		Expect(before.GetIndexes()).To(HaveLen(1))
+		Expect(before.GetIndexes()[0].GetCurrentVersion()).To(Equal(uint32(1)))
+		Expect(before.GetIndexes()[0].GetPendingVersion()).To(BeZero())
+		const readyDuplicateKey = "strict-create-ready-duplicate"
+		_, err = client.Apply(ctx, servicepb.UnsignedApplyRequest(readyDuplicateKey,
+			actions.CreateBuiltinTxIndexAction(ledger, builtin)))
+		Expect(status.Code(err)).To(Equal(codes.AlreadyExists))
+		Expect(actions.ExtractGRPCErrorInfo(err)).NotTo(BeNil())
+		Expect(actions.ExtractGRPCErrorInfo(err).Reason).To(Equal("INDEX_ALREADY_EXISTS"))
+		rejectedKeys = append(rejectedKeys, readyDuplicateKey)
+
+		// Wait until all committed logs have reached the builder before
+		// asserting that no creation allocated another local version.
+		var after *servicepb.GetIndexStatusResponse
+		Eventually(func(g Gomega) {
+			after, err = client.GetIndexStatus(ctx, &servicepb.GetIndexStatusRequest{Ledger: ledger})
+			g.Expect(err).To(Succeed())
+			g.Expect(after.GetLag()).To(BeZero())
+		}).Should(Succeed())
+		Expect(after.GetIndexes()).To(HaveLen(1))
+		Expect(proto.Equal(after.GetIndexes()[0], before.GetIndexes()[0])).To(BeTrue(),
+			"duplicate creation must preserve the full registry row and local build state")
+
+		entries, err := actions.ListAuditEntries(ctx, client, false)
+		Expect(err).To(Succeed())
+		for _, key := range rejectedKeys {
+			entry := auditEntryWithIdempotency(entries, key)
+			Expect(entry.GetFailure()).NotTo(BeNil())
+			Expect(entry.GetFailure().GetReason()).To(Equal(commonpb.ErrorReason_ERROR_REASON_INDEX_ALREADY_EXISTS))
+			full, err := client.GetAuditEntry(ctx, &servicepb.GetAuditEntryRequest{Sequence: entry.GetSequence()})
+			Expect(err).To(Succeed())
+			Expect(full.GetItems()).To(HaveLen(1))
+			Expect(full.GetItems()[0].GetLogSequence()).To(BeZero(), "failure must not emit a created or skipped log")
+			Expect(decodeOrder(full.GetItems()[0]).GetLedgerScoped().GetApply().GetCreateIndex()).NotTo(BeNil())
+		}
+		logs, err := actions.ListAllLogs(ctx, client, ledger)
+		Expect(err).To(Succeed())
+		Expect(logs).To(HaveLen(1), "only the winning creation may emit a ledger apply log")
+		Expect(logs[0].GetPayload().GetApply().GetLog().GetData().GetCreateIndex()).NotTo(BeNil())
+		check, err := actions.CollectCheckStoreEvents(ctx, client)
+		Expect(err).To(Succeed())
+		Expect(check.Errors).To(BeEmpty())
+	})
+})

--- a/tests/e2e/cluster/restore_index_registry_test.go
+++ b/tests/e2e/cluster/restore_index_registry_test.go
@@ -26,6 +26,9 @@ import (
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 // This suite pins the dropped-index loss the model test surfaced
@@ -253,10 +256,27 @@ var _ = Describe("Restore index registry", Ordered, func() {
 			Expect(removed.GetDroppedIndex()).ToNot(BeNil(), "live premise: the removal must drop the checkpoint-seeded index")
 		})
 
+		It("audits rejected duplicate creations in the delta without resetting registry rows", func() {
+			for _, key := range []string{retypedKey, deltaKey} {
+				before := registryRow(client, key)
+				Expect(before).NotTo(BeNil())
+				_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("idxreg-duplicate-"+key,
+					actions.CreateAccountMetadataIndexAction(ledgerName, key)))
+				Expect(status.Code(err)).To(Equal(codes.AlreadyExists))
+				Expect(actions.ExtractGRPCErrorInfo(err)).NotTo(BeNil())
+				Expect(actions.ExtractGRPCErrorInfo(err).Reason).To(Equal("INDEX_ALREADY_EXISTS"))
+				Expect(proto.Equal(registryRow(client, key), before)).To(BeTrue())
+			}
+			result, err := actions.CollectCheckStoreEvents(ctx, client)
+			Expect(err).To(Succeed())
+			Expect(result.Errors).To(BeEmpty())
+		})
+
 		It("exports the delta and captures the source registry", func() {
 			incResp, err := clusterClient.IncrementalBackup(ctx, &clusterpb.IncrementalBackupRequest{Storage: storage()})
 			Expect(err).To(Succeed())
 			Expect(incResp.GetLogEntriesExported()).To(BeNumerically(">", 0))
+			Expect(incResp.GetAuditEntriesExported()).To(BeNumerically(">", 0), "delta must include the failed duplicate creations")
 
 			sourceRows = map[string]*commonpb.Index{
 				retypedKey: registryRow(client, retypedKey),
@@ -393,6 +413,34 @@ var _ = Describe("Restore index registry", Ordered, func() {
 			result, err := actions.CollectCheckStoreEvents(ctx, client)
 			Expect(err).To(Succeed())
 			Expect(result.Errors).To(BeEmpty(), "CheckStore errors on the restored store: %v", result.Errors)
+		})
+
+		It("retains duplicate failure audits and rejects fresh creates after restore", func() {
+			entries, err := actions.ListAuditEntries(ctx, client, true)
+			Expect(err).To(Succeed())
+			for _, key := range []string{retypedKey, deltaKey} {
+				found := 0
+				for _, entry := range entries {
+					if entry.GetIdempotency().GetKey() == "idxreg-duplicate-"+key {
+						found++
+						Expect(entry.GetFailure().GetReason()).To(Equal(commonpb.ErrorReason_ERROR_REASON_INDEX_ALREADY_EXISTS))
+						full, err := client.GetAuditEntry(ctx, &servicepb.GetAuditEntryRequest{Sequence: entry.GetSequence()})
+						Expect(err).To(Succeed())
+						Expect(full.GetItems()).To(HaveLen(1))
+						Expect(full.GetItems()[0].GetLogSequence()).To(BeZero())
+					}
+				}
+				Expect(found).To(Equal(1), "failed duplicate audit for %s must survive the delta", key)
+				_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("idxreg-restored-duplicate-"+key,
+					actions.CreateAccountMetadataIndexAction(ledgerName, key)))
+				Expect(status.Code(err)).To(Equal(codes.AlreadyExists))
+				Expect(actions.ExtractGRPCErrorInfo(err)).NotTo(BeNil())
+				Expect(actions.ExtractGRPCErrorInfo(err).Reason).To(Equal("INDEX_ALREADY_EXISTS"))
+				Expect(proto.Equal(registryRow(client, key), sourceRows[key])).To(BeTrue())
+			}
+			result, err := actions.CollectCheckStoreEvents(ctx, client)
+			Expect(err).To(Succeed())
+			Expect(result.Errors).To(BeEmpty())
 		})
 
 		It("drops the retyped index when its field is removed", func() {


### PR DESCRIPTION
## What changed

Fresh `CreateIndex` requests now reject an existing ledger/canonical index identity with `INDEX_ALREADY_EXISTS` (HTTP 409 / gRPC AlreadyExists). The FSM checks the declared, preloaded registry before any mutation, preserving creation date, encoding version and build progress. Retained batch-idempotency retries still return their frozen result.

The operator now propagates a create conflict instead of recording it as a successful creation. Existing replay/indexbuilder guards remain intact.

## Why

Fixes [EN-2009](https://formance-team.atlassian.net/browse/EN-2009). A successful fresh creation must mean an index was actually created; repeated creation previously reset the registry and emitted another creation log.

## Product / operational motivation

Need: unambiguous successful creation and audit evidence. Requirement: reject duplicates regardless of readiness or schema rewrite state, preserve atomic batches and retained idempotency outcomes, and propagate coverage/read failures. The committed contract is in `docs/technical/architecture/subsystems/indexer/indexes.md`.

## Technical decision

Use the existing gated `indexes.Find` access inside deterministic FSM apply, followed by the ordinary audited business-error path. Admission already declares the index key. No additional storage access, ownership fields, mode flags, skip reason, migration or compatibility path is introduced.

## Risk

**MEDIUM** — intentional incompatible creation semantics. Service protocol revision changes from **5 to 6**; clients and servers must use the matching contract and replicas must agree on apply semantics.

## Validation

- [x] `bash scripts/agent-check`
- [x] Pinned Nix generation and root/operator lint: zero issues.
- [x] Full `-race` suites: processing, state, indexbuilder, domain, gRPC/error adapters; HTTP create and operator conflict regressions.
- [x] Targeted `-race` e2e: strict concurrent creation and S3 incremental index-registry restore.
- [x] Independent final review of implementation `2b570c13fd22762c1095035b688baf6453e4b706`: APPROVE, no findings. The follow-up documentation/comment corrections in `f08c185a376d34c7c8c719085da4da6b7b042210` were independently reviewed with no remaining findings; baseline validation passes on this head.
- [ ] `AI_REVIEW_BASE_SHA=dfa416b8216c0418ce7c18c9a01f50c74b9c34b4 bash scripts/agent-check-pr`: normalization and baseline PASS; root race suite failed only on the existing `TestRunModelTestRequiresVerifiedOutcome` 15-second fixture deadline. All other root packages passed. The fixture uses fake Go/server/driver shell programs and these files are unchanged by this PR. One isolated `-race -count=1` rerun passed in 7.761s; this does **not** turn the broad gate into a pass.
- [x] Remaining selected local gates passed separately: full business/cluster e2e with races, Schemathesis and the operator suite. The root failure had stopped the selector before these gates.
- [x] GitHub CI on implementation commit `2b570c1`: all test/build/coverage checks pass (run 34468517094); optional image/release jobs are skipped.
- [x] GitHub CI on current documentation follow-up `f08c185`: all test/build/coverage checks pass (run 34470218940); optional image/release jobs are skipped.
- [ ] Native review loop: `AI_PR_LOOP_RESULT: VALIDATION_FAILED` on the same unchanged Antithesis 15-second fixture, before review. The original launcher exited 141 because its worktree-discovery pipeline exits early under `pipefail`; a temporary untracked copy consumed the complete input to reach the unchanged trusted-base validation. No validator was skipped or relaxed.


```text
DISCOVERY: NO_EXISTING_WORK
BEFORE_FIX: BUG_REPRODUCED
AFTER_FIX: PASS
BASELINE_CLASSIFICATION: BASELINE_FAILURE
```

Regression sensitivity was checked in an isolated detached worktree at the exact candidate: restoring only the base `processor_index.go` makes the four new duplicate/read-failure subtests fail on an unexpected `GetDate` before any `Put`; restoring the candidate makes the same tests pass. No active candidate or unrelated PR was modified. The baseline classification refers to the existing Antithesis fixture timeout; the earlier disk failure was environmental.

## Architecture / behavior impact

No storage layout change. Failed duplicates create normal failure audits and no CreatedIndexLog. Existing registry/idempotency projections remain checker verified; restore tests exercise rejected duplicates within a non-empty post-checkpoint delta. API, CLI, index and operator documentation are synchronized.

## Review focus

Existence/coverage checks before writes; batch rollback and retained success/failure replay; operator conflict propagation; unchanged replay/indexbuilder guards.

## Known concerns

The initial broad validation encountered a full disk; a separately coordinated legacy Go cache cleanup resolved it. The rebased gate had no disk failure, but reproduced the previously observed `TestRunModelTestRequiresVerifiedOutcome` timeout. These results are reported without treating isolated passing tests as a green broad gate.

EN-2002 / PR #1971 remains separate and untouched. This change does not resolve ownership recovery after a lost response/status update or conditional deletion of a replaced index.

Shipfox approved with two minor documentation comments on `2b570c1`. Both are addressed in `f08c185`: the replay comment now describes accepted creation logs, and the API comparison no longer repeats an obsolete protocol version. Shipfox confirmed approval with no findings on current head `f08c185` (comment 5617982175); NumaryBot also approves this head. Team review has been requested.


[EN-2009]: https://formance-team.atlassian.net/browse/EN-2009?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ