### PR TITLE
fix(http): preserve chunked revert bodies (EN-2016)

### DIFF
--- a/docs/technical/architecture/subsystems/api/http-api.md
+++ b/docs/technical/architecture/subsystems/api/http-api.md
@@ -64,10 +64,12 @@ same guarantee for the `Request` oneof.
 `POST /v3/{ledgerName}/transactions/{transactionId}/revert` accepts an absent
 or empty body. When supplied, the JSON body carries `force`, `atEffectiveDate`
 and `metadata`, independently of HTTP framing: a chunked request is decoded
-even though its content length is unknown. Only EOF before reading any body byte
-is accepted as an empty body; malformed or truncated JSON returns
-`400 INVALID_REQUEST` before submitting Apply. The request remains subject to
-the 4 MiB body limit, with `413 BODY_TOO_LARGE` when exceeded.
+even though its content length is unknown. The complete body is read through
+the 4 MiB limit before decoding a single JSON document. Only a zero-byte body
+uses default options. Malformed or truncated JSON, extra JSON values and
+trailing non-whitespace return `400 INVALID_REQUEST` before submitting Apply.
+Trailing JSON whitespace is allowed, but counts towards the limit; exceeding
+it returns `413 BODY_TOO_LARGE`, including when only the suffix is oversized.
 
 ### Response Format
 

--- a/docs/technical/architecture/subsystems/api/http-api.md
+++ b/docs/technical/architecture/subsystems/api/http-api.md
@@ -59,6 +59,16 @@ the request reaches the endpoint — so the test asserts the matched pattern on 
 The gRPC analogue is `internal/adapter/auth/request_scope_exhaustiveness_test.go`, which gives the
 same guarantee for the `Request` oneof.
 
+### Optional transaction revert body
+
+`POST /v3/{ledgerName}/transactions/{transactionId}/revert` accepts an absent
+or empty body. When supplied, the JSON body carries `force`, `atEffectiveDate`
+and `metadata`, independently of HTTP framing: a chunked request is decoded
+even though its content length is unknown. Only EOF before reading any body byte
+is accepted as an empty body; malformed or truncated JSON returns
+`400 INVALID_REQUEST` before submitting Apply. The request remains subject to
+the 4 MiB body limit, with `413 BODY_TOO_LARGE` when exceeded.
+
 ### Response Format
 
 #### Success

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -228,6 +228,13 @@ See [Numscript Guide](./numscript.md) for complete documentation.
 - ✅ Revert metadata (typed values — string, integer, boolean — preserved losslessly; unsupported values rejected with `400 INVALID_REQUEST`)
 - ✅ Verification that transaction is not already reverted
 
+**Optional HTTP body.** A missing or empty revert body keeps the default options.
+A supplied JSON body is decoded regardless of `Content-Length`, including
+HTTP/1.1 chunked requests; `force`, `atEffectiveDate` and `metadata` reach the
+same Apply payload for known and unknown lengths. Malformed or truncated JSON
+returns `400 INVALID_REQUEST` before Apply. The existing 4 MiB body limit also
+applies to chunked bodies (`413 BODY_TOO_LARGE`).
+
 **Navigable revert relationship.** The revert link is a first-class part of the
 transaction representation (`GET`/list), not metadata — the platform never writes
 `com.formance.spec/*` keys. A transaction exposes:

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -232,8 +232,9 @@ See [Numscript Guide](./numscript.md) for complete documentation.
 A supplied JSON body is decoded regardless of `Content-Length`, including
 HTTP/1.1 chunked requests; `force`, `atEffectiveDate` and `metadata` reach the
 same Apply payload for known and unknown lengths. Malformed or truncated JSON
-returns `400 INVALID_REQUEST` before Apply. The existing 4 MiB body limit also
-applies to chunked bodies (`413 BODY_TOO_LARGE`).
+returns `400 INVALID_REQUEST` before Apply, including extra values or non-whitespace
+after the first value. The complete body, including trailing whitespace, counts
+towards the 4 MiB limit (`413 BODY_TOO_LARGE`), independently of framing.
 
 **Navigable revert relationship.** The revert link is a first-class part of the
 transaction representation (`GET`/list), not metadata — the platform never writes

--- a/internal/adapter/http/handlers_revert_transaction.go
+++ b/internal/adapter/http/handlers_revert_transaction.go
@@ -1,13 +1,11 @@
 package http
 
 import (
-	"bufio"
-	"errors"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 
-	"github.com/formancehq/ledger/v3/internal/adapter/json"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
@@ -24,17 +22,14 @@ func (s *Server) handleRevertTransaction(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Check actual emptiness, independent of ContentLength (chunked HTTP).
-	// Sonic also returns EOF for truncated JSON, so only EOF before the first
-	// byte is a valid empty body; every decoding error must reject the request.
+	// Read the whole body through the router's MaxBytesReader before decoding.
+	// A stream decoder can stop at the first value and miss trailing data or
+	// an oversized suffix. Only a zero-byte body means default revert options.
 	var reqBody map[string]any
 	if r.Body != nil {
-		body := bufio.NewReader(r.Body)
-		_, err := body.Peek(1)
-		if err == nil {
-			err = json.UnmarshalRead(body, &reqBody)
-		} else if errors.Is(err, io.EOF) {
-			err = nil
+		body, err := io.ReadAll(r.Body)
+		if err == nil && len(body) != 0 {
+			err = json.Unmarshal(body, &reqBody)
 		}
 		if err != nil {
 			writeBadRequest(w, "INVALID_REQUEST", fmt.Errorf("invalid request body: %w", err))

--- a/internal/adapter/http/handlers_revert_transaction.go
+++ b/internal/adapter/http/handlers_revert_transaction.go
@@ -1,7 +1,10 @@
 package http
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/formancehq/ledger/v3/internal/adapter/json"
@@ -21,10 +24,18 @@ func (s *Server) handleRevertTransaction(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Decode request body (optional - can be empty or contain metadata, force, atEffectiveDate)
+	// Check actual emptiness, independent of ContentLength (chunked HTTP).
+	// Sonic also returns EOF for truncated JSON, so only EOF before the first
+	// byte is a valid empty body; every decoding error must reject the request.
 	var reqBody map[string]any
-	if r.ContentLength > 0 {
-		err := json.UnmarshalRead(r.Body, &reqBody)
+	if r.Body != nil {
+		body := bufio.NewReader(r.Body)
+		_, err := body.Peek(1)
+		if err == nil {
+			err = json.UnmarshalRead(body, &reqBody)
+		} else if errors.Is(err, io.EOF) {
+			err = nil
+		}
 		if err != nil {
 			writeBadRequest(w, "INVALID_REQUEST", fmt.Errorf("invalid request body: %w", err))
 

--- a/internal/adapter/http/handlers_revert_transaction_body_test.go
+++ b/internal/adapter/http/handlers_revert_transaction_body_test.go
@@ -33,6 +33,9 @@ func TestHandleRevertTransaction_BodyFraming(t *testing.T) {
 		TransactionId: 1, Force: true, AtEffectiveDate: true, Metadata: metadata,
 	}
 	defaults := &servicepb.RevertTransactionPayload{TransactionId: 1}
+	controlMetadata, err := commonpb.MetadataFromAnyMap(map[string]any{"reason": "a\x00b"})
+	require.NoError(t, err)
+	escapedControl := &servicepb.RevertTransactionPayload{TransactionId: 1, Metadata: controlMetadata}
 
 	for _, tc := range []struct {
 		name   string
@@ -43,6 +46,15 @@ func TestHandleRevertTransaction_BodyFraming(t *testing.T) {
 		{"options", `{"force":true,"atEffectiveDate":true,"metadata":{"reason":"duplicate","count":42,"negative":-7,"active":true}}`, http.StatusCreated, options},
 		{"empty", "", http.StatusCreated, defaults},
 		{"empty object", `{}`, http.StatusCreated, defaults},
+		{"raw control", "{\"metadata\":{\"reason\":\"a\x00b\"}}", http.StatusBadRequest, nil},
+		{"escaped control", `{"metadata":{"reason":"a\u0000b"}}`, http.StatusCreated, escapedControl},
+		{"trailing junk", `{"force":true}garbage`, http.StatusBadRequest, nil},
+		{"second value", `{"force":true}{}`, http.StatusBadRequest, nil},
+		{"truncated second value", `{"force":true}{`, http.StatusBadRequest, nil},
+		{"trailing whitespace", "{} \t\r\n", http.StatusCreated, defaults},
+		{"exact size with whitespace", `{}` + strings.Repeat(" ", int(defaultMaxBodySize)-2), http.StatusCreated, defaults},
+		{"oversized whitespace", `{}` + strings.Repeat(" ", int(defaultMaxBodySize)-1), http.StatusRequestEntityTooLarge, nil},
+		{"oversized trailing junk", `{}` + strings.Repeat("x", int(defaultMaxBodySize)-1), http.StatusRequestEntityTooLarge, nil},
 		{"malformed", `{"force":!}`, http.StatusBadRequest, nil},
 		{"truncated", `{"force":true`, http.StatusBadRequest, nil},
 		{"oversized", `{"metadata":{"reason":"` + strings.Repeat("x", int(defaultMaxBodySize)) + `"}}`, http.StatusRequestEntityTooLarge, nil},
@@ -108,7 +120,7 @@ func TestHandleRevertTransaction_BodyFraming(t *testing.T) {
 				require.Equal(t, tc.status, status, "%s", responseBody)
 				if tc.want == nil {
 					require.Empty(t, calls, "invalid bodies must not reach Apply")
-					if tc.name == "oversized" {
+					if tc.status == http.StatusRequestEntityTooLarge {
 						require.Contains(t, string(responseBody), `"errorCode":"BODY_TOO_LARGE"`)
 						require.Contains(t, string(responseBody), "http: request body too large")
 					} else {

--- a/internal/adapter/http/handlers_revert_transaction_body_test.go
+++ b/internal/adapter/http/handlers_revert_transaction_body_test.go
@@ -1,0 +1,128 @@
+package http
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	internalauth "github.com/formancehq/ledger/v3/internal/adapter/auth"
+	"github.com/formancehq/ledger/v3/internal/pkg/version"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+)
+
+// Exercise the registered route with both explicit lengths and actual HTTP/1.1
+// chunked framing. The same expected Apply payload must survive every framing.
+func TestHandleRevertTransaction_BodyFraming(t *testing.T) {
+	t.Parallel()
+
+	metadata, err := commonpb.MetadataFromAnyMap(map[string]any{
+		"reason": "duplicate", "count": uint64(42), "negative": int64(-7), "active": true,
+	})
+	require.NoError(t, err)
+	options := &servicepb.RevertTransactionPayload{
+		TransactionId: 1, Force: true, AtEffectiveDate: true, Metadata: metadata,
+	}
+	defaults := &servicepb.RevertTransactionPayload{TransactionId: 1}
+
+	for _, tc := range []struct {
+		name   string
+		body   string
+		status int
+		want   *servicepb.RevertTransactionPayload
+	}{
+		{"options", `{"force":true,"atEffectiveDate":true,"metadata":{"reason":"duplicate","count":42,"negative":-7,"active":true}}`, http.StatusCreated, options},
+		{"empty", "", http.StatusCreated, defaults},
+		{"empty object", `{}`, http.StatusCreated, defaults},
+		{"malformed", `{"force":!}`, http.StatusBadRequest, nil},
+		{"truncated", `{"force":true`, http.StatusBadRequest, nil},
+		{"oversized", `{"metadata":{"reason":"` + strings.Repeat("x", int(defaultMaxBodySize)) + `"}}`, http.StatusRequestEntityTooLarge, nil},
+	} {
+		for _, framing := range []string{"known length", "unknown length", "HTTP1 chunked"} {
+			t.Run(tc.name+"/"+framing, func(t *testing.T) {
+				t.Parallel()
+
+				calls := make(chan *servicepb.ApplyRequest, 1)
+				backend := NewMockBackend(gomock.NewController(t))
+				backend.EXPECT().Apply(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(_ context.Context, req *servicepb.ApplyRequest) ([]*commonpb.Log, error) {
+						calls <- req
+
+						return []*commonpb.Log{{Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_Apply{
+							Apply: &commonpb.ApplyLedgerLog{Log: &commonpb.LedgerLog{Data: &commonpb.LedgerLogPayload{
+								Payload: &commonpb.LedgerLogPayload_RevertedTransaction{
+									RevertedTransaction: &commonpb.RevertedTransaction{RevertTransaction: &commonpb.Transaction{Id: 2}},
+								},
+							}}},
+						}}}}, nil
+					}).MaxTimes(1)
+				router := NewHandler(logging.Testing(), backend, internalauth.AuthConfig{}, version.Info{})
+				path := APIVersionPrefix + "/ledger1/transactions/1/revert"
+				var status int
+				var responseBody []byte
+				if framing == "HTTP1 chunked" {
+					type wireFraming struct {
+						protocol string
+						length   int64
+						encoding []string
+					}
+					wire := make(chan wireFraming, 1)
+					server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						wire <- wireFraming{r.Proto, r.ContentLength, r.TransferEncoding}
+						router.ServeHTTP(w, r)
+					}))
+					defer server.Close()
+					req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, server.URL+path, io.NopCloser(strings.NewReader(tc.body)))
+					require.NoError(t, err)
+					req.ContentLength = -1
+					req.TransferEncoding = []string{"chunked"}
+					resp, err := server.Client().Do(req)
+					require.NoError(t, err)
+					responseBody, err = io.ReadAll(resp.Body)
+					require.NoError(t, resp.Body.Close())
+					require.NoError(t, err)
+					status = resp.StatusCode
+					observed := <-wire
+					require.Equal(t, "HTTP/1.1", observed.protocol)
+					require.Equal(t, int64(-1), observed.length)
+					require.Equal(t, []string{"chunked"}, observed.encoding)
+				} else {
+					req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(tc.body))
+					if framing == "unknown length" {
+						req.ContentLength = -1
+					}
+					w := httptest.NewRecorder()
+					router.ServeHTTP(w, req)
+					status, responseBody = w.Code, w.Body.Bytes()
+				}
+
+				require.Equal(t, tc.status, status, "%s", responseBody)
+				if tc.want == nil {
+					require.Empty(t, calls, "invalid bodies must not reach Apply")
+					if tc.name == "oversized" {
+						require.Contains(t, string(responseBody), `"errorCode":"BODY_TOO_LARGE"`)
+						require.Contains(t, string(responseBody), "http: request body too large")
+					} else {
+						require.Contains(t, string(responseBody), `"errorCode":"INVALID_REQUEST"`)
+					}
+
+					return
+				}
+				require.Len(t, calls, 1)
+				req := <-calls
+				require.Equal(t, "ledger1", req.GetUnsigned().GetRequests()[0].GetApply().GetLedger())
+				got := revertPayloadFromApply(t, req)
+				require.True(t, proto.Equal(tc.want, got), "expected %v, got %v", tc.want, got)
+			})
+		}
+	}
+}

--- a/openapi.yml
+++ b/openapi.yml
@@ -1205,7 +1205,12 @@ paths:
   /v3/{ledgerName}/transactions/{transactionId}/revert:
     post:
       summary: Revert a transaction
-      description: Reverts a transaction by creating a reverse transaction that undoes its effects. Requires `ledger:write` scope.
+      description: |
+        Reverts a transaction by creating a reverse transaction that undoes its effects. Requires `ledger:write` scope.
+        The body is optional; an absent or empty body uses default options. Supplied
+        options and metadata are decoded for both known-length and HTTP/1.1 chunked
+        requests. Malformed or truncated JSON returns 400 before applying the revert.
+        Bodies exceeding the 4 MiB limit return 413, including chunked bodies.
       operationId: revertTransaction
       tags:
         - Transactions
@@ -1239,6 +1244,12 @@ paths:
           $ref: '#/components/responses/NotFound'
         '409':
           description: Conflict (e.g. transaction already reverted)
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '413':
+          description: Request body exceeds the 4 MiB limit
           content:
             application/json:
               schema:

--- a/openapi.yml
+++ b/openapi.yml
@@ -1209,8 +1209,9 @@ paths:
         Reverts a transaction by creating a reverse transaction that undoes its effects. Requires `ledger:write` scope.
         The body is optional; an absent or empty body uses default options. Supplied
         options and metadata are decoded for both known-length and HTTP/1.1 chunked
-        requests. Malformed or truncated JSON returns 400 before applying the revert.
-        Bodies exceeding the 4 MiB limit return 413, including chunked bodies.
+        requests. Malformed or truncated JSON, extra values and trailing non-whitespace
+        return 400 before applying the revert. The complete body, including trailing
+        whitespace, counts towards the 4 MiB limit; exceeding it returns 413.
       operationId: revertTransaction
       tags:
         - Transactions


### PR DESCRIPTION
## What changed

Transaction revert now reads its complete optional body through the existing 4 MiB limit before decoding one JSON document. Known-length and HTTP/1.1 chunked requests preserve force, atEffectiveDate and metadata. An absent or zero-byte body still uses defaults.

Malformed or truncated JSON, extra values and trailing non-whitespace return 400 before Apply. Trailing whitespace is valid but counts towards the size limit; an oversized suffix returns 413. Strict string validation rejects raw control characters while preserving valid escaped characters.

## Why

Fixes [EN-2016](https://formance-team.atlassian.net/browse/EN-2016), attached to Ledger v3.0 (EN-867). The positive ContentLength gate silently discarded chunked payloads, and a single streaming decode left suffixes unread and unvalidated.

## Product / operational motivation

N/A (focused correction of the documented request contract).

## Technical decision

Read the bounded body once, then use standard JSON unmarshalling to validate the entire document. This avoids ambiguous EOF handling, unread decoder buffers and a second truncated JSON value being mistaken for a clean end. Standard decoding also preserves the strict string validation of the previous Sonic ConfigStd reader.

The change stays in the revert handler. Extracting and migrating a shared optional-body helper across unrelated handlers is deferred; no shared decoder is changed.

## Risk

**LOW** — confined to HTTP revert admission. The request body is buffered within the existing limit; no FSM, persistence or gRPC contract changes.

## Validation

- Initial chunked-body regression: eight subcases fail before the framing correction at base `404ac87a4291701bdca5ba9fed4997fb71412933`.
- Review regression: 15 trailing-data/oversized-suffix subcases fail on the original PR head `474e3f4d4d557c85f1c3e88f8b21222cf10c971c` with 201 instead of 400/413.
- Final targeted revert tests pass under `-race`, with 45 framing cases including exact-limit success, one-byte-over rejection, raw versus escaped control characters, and all existing revert tests preserved.
- `bash scripts/agent-check`: passed.
- `AI_REVIEW_BASE_SHA=b96034bb0faa9650089da7b5e26950bd336f6f71 bash scripts/agent-check-pr`: passed (normalization, both lint runs, baseline, complete HTTP race suite and Schemathesis).
- Schemathesis tested 62 endpoints with no failures or unresolved errors; the runner accounted for one recovered transient network error.
- Independent final-diff review: approved, no findings.

## Architecture / behavior impact

The registered route preserves the same Apply payload across known, unknown and real HTTP/1.1 chunked framing. Invalid or oversized bodies never reach Apply. HTTP contract documentation and OpenAPI describe the complete-body validation and 413 response.

## Review focus

Whole-body size accounting, rejection of data after the first JSON value, strict string validation and optional empty-body behavior.

## Known concerns

EN-2014 independently addresses numeric precision. Its integration must preserve full-document validation, strict string validation and number-preserving decoding together; do not replace this call with a permissive or single-value streaming decoder. Coordination has been sent to that task. Do not close EN-2016 before merge.


[EN-2016]: https://formance-team.atlassian.net/browse/EN-2016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ