### PR TITLE
fix(bootstrap): preserve IPv6 service addresses (EN-2013)

### DIFF
--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -4059,6 +4059,13 @@ ledger run --pebble-compression "none,snappy,zstd,zstd,zstd,zstd,zstd" [other fl
 
 ---
 
+### Server Advertised Addresses
+
+For server startup, `--advertise-addr` supplies the host shared by the Raft
+and service endpoints; `--grpc-port` supplies the service port. For example,
+`--advertise-addr '[2001:db8::1]:7777' --grpc-port 8888` advertises
+`[2001:db8::1]:8888` for service RPCs. See [deployment](deployment.md#command-structure).
+
 ### Server Raft Consensus Flags
 
 Tune the Raft consensus layer. These flags control election timing, message sizes, compaction, and the propose queue.

--- a/docs/ops/deployment.md
+++ b/docs/ops/deployment.md
@@ -67,6 +67,12 @@ Available flags for `run`:
 - `--health-wal-threshold`: WAL volume usage threshold, 0.0-1.0 (default: `0.8`)
 - `--health-data-threshold`: Data volume usage threshold, 0.0-1.0 (default: `0.8`)
 
+The service address published to peers uses the host from `--advertise-addr`
+and the port from `--grpc-port`. IPv6 hosts retain their brackets: for example,
+`--advertise-addr '[2001:db8::1]:7777' --grpc-port 8888` publishes
+`[2001:db8::1]:8888` for service RPCs while keeping `[2001:db8::1]:7777` for Raft.
+IPv4 addresses and hostnames use the same host with the configured service port.
+
 ### Configuration
 
 Options can be provided via:

--- a/internal/bootstrap/config.go
+++ b/internal/bootstrap/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
 	"time"
 
 	"github.com/formancehq/ledger/v3/internal/infra/monitoring/metrics"
@@ -395,13 +396,13 @@ func (c Config) validateAuthConfig() error {
 }
 
 // ServiceAdvertiseAddr returns the routable gRPC service address for this node.
-// It derives the hostname from the Raft advertise address and uses the gRPC port,
-// so that other nodes can reach this node's service API.
+// It derives the host from the Raft advertise address and uses the gRPC port,
+// preserving IPv6 brackets so other nodes can reach this node's service API.
 func (c Config) ServiceAdvertiseAddr() string {
 	host, _, err := net.SplitHostPort(c.RaftConfig.AdvertiseAddr)
 	if err != nil {
 		host = c.RaftConfig.AdvertiseAddr
 	}
 
-	return fmt.Sprintf("%s:%d", host, c.GRPCPort)
+	return net.JoinHostPort(host, strconv.Itoa(c.GRPCPort))
 }

--- a/internal/bootstrap/config_test.go
+++ b/internal/bootstrap/config_test.go
@@ -1,6 +1,8 @@
 package bootstrap
 
 import (
+	"net"
+	"strconv"
 	"testing"
 	"time"
 
@@ -29,6 +31,39 @@ func TestServiceAdvertiseAddr_WithoutPort(t *testing.T) {
 	}
 
 	require.Equal(t, "myhost:8080", cfg.ServiceAdvertiseAddr())
+}
+
+func TestServiceAdvertiseAddr_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name      string
+		advertise string
+		host      string
+		want      string
+	}{
+		{"IPv4", "10.0.0.1:7777", "10.0.0.1", "10.0.0.1:8888"},
+		{"hostname with port", "myhost:7777", "myhost", "myhost:8888"},
+		{"hostname without port", "myhost", "myhost", "myhost:8888"},
+		{"IPv6", "[2001:db8::1]:7777", "2001:db8::1", "[2001:db8::1]:8888"},
+		{"IPv6 without port", "2001:db8::1", "2001:db8::1", "[2001:db8::1]:8888"},
+		{"IPv6 with zone", "[fe80::1%en0]:7777", "fe80::1%en0", "[fe80::1%en0]:8888"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := Config{
+				RaftConfig: node.NodeConfig{AdvertiseAddr: tt.advertise},
+				GRPCPort:   8888,
+			}
+			addr := cfg.ServiceAdvertiseAddr()
+			require.Equal(t, tt.want, addr)
+			host, port, err := net.SplitHostPort(addr)
+			require.NoError(t, err)
+			require.Equal(t, tt.host, host)
+			require.Equal(t, strconv.Itoa(cfg.GRPCPort), port)
+		})
+	}
 }
 
 // validBaseConfig returns a Config with required fields set so that

--- a/internal/bootstrap/module.go
+++ b/internal/bootstrap/module.go
@@ -377,24 +377,7 @@ func Module() fx.Option {
 				return nodeProvideResult{Node: n, FreshStart: freshStart}, nil
 			},
 			buildResponseSigner,
-			func(cfg Config) (node.NodeConfig, error) {
-				cfg.RaftConfig.DataDir = cfg.DataDir
-				cfg.RaftConfig.ServiceAdvertiseAddr = cfg.ServiceAdvertiseAddr()
-				cfg.RaftConfig.SetDefaults()
-
-				// EN-1045: establish this peer's identity UUID before any
-				// membership plumbing runs. First boot generates and
-				// persists it in INSTANCE_ID under WalDir; later boots
-				// return the same value.
-				instanceID, err := wal.EnsureInstanceID(cfg.RaftConfig.WalDir)
-				if err != nil {
-					return node.NodeConfig{}, fmt.Errorf("ensuring instance id: %w", err)
-				}
-
-				cfg.RaftConfig.InstanceID = instanceID
-
-				return cfg.RaftConfig, nil
-			},
+			buildNodeConfig,
 			func(cfg Config) node.TransportConfig {
 				return cfg.TransportConfig
 			},
@@ -1797,4 +1780,23 @@ func handleLeadershipChangeEvent(
 
 	eventsManager.OnLeadershipChange(e.IsLeader)
 	mirrorManager.OnLeadershipChange(e.IsLeader)
+}
+
+func buildNodeConfig(cfg Config) (node.NodeConfig, error) {
+	cfg.RaftConfig.DataDir = cfg.DataDir
+	cfg.RaftConfig.ServiceAdvertiseAddr = cfg.ServiceAdvertiseAddr()
+	cfg.RaftConfig.SetDefaults()
+
+	// EN-1045: establish this peer's identity UUID before any
+	// membership plumbing runs. First boot generates and
+	// persists it in INSTANCE_ID under WalDir; later boots
+	// return the same value.
+	instanceID, err := wal.EnsureInstanceID(cfg.RaftConfig.WalDir)
+	if err != nil {
+		return node.NodeConfig{}, fmt.Errorf("ensuring instance id: %w", err)
+	}
+
+	cfg.RaftConfig.InstanceID = instanceID
+
+	return cfg.RaftConfig, nil
 }

--- a/internal/bootstrap/service_address_test.go
+++ b/internal/bootstrap/service_address_test.go
@@ -1,0 +1,92 @@
+package bootstrap
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/peer"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/infra/membership"
+	"github.com/formancehq/ledger/v3/internal/infra/node"
+	"github.com/formancehq/ledger/v3/internal/infra/transport"
+)
+
+// Service forwarding is under test; Raft message transport has no work here.
+type serviceAddressRaftTransport struct{}
+
+func (serviceAddressRaftTransport) AddPeer(uint64, string)             {}
+func (serviceAddressRaftTransport) RemovePeer(context.Context, uint64) {}
+
+func TestServiceAdvertiseAddr_IPv6RemoteRPC(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp6", "[::1]:0")
+	require.NoError(t, err, "the IPv6 regression requires IPv6 loopback")
+	server := grpc.NewServer()
+	healthpb.RegisterHealthServer(server, health.NewServer())
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- server.Serve(listener) }()
+	t.Cleanup(func() {
+		server.Stop() // Also closes the owned listener and active connections.
+		select {
+		case err := <-serveDone:
+			require.NoError(t, err)
+		case <-time.After(5 * time.Second):
+			t.Error("gRPC server did not stop")
+		}
+	})
+
+	// Hold a distinct Raft socket so replacing its port cannot accidentally
+	// pass by dialing the original advertise address.
+	raftListener, err := net.Listen("tcp6", "[::1]:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, raftListener.Close()) })
+	cfg := Config{
+		RaftConfig: node.NodeConfig{
+			NodeID:        2,
+			AdvertiseAddr: raftListener.Addr().String(),
+			WalDir:        t.TempDir(),
+		},
+		DataDir:  t.TempDir(),
+		GRPCPort: listener.Addr().(*net.TCPAddr).Port,
+	}
+	// Exercise the same provider registered in the bootstrap Fx graph.
+	published, err := buildNodeConfig(cfg)
+	require.NoError(t, err)
+	require.Equal(t, cfg.RaftConfig.AdvertiseAddr, published.AdvertiseAddr)
+	require.Equal(t, cfg.DataDir, published.DataDir)
+	require.Len(t, published.InstanceID, 16)
+
+	pool := transport.NewConnectionPool(transport.TLSPolicy{}, transport.PoolConfig{})
+	t.Cleanup(func() { require.NoError(t, pool.Close()) })
+	peerStore := membership.NewPeerStore(newTestStore(t))
+	remote, err := membership.NewMembership(peerStore, serviceAddressRaftTransport{}, pool,
+		1, "", "", nil, logging.Testing())
+	require.NoError(t, err)
+	require.NoError(t, remote.Register(published.NodeID, published.AdvertiseAddr,
+		published.ServiceAdvertiseAddr, published.InstanceID))
+	remote.Start()
+	conn := pool.GetConnection(published.NodeID)
+	require.NotNil(t, conn)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+	var reached peer.Peer
+	response, err := healthpb.NewHealthClient(conn).Check(ctx, &healthpb.HealthCheckRequest{},
+		grpc.WaitForReady(true), grpc.Peer(&reached))
+	require.NoError(t, err)
+	require.Equal(t, healthpb.HealthCheckResponse_SERVING, response.GetStatus())
+	require.Equal(t, listener.Addr().String(), reached.Addr.String())
+	require.Equal(t, listener.Addr().String(), pool.GetPeerAddress(published.NodeID))
+	stored, err := peerStore.LoadAll()
+	require.NoError(t, err)
+	require.Equal(t, listener.Addr().String(), stored[published.NodeID].ServiceAddress)
+}


### PR DESCRIPTION
## What changed

Preserve IPv6 brackets when deriving the service endpoint from the Raft advertise address. For example, `[2001:db8::1]:7777` with service port `8888` now publishes `[2001:db8::1]:8888`.

Use `net.JoinHostPort` at the source. Extract the existing NodeConfig provider without changing its identity/default initialization, so the regression exercises production publication through remote membership and the connection pool.

## Why

[EN-2013](https://formance-team.atlassian.net/browse/EN-2013), under Ledger v3.0 (EN-867). The previous concatenation lost the IPv6 delimiter and prevented peers from reaching the intended service endpoint.

## Product / operational motivation

N/A (mechanical endpoint-format correction).

## Technical decision

N/A

## Risk

**LOW** — endpoint formatting only; NodeConfig provider extraction preserves its existing behavior.

## Validation

- [x] Fail-before on base `404ac87a4291701bdca5ba9fed4997fb71412933` with the new regressions and unchanged address derivation: IPv6 formatting fails; the real remote RPC times out with `invalid target address ::1:<port>` / `too many colons in address`.
- [x] Pass-after: `go test -race ./internal/bootstrap ./internal/infra/membership ./internal/infra/transport -count=1 -timeout=5m` through the repository cache wrapper and pinned Nix environment.
- [x] `bash scripts/agent-check`
- [x] `AI_REVIEW_BASE_SHA=404ac87a4291701bdca5ba9fed4997fb71412933 bash scripts/agent-check-pr`

The prior audit was static confirmation; the executable reproduction above was obtained for this change. IPv6 loopback is required by the RPC regression, which does not skip when IPv6 is unavailable.

## Architecture / behavior impact

IPv6 service addresses retain host/port boundaries through NodeConfig and membership publication. IPv4 and hostname behavior is preserved. No protobuf contract, FSM semantics, storage schema, or persisted-configuration validation change. CLI and deployment docs explain the advertised endpoint.

## Review focus

The test performs an actual five-second-bounded health RPC through the remote pool, verifies the reached IPv6 socket and persisted peer endpoint, and holds a separate Raft socket to detect use of the wrong port.

## Known concerns

None. CI and human review remain merge gates. EN-2013 stays open until merge.


[EN-2013]: https://formance-team.atlassian.net/browse/EN-2013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ