### PR TITLE
fix(http): decode metadata key path segments once (EN-2015)

### DIFF
--- a/docs/technical/architecture/subsystems/api/README.md
+++ b/docs/technical/architecture/subsystems/api/README.md
@@ -9,7 +9,7 @@ Client-facing transport layers (`internal/adapter/grpc`, `internal/adapter/http`
 | [grpc-api.md](grpc-api.md) | gRPC service, methods, request/response types, type-owned public error details, client examples, and restore-mode service lifetime. |
 | [grpc-connections.md](grpc-connections.md) | gRPC connection mechanics, reconnection, and rolling deployment optimizations. |
 | [protocol-compatibility.md](protocol-compatibility.md) | Mandatory service protocol revision, client/server rejection behavior, diagnostics, and revision maintenance (EN-1851). |
-| [http-api.md](http-api.md) | HTTP REST API endpoints, response formats, ledger-log JSON output and discriminators, error handling, and the `apierr`/`grpcerr` error boundary crossed by a forwarded write. |
+| [http-api.md](http-api.md) | HTTP REST API endpoints, single-decoding metadata key paths, response formats, ledger-log JSON output and discriminators, error handling, and the `apierr`/`grpcerr` error boundary crossed by a forwarded write. |
 | [auth.md](auth.md) | Client JWT authentication (OIDC + Ed25519), scope-based authorization, and the Raft inter-node cluster-secret auth layer. |
 
 ## Related

--- a/docs/technical/architecture/subsystems/api/http-api.md
+++ b/docs/technical/architecture/subsystems/api/http-api.md
@@ -17,6 +17,21 @@ By default: `http://localhost:9000`
 
 All business routes are served under the `/v3/` prefix. Ops routes (`/health`, `/livez`, `/readyz`, `/clusterz`, `/_info`, `/debug/pprof/`) are unversioned and served at the root.
 
+### Encoded metadata keys
+
+Metadata DELETE routes (account, transaction and ledger) and metadata-schema
+PUT/DELETE routes accept a metadata key as one URL path segment. Encode a slash
+inside the key as `%2F`: a key saved through JSON as `formance.com/reviewed` is
+addressed as `formance.com%2Freviewed`. JSON keys are not URL-decoded.
+
+Path parameters are decoded exactly once overall. Chi uses `URL.RawPath` when
+present, so the adapter unescapes that captured segment; otherwise Chi uses
+`URL.Path`, already decoded by Go. The same extraction rule applies to canonical
+index IDs. Double encoding (`formance.com%252Freviewed`) retains a literal
+`%2F` in the key and cannot select `formance.com/reviewed`. Metadata admission
+rejects percent-containing keys, including literal malformed escape sequences,
+with HTTP 400. A raw malformed URL escape is rejected by Go's HTTP parser.
+
 ### Authentication
 
 The server supports optional JWT/OIDC authentication with scope-based authorization. When enabled via `--auth-enabled`, all API requests must carry a valid Bearer token in the `Authorization` header. See [Authentication Guide](../../../../ops/authentication.md) for configuration details.

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -258,6 +258,12 @@ navigable in the representation but not queryable (v3-only, no parity baseline).
 - `PUT /v3/{ledgerName}/metadata-schema/{targetType}/{key}` - Set/change metadata field type
 - `DELETE /v3/{ledgerName}/metadata-schema/{targetType}/{key}` - Remove metadata field type declaration
 
+All metadata-key path parameters above use one URL-decoding pass, including
+schema PUT/DELETE. A JSON key `formance.com/reviewed` is addressed with
+`formance.com%2Freviewed`; double-encoded `%252F` retains a percent-containing
+key and is rejected by metadata admission with HTTP 400. Canonical index IDs
+use the same single-decoding rule.
+
 Ledger metadata is stored separately from ledger configuration (LedgerInfo) and is populated at read time when calling `GET /v3/{ledgerName}` or `GET /v3/` (list ledgers). It uses the same typed value system as account/transaction metadata.
 
 ### 4. Bulk Operations

--- a/internal/adapter/http/handlers_delete_account_metadata.go
+++ b/internal/adapter/http/handlers_delete_account_metadata.go
@@ -24,10 +24,8 @@ func (s *Server) handleDeleteAccountMetadata(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	key := chi.URLParam(r, "key")
-	if key == "" {
-		writeBadRequest(w, "INVALID_REQUEST", errors.New("metadata key is required"))
-
+	key, ok := requireMetadataKey(w, r)
+	if !ok {
 		return
 	}
 

--- a/internal/adapter/http/handlers_delete_ledger_metadata.go
+++ b/internal/adapter/http/handlers_delete_ledger_metadata.go
@@ -1,10 +1,7 @@
 package http
 
 import (
-	"errors"
 	"net/http"
-
-	"github.com/go-chi/chi/v5"
 
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
@@ -16,10 +13,8 @@ func (s *Server) handleDeleteLedgerMetadata(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	key := chi.URLParam(r, "key")
-	if key == "" {
-		writeBadRequest(w, "INVALID_REQUEST", errors.New("metadata key is required"))
-
+	key, ok := requireMetadataKey(w, r)
+	if !ok {
 		return
 	}
 

--- a/internal/adapter/http/handlers_delete_transaction_metadata.go
+++ b/internal/adapter/http/handlers_delete_transaction_metadata.go
@@ -1,10 +1,7 @@
 package http
 
 import (
-	"errors"
 	"net/http"
-
-	"github.com/go-chi/chi/v5"
 
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
@@ -22,10 +19,8 @@ func (s *Server) handleDeleteTransactionMetadata(w http.ResponseWriter, r *http.
 		return
 	}
 
-	key := chi.URLParam(r, "key")
-	if key == "" {
-		writeBadRequest(w, "INVALID_REQUEST", errors.New("metadata key is required"))
-
+	key, ok := requireMetadataKey(w, r)
+	if !ok {
 		return
 	}
 

--- a/internal/adapter/http/handlers_remove_metadata_type.go
+++ b/internal/adapter/http/handlers_remove_metadata_type.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"errors"
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
@@ -26,10 +25,8 @@ func (s *Server) handleRemoveMetadataType(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	key := chi.URLParam(r, "key")
-	if key == "" {
-		writeBadRequest(w, "INVALID_REQUEST", errors.New("metadata key is required"))
-
+	key, ok := requireMetadataKey(w, r)
+	if !ok {
 		return
 	}
 

--- a/internal/adapter/http/handlers_set_metadata_type.go
+++ b/internal/adapter/http/handlers_set_metadata_type.go
@@ -1,7 +1,6 @@
 package http
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -28,10 +27,8 @@ func (s *Server) handleSetMetadataType(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	key := chi.URLParam(r, "key")
-	if key == "" {
-		writeBadRequest(w, "INVALID_REQUEST", errors.New("metadata key is required"))
-
+	key, ok := requireMetadataKey(w, r)
+	if !ok {
 		return
 	}
 

--- a/internal/adapter/http/metadata_key_routing_test.go
+++ b/internal/adapter/http/metadata_key_routing_test.go
@@ -1,0 +1,103 @@
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	internalauth "github.com/formancehq/ledger/v3/internal/adapter/auth"
+	"github.com/formancehq/ledger/v3/internal/pkg/version"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+)
+
+// Exercise NewHandler so URL.Path/RawPath and chi's route segmentation are real.
+// The mock captures boundary identity; service-backed tests cover admission and
+// persisted state, including rejection of percent-containing keys.
+func TestMetadataKeyRouting(t *testing.T) {
+	t.Parallel()
+	routes := []struct {
+		name, method, path string
+		key                func(*servicepb.Request) string
+	}{
+		{"account", http.MethodDelete, "/accounts/users:001/metadata/", func(r *servicepb.Request) string { return r.GetApply().GetAction().GetDeleteMetadata().GetKey() }},
+		{"transaction", http.MethodDelete, "/transactions/0/metadata/", func(r *servicepb.Request) string { return r.GetApply().GetAction().GetDeleteMetadata().GetKey() }},
+		{"ledger", http.MethodDelete, "/metadata/", func(r *servicepb.Request) string { return r.GetDeleteLedgerMetadata().GetKey() }},
+		{"schema_put", http.MethodPut, "/metadata-schema/account/", func(r *servicepb.Request) string { return r.GetSetMetadataFieldType().GetKey() }},
+		{"schema_delete", http.MethodDelete, "/metadata-schema/account/", func(r *servicepb.Request) string { return r.GetRemoveMetadataFieldType().GetKey() }},
+	}
+	keys := []struct {
+		name, encoded, decoded string
+		rawPath                bool
+	}{
+		{"plain", "reviewed", "reviewed", false},
+		{"slash_upper", "formance.com%2Freviewed", "formance.com/reviewed", true},
+		{"slash_lower", "formance.com%2freviewed", "formance.com/reviewed", true},
+		{"escaped_letter", "%72eviewed", "reviewed", true},
+		{"colon", "formance.com%3Areviewed", "formance.com:reviewed", true},
+		{"double_encoded_path", "formance.com%252Freviewed", "formance.com%2Freviewed", false},
+		{"double_encoded_raw_path", "%66ormance.com%252Freviewed", "formance.com%2Freviewed", true},
+		{"percent", "reviewed%25", "reviewed%", false},
+		{"invalid_escape_literal", "reviewed%25ZZ", "reviewed%ZZ", false},
+		{"plus_is_not_space", "reviewed+flag", "reviewed+flag", false},
+	}
+	for _, route := range routes {
+		for _, key := range keys {
+			t.Run(route.name+"/"+key.name, func(t *testing.T) {
+				t.Parallel()
+				var captured *servicepb.Request
+				backend := NewMockBackend(gomock.NewController(t))
+				backend.EXPECT().Apply(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, req *servicepb.ApplyRequest) ([]*commonpb.Log, error) {
+					require.Len(t, req.GetUnsigned().GetRequests(), 1)
+					captured = req.GetUnsigned().GetRequests()[0]
+
+					return []*commonpb.Log{{}}, nil
+				})
+				handler := NewHandler(logging.Testing(), backend, internalauth.AuthConfig{}, version.Info{})
+				req := httptest.NewRequest(route.method, "/v3/ledger1"+route.path+key.encoded, strings.NewReader(`{"type":"string"}`))
+				require.Equal(t, key.rawPath, req.URL.RawPath != "")
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+				require.Equal(t, http.StatusNoContent, rec.Code, rec.Body.String())
+				require.NotNil(t, captured)
+				require.Equal(t, key.decoded, route.key(captured))
+			})
+		}
+	}
+}
+
+func TestCanonicalIDRoutingSingleDecode(t *testing.T) {
+	t.Parallel()
+	for _, scope := range []string{"ledger1", "_"} {
+		for _, key := range []struct{ encoded, decoded string }{
+			{"formance.com%2Freviewed", "formance.com/reviewed"},
+			{"formance.com%252Freviewed", "formance.com%2Freviewed"},
+			{"%66ormance.com%252Freviewed", "formance.com%2Freviewed"},
+		} {
+			t.Run(scope+"/"+key.encoded, func(t *testing.T) {
+				t.Parallel()
+				var captured *servicepb.GetIndexRequest
+				backend := NewMockBackend(gomock.NewController(t))
+				backend.EXPECT().GetIndex(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, req *servicepb.GetIndexRequest) (*commonpb.Index, error) {
+					captured = req
+
+					return &commonpb.Index{Ledger: req.GetLedger()}, nil
+				})
+				handler := NewHandler(logging.Testing(), backend, internalauth.AuthConfig{}, version.Info{})
+				req := httptest.NewRequest(http.MethodGet, "/v3/"+scope+"/indexes/metadata:TARGET_TYPE_ACCOUNT:"+key.encoded, nil)
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+				require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+				require.NotNil(t, captured)
+				require.Equal(t, key.decoded, captured.GetId().GetMetadata().GetKey())
+			})
+		}
+	}
+}

--- a/internal/adapter/http/params.go
+++ b/internal/adapter/http/params.go
@@ -70,34 +70,43 @@ func requireTransactionID(w http.ResponseWriter, r *http.Request) (uint64, bool)
 	return transactionID, true
 }
 
-// requireCanonicalID extracts, path-unescapes, and non-empty-validates the
-// {canonicalId} URL parameter shared by every single-index route (get / status
-// / inspect / drop, both bucket- and ledger-scoped).
-//
-// A canonical index id can contain characters that are reserved in a path
-// segment — most importantly the metadata form `metadata:<target>:<key>` where
-// <key> is a namespaced metadata key such as `formance.com/reviewed`. The
-// slash and colon must be percent-encoded by the client (`%2F`, `%3A`); chi
-// routes on r.URL.RawPath and hands back the still-escaped segment via
-// URLParam, so ParseCanonical would otherwise see the literal `%2F`/`%3A` and
-// reject or mis-parse the id. Unescape here before handing it to the caller so
-// every canonical-id route addresses namespaced keys correctly.
+// requireCanonicalID extracts the decoded, non-empty index ID shared by all
+// single-index routes (get/status/inspect/drop, bucket- and ledger-scoped).
+// Namespaced metadata keys may include a slash encoded as %2F in the segment.
 func requireCanonicalID(w http.ResponseWriter, r *http.Request) (string, bool) {
-	raw := chi.URLParam(r, "canonicalId")
-	if raw == "" {
-		writeBadRequest(w, "INVALID_REQUEST", errors.New("index id is required"))
+	return requirePathParameter(w, r, "canonicalId", "index id")
+}
+
+// requireMetadataKey preserves the identity of metadata keys carried in a URL
+// segment. Business validation, including rejection of percent characters,
+// remains in admission, as for keys supplied through JSON or gRPC.
+func requireMetadataKey(w http.ResponseWriter, r *http.Request) (string, bool) {
+	return requirePathParameter(w, r, "key", "metadata key")
+}
+
+// requirePathParameter decodes a chi path parameter exactly once overall. Chi
+// matches RawPath when present, otherwise Path, which net/url already decoded.
+// Unconditionally unescaping would turn a double-encoded %252F into a slash
+// when RawPath is empty, selecting a different key.
+func requirePathParameter(w http.ResponseWriter, r *http.Request, name, label string) (string, bool) {
+	value := chi.URLParam(r, name)
+	if value == "" {
+		writeBadRequest(w, "INVALID_REQUEST", fmt.Errorf("%s is required", label))
 
 		return "", false
 	}
 
-	canonical, err := url.PathUnescape(raw)
-	if err != nil {
-		writeBadRequest(w, "INVALID_REQUEST", fmt.Errorf("invalid index id encoding: %w", err))
+	if r.URL.RawPath != "" {
+		var err error
+		value, err = url.PathUnescape(value)
+		if err != nil {
+			writeBadRequest(w, "INVALID_REQUEST", fmt.Errorf("invalid %s encoding: %w", label, err))
 
-		return "", false
+			return "", false
+		}
 	}
 
-	return canonical, true
+	return value, true
 }
 
 const (

--- a/openapi.yml
+++ b/openapi.yml
@@ -1464,12 +1464,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/LedgerName'
         - $ref: '#/components/parameters/TargetType'
-        - name: key
-          in: path
-          required: true
-          schema:
-            type: string
-          description: Metadata key name
+        - $ref: '#/components/parameters/MetadataKey'
       requestBody:
         required: true
         content:
@@ -1509,12 +1504,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/LedgerName'
         - $ref: '#/components/parameters/TargetType'
-        - name: key
-          in: path
-          required: true
-          schema:
-            type: string
-          description: Metadata key name
+        - $ref: '#/components/parameters/MetadataKey'
       responses:
         '204':
           description: Metadata field type removed successfully
@@ -2831,7 +2821,11 @@ components:
       required: true
       schema:
         type: string
-      description: Metadata key
+      description: |
+        Metadata key, URL-encoded as one path segment. Encode slashes as %2F
+        (for example, formance.com%2Freviewed). Decoded exactly once; percent
+        characters remaining after decoding, including double-encoded slashes,
+        are invalid metadata keys and are rejected with HTTP 400.
 
     TargetType:
       name: targetType

--- a/tests/e2e/business/encoded_metadata_keys_test.go
+++ b/tests/e2e/business/encoded_metadata_keys_test.go
@@ -1,0 +1,140 @@
+//go:build e2e
+
+package business
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+	"github.com/formancehq/ledger/v3/pkg/actions"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// EN-2015: exercise the real HTTP server and admission, including keys created
+// in JSON before they are addressed as escaped URL segments. Percent-bearing
+// keys are invalid; there is no valid percent-encoded sibling to mutate.
+var _ = Describe("Encoded metadata keys (EN-2015)", func() {
+	const key = "formance.com/reviewed"
+
+	request := func(method, ledgerName, path, body string, wantStatus int) {
+		GinkgoHelper()
+		req, err := http.NewRequestWithContext(sharedCtx, method,
+			fmt.Sprintf("http://localhost:%d/v3/%s%s", sharedHTTPPort, ledgerName, path), bytes.NewBufferString(body))
+		Expect(err).To(Succeed())
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		Expect(err).To(Succeed())
+		raw, err := io.ReadAll(resp.Body)
+		Expect(err).To(Succeed())
+		Expect(resp.Body.Close()).To(Succeed())
+		Expect(resp.StatusCode).To(Equal(wantStatus), "%s %s: %s", method, path, raw)
+	}
+
+	DescribeTable("deletes a JSON-created namespaced metadata key", func(target string) {
+		ledgerName := "encoded-meta-" + target
+		_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledgerName, nil)))
+		Expect(err).To(Succeed())
+		logs, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateTransactionAction(ledgerName,
+			[]*commonpb.Posting{actions.NewPosting("world", "alice", big.NewInt(1), "USD")}, nil, nil)))
+		Expect(err).To(Succeed())
+		txID := logs.GetLogs()[0].GetPayload().GetApply().GetLog().GetData().GetCreatedTransaction().GetTransaction().GetId()
+
+		path := "/metadata"
+		switch target {
+		case "account":
+			path = "/accounts/alice/metadata"
+		case "transaction":
+			path = fmt.Sprintf("/transactions/%d/metadata", txID)
+		}
+		readMetadata := func(g Gomega) map[string]string {
+			switch target {
+			case "account":
+				account, err := sharedClient.GetAccount(sharedCtx, &servicepb.GetAccountRequest{Ledger: ledgerName, Address: "alice"})
+				g.Expect(err).To(Succeed())
+				return commonpb.MetadataToGoMap(account.GetMetadata())
+			case "transaction":
+				tx, err := sharedClient.GetTransaction(sharedCtx, &servicepb.GetTransactionRequest{Ledger: ledgerName, TransactionId: txID})
+				g.Expect(err).To(Succeed())
+				return commonpb.MetadataToGoMap(tx.GetTransaction().GetMetadata())
+			default:
+				ledger, err := actions.GetLedger(sharedCtx, sharedClient, ledgerName)
+				g.Expect(err).To(Succeed())
+				return commonpb.MetadataToGoMap(ledger.GetMetadata())
+			}
+		}
+		request(http.MethodPost, ledgerName, path, `{"formance.com/reviewed":"yes","keep":"untouched"}`, http.StatusNoContent)
+		Eventually(func(g Gomega) {
+			g.Expect(readMetadata(g)).To(HaveKeyWithValue(key, "yes"))
+		}).Should(Succeed())
+
+		// Both a literal percent and a double-encoded slash must remain invalid.
+		// The latter is canonical URL escaping, so net/url leaves RawPath empty.
+		for _, invalid := range []string{"formance.com%25reviewed", "formance.com%25ZZreviewed", "formance.com%252Freviewed"} {
+			request(http.MethodDelete, ledgerName, path+"/"+invalid, "", http.StatusBadRequest)
+			Eventually(func(g Gomega) {
+				g.Expect(readMetadata(g)).To(HaveKeyWithValue(key, "yes"))
+			}).Should(Succeed())
+		}
+
+		request(http.MethodDelete, ledgerName, path+"/formance.com%2Freviewed", "", http.StatusNoContent)
+		Eventually(func(g Gomega) {
+			metadata := readMetadata(g)
+			g.Expect(metadata).NotTo(HaveKey(key))
+			g.Expect(metadata).To(HaveKeyWithValue("keep", "untouched"))
+		}).Should(Succeed())
+	}, Entry("ledger", "ledger"), Entry("account", "account"), Entry("transaction", "transaction"))
+
+	DescribeTable("addresses the decoded schema key on PUT and DELETE", func(target string) {
+		ledgerName := "encoded-schema-" + target
+		_, err := sharedClient.Apply(sharedCtx, servicepb.UnsignedApplyRequest("", actions.CreateLedgerAction(ledgerName, nil)))
+		Expect(err).To(Succeed())
+		readFields := func(g Gomega) map[string]*servicepb.MetadataFieldStatus {
+			schema, err := sharedClient.GetMetadataSchemaStatus(sharedCtx, &servicepb.GetMetadataSchemaStatusRequest{Ledger: ledgerName})
+			g.Expect(err).To(Succeed())
+			switch target {
+			case "account":
+				return schema.GetAccountFields()
+			case "transaction":
+				return schema.GetTransactionFields()
+			default:
+				return schema.GetLedgerFields()
+			}
+		}
+		path := "/metadata-schema/" + target + "/"
+		request(http.MethodPut, ledgerName, path+"keep", `{"type":"string"}`, http.StatusNoContent)
+		request(http.MethodPut, ledgerName, path+"formance.com%2Freviewed", `{"type":"string"}`, http.StatusNoContent)
+		Eventually(func(g Gomega) {
+			g.Expect(readFields(g)).To(HaveKey(key))
+		}).Should(Succeed())
+
+		for _, invalid := range []string{"formance.com%25reviewed", "formance.com%25ZZreviewed", "formance.com%252Freviewed"} {
+			request(http.MethodPut, ledgerName, path+invalid, `{"type":"bool"}`, http.StatusBadRequest)
+			request(http.MethodDelete, ledgerName, path+invalid, "", http.StatusBadRequest)
+			Eventually(func(g Gomega) {
+				fields := readFields(g)
+				g.Expect(fields).To(HaveLen(2))
+				g.Expect(fields).To(HaveKey(key))
+				g.Expect(fields[key].GetDeclaredType()).To(Equal(commonpb.MetadataType_METADATA_TYPE_STRING))
+			}).Should(Succeed())
+		}
+
+		request(http.MethodPut, ledgerName, path+"formance.com%2freviewed", `{"type":"bool"}`, http.StatusNoContent)
+		Eventually(func(g Gomega) {
+			fields := readFields(g)
+			g.Expect(fields).To(HaveKey(key))
+			g.Expect(fields[key].GetDeclaredType()).To(Equal(commonpb.MetadataType_METADATA_TYPE_BOOL))
+		}).Should(Succeed())
+		request(http.MethodDelete, ledgerName, path+"formance.com%2Freviewed", "", http.StatusNoContent)
+		Eventually(func(g Gomega) {
+			fields := readFields(g)
+			g.Expect(fields).NotTo(HaveKey(key))
+			g.Expect(fields).To(HaveKey("keep"))
+		}).Should(Succeed())
+	}, Entry("ledger", "ledger"), Entry("account", "account"), Entry("transaction", "transaction"))
+})


### PR DESCRIPTION
## What changed

Metadata DELETE routes for accounts, transactions and ledgers, plus metadata-schema PUT/DELETE, decode their key path segment once. A JSON key `formance.com/reviewed` can be addressed with `formance.com%2Freviewed`. Canonical index IDs use the same extraction rule, avoiding a second decode when Chi routes on the already-decoded URL.Path.

## Why

[EN-2015](https://formance-team.atlassian.net/browse/EN-2015), part of [Ledger v3.0 (EN-867)](https://formance-team.atlassian.net/browse/EN-867). Chi exposes escaped captures when RawPath is present. Previously valid slash-containing metadata keys were rejected by admission when addressed via an encoded route. Percent-containing keys are invalid; this fix does not claim a valid percent-encoded sibling could be mutated.

## Product / operational motivation

N/A — targeted correction of the existing valid metadata-key contract.

## Technical decision

Unescape captured segments only when RawPath is present; otherwise net/url has already decoded Path. Keep metadata validation in admission. Unconditional unescaping would turn double-encoded input into a different valid key.

## Risk

**LOW** — confined to HTTP path extraction and canonical IDs sharing that extraction.

## Validation

- [x] `bash scripts/agent-check`
- [x] Entire HTTP package with `-race` (including 50 metadata-route cases and 6 canonical-ID cases).
- [x] Focused service-backed E2E with `-race -count=1`: six specs pass, proving actual deletion/schema changes and invalid-key rejection.
- [x] Fail-before: the same six service specs return HTTP 400 `VALIDATION` on base `404ac87a4291701bdca5ba9fed4997fb71412933`; the router regression also fails on escaped-key identity and canonical-ID double decoding. This is executable evidence in addition to the earlier static audit qualification.
- [x] `AI_REVIEW_BASE_SHA=404ac87a4291701bdca5ba9fed4997fb71412933 bash scripts/agent-check-pr`: normalization/lint, baseline, HTTP race suite, full light business E2E (154s) and cluster E2E (323s) passed. Its final Schemathesis stage stopped at fixture creation (409 on default ports); rerunning that unchanged stage with three isolated local ports passed all checks across 62 endpoints. No test filtering, shared-cache purge or global serialization was added.


## Architecture / behavior impact

HTTP encoded-key operations preserve the supplied key identity. OpenAPI and API documentation describe encoding and invalid percent controls. No gRPC service wire or semantic contract changes, so no protocol revision increment is needed. No persisted format, FSM, Raft or authentication changes.

## Review focus

RawPath versus Path, exactly one decode across the HTTP parser and handler, and retaining admission rejection for double encoding. Tests use the registered router and a real service.

## Known concerns

None.


[EN-2015]: https://formance-team.atlassian.net/browse/EN-2015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ