### PR TITLE
fix(ledgerctl): preserve structured output integers (EN-2017)

### DIFF
--- a/cmd/ledgerctl/cmdutil/output.go
+++ b/cmd/ledgerctl/cmdutil/output.go
@@ -1,10 +1,12 @@
 package cmdutil
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
 	"reflect"
+	"strings"
 
 	"github.com/pterm/pterm"
 	"github.com/spf13/cobra"
@@ -92,7 +94,8 @@ func writeResultFile(path string, payload []byte) error {
 
 // encodeYAMLViaJSON marshals data to JSON first (using protojson for proto
 // types), then converts to YAML. This ensures YAML keys use camelCase from
-// protobuf canonical JSON rather than lowercased Go field names.
+// protobuf canonical JSON rather than lowercased Go field names, and preserves
+// custom JSON projections. Numeric tokens retain their precision and scalar kind.
 func encodeYAMLViaJSON(data any) error {
 	jsonBytes, err := marshalJSON(data)
 	if err != nil {
@@ -100,19 +103,46 @@ func encodeYAMLViaJSON(data any) error {
 	}
 
 	var intermediate any
-	if err := json.Unmarshal(jsonBytes, &intermediate); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(jsonBytes))
+	decoder.UseNumber()
+	if err := decoder.Decode(&intermediate); err != nil {
 		return err
 	}
 
 	encoder := yaml.NewEncoder(os.Stdout)
 	encoder.SetIndent(2)
 
-	err = encoder.Encode(intermediate)
+	err = encoder.Encode(yamlNumbers(intermediate))
 	if closeErr := encoder.Close(); err == nil {
 		err = closeErr
 	}
 
 	return err
+}
+
+// yamlNumbers keeps JSON numbers numeric in YAML without converting through
+// float64 or limiting integers to 64 bits (posting amounts can be uint256).
+// The input is a freshly decoded JSON tree, so containers can be updated in place.
+func yamlNumbers(value any) any {
+	switch value := value.(type) {
+	case json.Number:
+		tag := "!!int"
+		if strings.ContainsAny(value.String(), ".eE") {
+			tag = "!!float"
+		}
+
+		return &yaml.Node{Kind: yaml.ScalarNode, Tag: tag, Value: value.String()}
+	case []any:
+		for i, item := range value {
+			value[i] = yamlNumbers(item)
+		}
+	case map[string]any:
+		for key, item := range value {
+			value[key] = yamlNumbers(item)
+		}
+	}
+
+	return value
 }
 
 // marshalJSON dispatches to the appropriate JSON encoder:
@@ -265,6 +295,7 @@ func convertAnyValue(rv reflect.Value) (any, error) {
 // protoToAny marshals a proto.Message to JSON, then unmarshals to any so it
 // can be combined with other values in a json.MarshalIndent call.
 // Prefers custom MarshalJSON when available (handles Uint256, Timestamp, etc.).
+// UseNumber keeps numeric tokens exact when composing proto slices and maps.
 func protoToAny(msg proto.Message) (any, error) {
 	var b []byte
 	var err error
@@ -280,7 +311,9 @@ func protoToAny(msg proto.Message) (any, error) {
 	}
 
 	var v any
-	if err := json.Unmarshal(b, &v); err != nil {
+	decoder := json.NewDecoder(bytes.NewReader(b))
+	decoder.UseNumber()
+	if err := decoder.Decode(&v); err != nil {
 		return nil, err
 	}
 

--- a/cmd/ledgerctl/cmdutil/output_test.go
+++ b/cmd/ledgerctl/cmdutil/output_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,7 +15,121 @@ import (
 
 	"github.com/formancehq/ledger/v3/cmd/ledgerctl/cmdutil"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
+
+// Sequential because captureStdout mutates os.Stdout.
+func TestEncodeStructured_ExactNumbers(t *testing.T) {
+	response := &servicepb.GetTransactionResponse{Transaction: &commonpb.Transaction{
+		Id: 9007199254740993,
+		Metadata: map[string]*commonpb.MetadataValue{
+			"positive":      commonpb.NewUintValue(9007199254740993),
+			"negative":      commonpb.NewIntValue(-9007199254740993),
+			"maxUint":       commonpb.NewUintValue(math.MaxUint64),
+			"minInt":        commonpb.NewIntValue(math.MinInt64),
+			"numericString": commonpb.NewStringValue("9007199254740993"),
+		},
+	}}
+	for _, format := range []string{"json", "yaml"} {
+		for _, tc := range []struct {
+			name   string
+			data   any
+			prefix []string
+		}{
+			{name: "response", data: response},
+			{name: "proto slice", data: []*servicepb.GetTransactionResponse{response}, prefix: []string{"0"}},
+			{name: "proto map", data: map[string]*servicepb.GetTransactionResponse{"item": response}, prefix: []string{"item"}},
+			{name: "mixed map", data: map[string]any{"item": response}, prefix: []string{"item"}},
+		} {
+			t.Run(format+"/"+tc.name, func(t *testing.T) {
+				cmd := &cobra.Command{}
+				cmdutil.AddOutputFlags(cmd)
+				require.NoError(t, cmd.Flags().Set(format, "true"))
+				out := captureStdout(t, func() {
+					handled, err := cmdutil.EncodeStructured(cmd, tc.data)
+					require.NoError(t, err)
+					require.True(t, handled)
+				})
+				// Nodes preserve scalar spelling and tags without converting to float64.
+				var document yaml.Node
+				require.NoError(t, yaml.Unmarshal([]byte(out), &document))
+				transaction := outputNodeAt(t, document.Content[0], append(tc.prefix, "transaction")...)
+				for key, want := range map[string]string{
+					"positive": "9007199254740993", "negative": "-9007199254740993",
+					"maxUint": "18446744073709551615", "minInt": "-9223372036854775808",
+				} {
+					t.Run(key, func(t *testing.T) {
+						node := outputNodeAt(t, transaction, "metadata", key)
+						require.Equal(t, "!!int", node.Tag)
+						require.Equal(t, want, node.Value)
+					})
+				}
+				require.Equal(t, "9007199254740993", outputNodeAt(t, transaction, "id").Value)
+				require.Equal(t, "!!str", outputNodeAt(t, transaction, "metadata", "numericString").Tag)
+			})
+		}
+	}
+}
+
+func outputNodeAt(t *testing.T, node *yaml.Node, path ...string) *yaml.Node {
+	t.Helper()
+	for _, key := range path {
+		if node.Kind == yaml.SequenceNode {
+			require.Equal(t, "0", key)
+			require.NotEmpty(t, node.Content)
+			node = node.Content[0]
+
+			continue
+		}
+		require.Equal(t, yaml.MappingNode, node.Kind)
+		var child *yaml.Node
+		for i := 0; i < len(node.Content); i += 2 {
+			if node.Content[i].Value == key {
+				child = node.Content[i+1]
+
+				break
+			}
+		}
+		require.NotNil(t, child, "missing key %q", key)
+		node = child
+	}
+
+	return node
+}
+
+// Sequential because captureStdout mutates os.Stdout.
+func TestEncodeStructured_YAMLScalarKinds(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		data  any
+		tag   string
+		value string
+	}{
+		{name: "uint256", data: &commonpb.Uint256{V3: 256}, tag: "!!int", value: "1606938044258990275541962092341162602522202993782792835301376"},
+		{name: "fraction", data: json.Number("1.25"), tag: "!!float", value: "1.25"},
+		{name: "exponent", data: json.Number("1e+30"), tag: "!!float", value: "1e+30"},
+		{name: "string", data: "9007199254740993", tag: "!!str", value: "9007199254740993"},
+		{name: "boolean", data: true, tag: "!!bool", value: "true"},
+		{name: "null", data: nil, tag: "!!null", value: "null"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			cmdutil.AddOutputFlags(cmd)
+			require.NoError(t, cmd.Flags().Set("yaml", "true"))
+			out := captureStdout(t, func() {
+				handled, err := cmdutil.EncodeStructured(cmd, tc.data)
+				require.NoError(t, err)
+				require.True(t, handled)
+			})
+			var document yaml.Node
+			require.NoError(t, yaml.Unmarshal([]byte(out), &document))
+			require.Len(t, document.Content, 1)
+			require.Equal(t, yaml.ScalarNode, document.Content[0].Kind)
+			require.Equal(t, tc.tag, document.Content[0].Tag)
+			require.Equal(t, tc.value, document.Content[0].Value)
+		})
+	}
+}
 
 // TestEncodeStructured is sequential because captureStdout mutates os.Stdout.
 func TestEncodeStructured(t *testing.T) {

--- a/cmd/ledgerctl/transactions_output_test.go
+++ b/cmd/ledgerctl/transactions_output_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/pterm/pterm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+	"google.golang.org/grpc"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+)
+
+type transactionOutputServer struct {
+	servicepb.UnimplementedBucketServiceServer
+
+	response *servicepb.GetTransactionResponse
+	requests chan *servicepb.GetTransactionRequest
+}
+
+func (s *transactionOutputServer) GetTransaction(_ context.Context, request *servicepb.GetTransactionRequest) (*servicepb.GetTransactionResponse, error) {
+	s.requests <- request
+
+	return s.response, nil
+}
+
+// Sequential because the registered command changes pterm writers and the
+// stdout capture and isolated profile configuration modify process globals.
+func TestTransactionsGetStructuredOutputPreservesIntegers(t *testing.T) {
+	const positive = uint64(9_007_199_254_740_993)
+	const negative = int64(-9_007_199_254_740_993)
+
+	// Seed the transport fixture with typed protobuf values. Passing through
+	// HTTP/JSON on the way in could round the input before this CLI regression.
+	fixture := &transactionOutputServer{
+		response: &servicepb.GetTransactionResponse{
+			Transaction: &commonpb.Transaction{
+				Id: positive,
+				Metadata: map[string]*commonpb.MetadataValue{
+					"positive": commonpb.NewUintValue(positive),
+					"negative": commonpb.NewIntValue(negative),
+				},
+			},
+		},
+		requests: make(chan *servicepb.GetTransactionRequest, 2),
+	}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	server := grpc.NewServer()
+	servicepb.RegisterBucketServiceServer(server, fixture)
+	serveResult := make(chan error, 1)
+	go func() { serveResult <- server.Serve(listener) }()
+	t.Cleanup(func() {
+		server.Stop()
+		require.NoError(t, <-serveResult)
+	})
+
+	configDir := t.TempDir()
+	t.Setenv("HOME", configDir)
+	t.Setenv("XDG_CONFIG_HOME", configDir)
+	t.Setenv("APPDATA", configDir)
+	t.Setenv("LEDGERCTL_PROFILE", "")
+
+	for _, format := range []string{"json", "yaml"} {
+		t.Run(format, func(t *testing.T) {
+			root := newRootCommand()
+			root.SetArgs([]string{
+				"transactions", "get", "9007199254740993", "--ledger", "precise",
+				"--server", listener.Addr().String(), "--insecure",
+				"--tls-ca-cert=", "--tls-server-name=", "--result-file=",
+				"--signing-key=", "--response-verify-key=",
+				"--auth-token=test-token", "--" + format,
+			})
+
+			stdout, err := os.Create(filepath.Join(t.TempDir(), "stdout"))
+			require.NoError(t, err)
+			originalStdout := os.Stdout
+			os.Stdout = stdout
+			t.Cleanup(func() {
+				os.Stdout = originalStdout
+				pterm.SetDefaultOutput(originalStdout)
+				require.NoError(t, stdout.Close())
+			})
+			require.NoError(t, root.ExecuteContext(t.Context()))
+			_, err = stdout.Seek(0, io.SeekStart)
+			require.NoError(t, err)
+			output, err := io.ReadAll(stdout)
+			require.NoError(t, err)
+
+			select {
+			case request := <-fixture.requests:
+				require.Equal(t, "precise", request.GetLedger())
+				require.Equal(t, positive, request.GetTransactionId())
+			default:
+				t.Fatal("registered transactions get command did not call GetTransaction")
+			}
+
+			if format == "json" {
+				decoder := json.NewDecoder(bytes.NewReader(output))
+				decoder.UseNumber()
+				var response map[string]any
+				require.NoError(t, decoder.Decode(&response))
+				transaction := response["transaction"].(map[string]any)
+				metadata := transaction["metadata"].(map[string]any)
+				assert.Equal(t, json.Number("9007199254740993"), transaction["id"])
+				assert.Equal(t, json.Number("9007199254740993"), metadata["positive"])
+				assert.Equal(t, json.Number("-9007199254740993"), metadata["negative"])
+
+				return
+			}
+
+			var document yaml.Node
+			require.NoError(t, yaml.Unmarshal(output, &document))
+			require.Len(t, document.Content, 1)
+			transaction := transactionOutputYAMLField(t, document.Content[0], "transaction")
+			metadata := transactionOutputYAMLField(t, transaction, "metadata")
+			for _, expected := range []struct {
+				node  *yaml.Node
+				value string
+			}{
+				{transactionOutputYAMLField(t, transaction, "id"), "9007199254740993"},
+				{transactionOutputYAMLField(t, metadata, "positive"), "9007199254740993"},
+				{transactionOutputYAMLField(t, metadata, "negative"), "-9007199254740993"},
+			} {
+				assert.Equal(t, yaml.ScalarNode, expected.node.Kind)
+				assert.Equal(t, "!!int", expected.node.Tag, "integer %s must remain a numeric YAML scalar", expected.value)
+				assert.Equal(t, expected.value, expected.node.Value)
+			}
+		})
+	}
+}
+
+func transactionOutputYAMLField(t *testing.T, mapping *yaml.Node, key string) *yaml.Node {
+	t.Helper()
+	require.Equal(t, yaml.MappingNode, mapping.Kind)
+	for i := 0; i < len(mapping.Content); i += 2 {
+		if mapping.Content[i].Value == key {
+			return mapping.Content[i+1]
+		}
+	}
+	t.Fatalf("missing YAML field %q", key)
+
+	return nil
+}

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -186,6 +186,16 @@ scripting against the CLI predictable across resources.
 | Aliases | `get` | — | `g`, `show`, `describe` |
 | Aliases | `inspect` | — | `i` |
 
+Structured JSON and YAML output preserve the full precision of integer metadata,
+transaction IDs, and posting amounts, including values greater than `2^53`.
+YAML uses numeric scalars for JSON numbers and retains strings as strings. Both
+formats use the same public JSON projection and camelCase field names, including
+when responses are wrapped in lists or maps. For example, metadata values
+`9007199254740993` and `-9007199254740993` remain exact in either format.
+Use an integer-aware parser when consuming this output. The ledger-log projection
+is an output format, not an audit replay or backup format; it does not restore
+internal type distinctions omitted by the JSON projection.
+
 #### Unpaginated endpoints
 
 A few endpoints intentionally do not expose pagination because the underlying


### PR DESCRIPTION
## What changed

Preserve exact numeric tokens in ledgerctl JSON/YAML conversion, including protobuf responses wrapped in lists or maps. YAML emits integer scalars for integers, retains numeric-looking strings, and keeps the existing camelCase and LedgerLog JSON projection.

## Why

[EN-2017](https://formance-team.atlassian.net/browse/EN-2017): `transactions get --yaml` rounded valid metadata values `9007199254740993` and `-9007199254740993` through float64, although the typed gRPC response and direct JSON output were exact.

## Product / operational motivation

N/A — targeted correction of the existing structured-output numeric preservation contract.

## Technical decision

Keep the existing JSON projection boundary, decode numbers as tokens, and emit explicitly typed YAML scalar nodes. This also supports posting amounts beyond uint64 without introducing dependencies or restoring internal type distinctions omitted by LedgerLog JSON.

## Risk

**LOW** — limited to CLI structured output; no protobuf, persisted-state, FSM, or audit-format changes.

## Validation

- [x] `bash scripts/agent-check`
- [x] `AI_REVIEW_BASE_SHA=404ac87a4291701bdca5ba9fed4997fb71412933 bash scripts/agent-check-pr` (generation, tidy, both lints: zero issues, baseline, full race tests for `cmd/ledgerctl/cmdutil` and `cmd/ledgerctl`)
- [x] Targeted `go test -race ./cmd/ledgerctl/cmdutil ./cmd/ledgerctl -run 'TestEncodeStructured|TestTransactionsGetStructuredOutputPreservesIntegers' -count=1`
- [x] Fail-before/pass-after: registered command JSON passes before the fix, YAML fails numeric scalar assertions; EncodeStructured also reproduces rounding in direct YAML and composed protobuf JSON/YAML.
- [x] Final diff and independent review: no actionable findings. Existing camelCase and LedgerLog projection tests retained and passing.

## Architecture / behavior impact

CLI JSON/YAML now preserves full integer precision through composition and conversion. Documented in `docs/ops/cli.md`.

## Review focus

Integer scalar tags and exact digits, uint256 amounts, numeric-looking strings, and existing custom JSON projections. The registered CLI regression uses a local typed gRPC response fixture, independently of the HTTP input decoder addressed by EN-2014.

## Known concerns

The original qualified audit artifact/worktree is no longer available. Its contents were read from preserved tool output in the EN-2016 task, and the finding was independently reproduced here on base `404ac87a4291701bdca5ba9fed4997fb71412933`; static qualification is not presented as runtime reproduction. EN-2017 is attached to epic EN-867 and remains open until merge.


[EN-2017]: https://formance-team.atlassian.net/browse/EN-2017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ