### PR TITLE
fix(http): preserve exact metadata integers (EN-2014)

### DIFF
--- a/docs/technical/architecture/subsystems/api/README.md
+++ b/docs/technical/architecture/subsystems/api/README.md
@@ -9,7 +9,7 @@ Client-facing transport layers (`internal/adapter/grpc`, `internal/adapter/http`
 | [grpc-api.md](grpc-api.md) | gRPC service, methods, request/response types, type-owned public error details, client examples, and restore-mode service lifetime. |
 | [grpc-connections.md](grpc-connections.md) | gRPC connection mechanics, reconnection, and rolling deployment optimizations. |
 | [protocol-compatibility.md](protocol-compatibility.md) | Mandatory service protocol revision, client/server rejection behavior, diagnostics, and revision maintenance (EN-1851). |
-| [http-api.md](http-api.md) | HTTP REST API endpoints, single-decoding metadata key paths, response formats, ledger-log JSON output and discriminators, error handling, and the `apierr`/`grpcerr` error boundary crossed by a forwarded write. |
+| [http-api.md](http-api.md) | HTTP REST API endpoints, single-decoding metadata key paths, response formats, exact metadata number decoding, ledger-log JSON output and discriminators, error handling, and the `apierr`/`grpcerr` error boundary crossed by a forwarded write. |
 | [auth.md](auth.md) | Client JWT authentication (OIDC + Ed25519), scope-based authorization, and the Raft inter-node cluster-secret auth layer. |
 
 Decoded leader errors retain their exact gRPC status through routing wrappers

--- a/docs/technical/architecture/subsystems/api/http-api.md
+++ b/docs/technical/architecture/subsystems/api/http-api.md
@@ -397,6 +397,29 @@ Clients should:
 - **Idempotency**: Ensure write operations are idempotent to safely retry after leader election
 - **Monitoring**: Track `503` responses to monitor cluster health and leader election frequency
 
+## Metadata number decoding
+
+HTTP metadata numbers retain their exact decimal value before conversion to
+protobuf metadata. This applies to account, transaction and ledger metadata
+updates, transaction creation (including `accountMetadata`), and unitary and
+bulk reversals. For example, `9007199254740993` and `-9007199254740993` reach
+`Apply` unchanged, including beyond the exact-integer range of IEEE-754 doubles.
+
+Nonnegative values use unsigned 64-bit metadata; negative values use signed
+64-bit metadata. All signed 64-bit integers are supported. Integral decimal and
+exponent spellings (`1.0`, `1e3`, `10e-1`) are accepted, while fractions and
+out-of-range values return `400 INVALID_REQUEST` before `Apply`. Fractions are
+checked exactly, including values that a floating-point decoder would round to
+an integer or underflow to zero. Numeric strings remain strings; null and other
+metadata types retain their existing handling.
+
+The JSON adapter exposes explicit number-preserving decode helpers for these
+metadata consumers. Its ordinary decoders retain their existing behavior.
+Custom metadata JSON decoders opt in themselves, since an outer decoder's
+configuration does not propagate into a custom `UnmarshalJSON` method. This
+changes input conversion only; protobuf contracts, stored representations,
+FSM behavior and audit replay formats are unchanged.
+
 ## Main Endpoints
 
 ### Ledgers

--- a/docs/technical/architecture/subsystems/api/http-api.md
+++ b/docs/technical/architecture/subsystems/api/http-api.md
@@ -406,9 +406,11 @@ bulk reversals. For example, `9007199254740993` and `-9007199254740993` reach
 `Apply` unchanged, including beyond the exact-integer range of IEEE-754 doubles.
 
 Nonnegative values use unsigned 64-bit metadata; negative values use signed
-64-bit metadata. All signed 64-bit integers are supported. Integral decimal and
-exponent spellings (`1.0`, `1e3`, `10e-1`) are accepted, while fractions and
-out-of-range values return `400 INVALID_REQUEST` before `Apply`. Fractions are
+64-bit metadata. The accepted range is `-9223372036854775808` through
+`18446744073709551615`. OpenAPI declares an integer with these explicit bounds
+and no `int64` format, which would exclude the upper unsigned range. Integral
+decimal and exponent spellings (`1.0`, `1e3`, `10e-1`) are accepted, while
+fractions and out-of-range values return `400 INVALID_REQUEST` before `Apply`. Fractions are
 checked exactly, including values that a floating-point decoder would round to
 an integer or underflow to zero. Numeric strings remain strings; null and other
 metadata types retain their existing handling.

--- a/docs/technical/architecture/subsystems/api/http-api.md
+++ b/docs/technical/architecture/subsystems/api/http-api.md
@@ -416,7 +416,9 @@ an integer or underflow to zero. Numeric strings remain strings; null and other
 metadata types retain their existing handling.
 
 The JSON adapter exposes explicit number-preserving decode helpers for these
-metadata consumers. Its ordinary decoders retain their existing behavior.
+metadata consumers. Unitary reversals validate the complete body with the standard
+JSON decoder and enable `UseNumber`, preserving strict document validation for
+both known-length and chunked bodies. Ordinary shared decoders retain their existing behavior.
 Custom metadata JSON decoders opt in themselves, since an outer decoder's
 configuration does not propagate into a custom `UnmarshalJSON` method. This
 changes input conversion only; protobuf contracts, stored representations,

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -11,7 +11,9 @@ This document compares the POC's API with the original Formance ledger API and d
 HTTP typed metadata preserves exact integer values, including signed 64-bit
 bounds and values above 2^53, for metadata writes, transaction creation and
 reversal (unitary and bulk). Integral decimal/exponent spellings are accepted;
-fractions and out-of-range values are rejected before submission. See
+fractions and out-of-range values are rejected before submission. The OpenAPI
+integer schema spans `-9223372036854775808` through `18446744073709551615`,
+matching signed negative and unsigned nonnegative metadata values. See
 [Metadata number decoding](../architecture/subsystems/api/http-api.md#metadata-number-decoding).
 
 ## Summary

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -8,6 +8,12 @@ This document compares the POC's API with the original Formance ledger API and d
 > intentionally unversioned. The original ledger's `/v2` is **not** preserved
 > by this POC — there is no compatibility shim.
 
+HTTP typed metadata preserves exact integer values, including signed 64-bit
+bounds and values above 2^53, for metadata writes, transaction creation and
+reversal (unitary and bulk). Integral decimal/exponent spellings are accepted;
+fractions and out-of-range values are rejected before submission. See
+[Metadata number decoding](../architecture/subsystems/api/http-api.md#metadata-number-decoding).
+
 ## Summary
 
 ### Service protocol compatibility (EN-1851)

--- a/internal/adapter/http/handlers_revert_transaction.go
+++ b/internal/adapter/http/handlers_revert_transaction.go
@@ -3,6 +3,7 @@ package http
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -31,7 +32,7 @@ func (s *Server) handleRevertTransaction(w http.ResponseWriter, r *http.Request)
 		body, err := io.ReadAll(r.Body)
 		if err == nil && len(body) != 0 {
 			if !json.Valid(body) {
-				err = fmt.Errorf("expected a single valid JSON value")
+				err = errors.New("expected a single valid JSON value")
 			} else {
 				decoder := json.NewDecoder(bytes.NewReader(body))
 				decoder.UseNumber()

--- a/internal/adapter/http/handlers_revert_transaction.go
+++ b/internal/adapter/http/handlers_revert_transaction.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -29,7 +30,13 @@ func (s *Server) handleRevertTransaction(w http.ResponseWriter, r *http.Request)
 	if r.Body != nil {
 		body, err := io.ReadAll(r.Body)
 		if err == nil && len(body) != 0 {
-			err = json.Unmarshal(body, &reqBody)
+			if !json.Valid(body) {
+				err = fmt.Errorf("expected a single valid JSON value")
+			} else {
+				decoder := json.NewDecoder(bytes.NewReader(body))
+				decoder.UseNumber()
+				err = decoder.Decode(&reqBody)
+			}
 		}
 		if err != nil {
 			writeBadRequest(w, "INVALID_REQUEST", fmt.Errorf("invalid request body: %w", err))

--- a/internal/adapter/http/metadata_integers_test.go
+++ b/internal/adapter/http/metadata_integers_test.go
@@ -1,0 +1,108 @@
+package http
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	internalauth "github.com/formancehq/ledger/v3/internal/adapter/auth"
+	"github.com/formancehq/ledger/v3/internal/pkg/version"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
+)
+
+// Exercise the registered routes with known-length bodies and compare native
+// integers at Apply, before any response JSON decoding can mask precision loss.
+func TestMetadataIntegers_Routes(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		token string
+		want  any
+	}{
+		{"0", uint64(0)}, {"42", uint64(42)}, {"-7", int64(-7)},
+		{"9007199254740991", uint64(9007199254740991)},
+		{"9007199254740992", uint64(9007199254740992)},
+		{"9007199254740993", uint64(9007199254740993)},
+		{"-9007199254740991", int64(-9007199254740991)},
+		{"-9007199254740992", int64(-9007199254740992)},
+		{"-9007199254740993", int64(-9007199254740993)},
+		{"9223372036854775807", uint64(9223372036854775807)},
+		{"-9223372036854775808", int64(-9223372036854775808)},
+		{"18446744073709551615", uint64(18446744073709551615)},
+		{"1.0", uint64(1)}, {"1e3", uint64(1000)}, {"1e-400", nil}, {"1.5", nil}, {"9007199254740993.5", nil},
+		{"-9223372036854775809", nil}, {"18446744073709551616", nil},
+	}
+	for _, route := range []string{"account", "create", "createAccount", "revert"} {
+		for _, tc := range cases {
+			t.Run(route+"/"+tc.token, func(t *testing.T) {
+				t.Parallel()
+				backend := NewMockBackend(gomock.NewController(t))
+				if tc.want != nil {
+					backend.EXPECT().Apply(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, req *servicepb.ApplyRequest) ([]*commonpb.Log, error) {
+						requests := req.GetUnsigned().GetRequests()
+						require.Len(t, requests, 1)
+						require.Equal(t, "ledger1", requests[0].GetApply().GetLedger())
+						action := requests[0].GetApply().GetAction()
+						var md map[string]*commonpb.MetadataValue
+						logData := &commonpb.LedgerLogPayload{}
+						switch route {
+						case "account":
+							cmd := action.GetAddMetadata()
+							require.Equal(t, "users:001", cmd.GetTarget().GetAccount().GetAddr())
+							md = cmd.GetMetadata()
+						case "create", "createAccount":
+							cmd := action.GetCreateTransaction()
+							md = cmd.GetMetadata()
+							if route == "createAccount" {
+								md = cmd.GetAccountMetadata()["users:001"].GetValues()
+							}
+							require.Equal(t, tc.want, commonpb.MetadataValueToAny(cmd.GetAccountMetadata()["users:001"].GetValues()["count"]))
+							logData.Payload = &commonpb.LedgerLogPayload_CreatedTransaction{CreatedTransaction: &commonpb.CreatedTransaction{Transaction: &commonpb.Transaction{Id: 1}}}
+						case "revert":
+							md = action.GetRevertTransaction().GetMetadata()
+							logData.Payload = &commonpb.LedgerLogPayload_RevertedTransaction{RevertedTransaction: &commonpb.RevertedTransaction{RevertTransaction: &commonpb.Transaction{Id: 2}}}
+						}
+						require.Equal(t, tc.want, commonpb.MetadataValueToAny(md["count"]))
+
+						return []*commonpb.Log{{Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_Apply{Apply: &commonpb.ApplyLedgerLog{Log: &commonpb.LedgerLog{Data: logData}}}}}}, nil
+					})
+				}
+				path := "/v3/ledger1/accounts/users:001/metadata"
+				body := fmt.Sprintf(`{"count":%s}`, tc.token)
+				status := http.StatusNoContent
+				switch route {
+				case "create", "createAccount":
+					path = "/v3/ledger1/transactions"
+					body = fmt.Sprintf(`{"postings":[{"source":"world","destination":"users:001","asset":"USD","amount":1}],"metadata":{"count":%s},"accountMetadata":{"users:001":{"count":%s}}}`, tc.token, tc.token)
+					if route == "createAccount" {
+						body = fmt.Sprintf(`{"postings":[{"source":"world","destination":"users:001","asset":"USD","amount":1}],"accountMetadata":{"users:001":{"count":%s}}}`, tc.token)
+					}
+					status = http.StatusCreated
+				case "revert":
+					path = "/v3/ledger1/transactions/1/revert"
+					body = fmt.Sprintf(`{"metadata":{"count":%s}}`, tc.token)
+					status = http.StatusCreated
+				}
+				if tc.want == nil {
+					status = http.StatusBadRequest
+				}
+				r := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+				require.Positive(t, r.ContentLength)
+				w := httptest.NewRecorder()
+				NewHandler(logging.Testing(), backend, internalauth.AuthConfig{}, version.Info{}).ServeHTTP(w, r)
+				require.Equal(t, status, w.Code, w.Body.String())
+				if tc.want == nil {
+					require.Equal(t, "INVALID_REQUEST", decodeResponse[ErrorResponse](t, w).ErrorCode)
+				}
+			})
+		}
+	}
+}

--- a/internal/adapter/http/metadata_integers_test.go
+++ b/internal/adapter/http/metadata_integers_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
 )
 
-// Exercise the registered routes with known-length bodies and compare native
+// Exercise registered routes, including unknown-length revert bodies, and compare native
 // integers at Apply, before any response JSON decoding can mask precision loss.
 func TestMetadataIntegers_Routes(t *testing.T) {
 	t.Parallel()
@@ -40,7 +40,7 @@ func TestMetadataIntegers_Routes(t *testing.T) {
 		{"1.0", uint64(1)}, {"1e3", uint64(1000)}, {"1e-400", nil}, {"1.5", nil}, {"9007199254740993.5", nil},
 		{"-9223372036854775809", nil}, {"18446744073709551616", nil},
 	}
-	for _, route := range []string{"account", "create", "createAccount", "revert"} {
+	for _, route := range []string{"account", "create", "createAccount", "revert", "revertUnknownLength"} {
 		for _, tc := range cases {
 			t.Run(route+"/"+tc.token, func(t *testing.T) {
 				t.Parallel()
@@ -66,7 +66,7 @@ func TestMetadataIntegers_Routes(t *testing.T) {
 							}
 							require.Equal(t, tc.want, commonpb.MetadataValueToAny(cmd.GetAccountMetadata()["users:001"].GetValues()["count"]))
 							logData.Payload = &commonpb.LedgerLogPayload_CreatedTransaction{CreatedTransaction: &commonpb.CreatedTransaction{Transaction: &commonpb.Transaction{Id: 1}}}
-						case "revert":
+						case "revert", "revertUnknownLength":
 							md = action.GetRevertTransaction().GetMetadata()
 							logData.Payload = &commonpb.LedgerLogPayload_RevertedTransaction{RevertedTransaction: &commonpb.RevertedTransaction{RevertTransaction: &commonpb.Transaction{Id: 2}}}
 						}
@@ -86,7 +86,7 @@ func TestMetadataIntegers_Routes(t *testing.T) {
 						body = fmt.Sprintf(`{"postings":[{"source":"world","destination":"users:001","asset":"USD","amount":1}],"accountMetadata":{"users:001":{"count":%s}}}`, tc.token)
 					}
 					status = http.StatusCreated
-				case "revert":
+				case "revert", "revertUnknownLength":
 					path = "/v3/ledger1/transactions/1/revert"
 					body = fmt.Sprintf(`{"metadata":{"count":%s}}`, tc.token)
 					status = http.StatusCreated
@@ -96,6 +96,9 @@ func TestMetadataIntegers_Routes(t *testing.T) {
 				}
 				r := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
 				require.Positive(t, r.ContentLength)
+				if route == "revertUnknownLength" {
+					r.ContentLength = -1
+				}
 				w := httptest.NewRecorder()
 				NewHandler(logging.Testing(), backend, internalauth.AuthConfig{}, version.Info{}).ServeHTTP(w, r)
 				require.Equal(t, status, w.Code, w.Body.String())

--- a/internal/adapter/http/params.go
+++ b/internal/adapter/http/params.go
@@ -145,7 +145,7 @@ func parsePageSize(w http.ResponseWriter, r *http.Request) (uint32, bool) {
 // Returns the parsed metadata map and true on success; writes a 400 response and returns false on failure.
 func parseMetadataBody(w http.ResponseWriter, r *http.Request) (map[string]*commonpb.MetadataValue, bool) {
 	var inputMetadata map[string]any
-	if err := json.UnmarshalRead(r.Body, &inputMetadata); err != nil {
+	if err := json.UnmarshalReadUseNumber(r.Body, &inputMetadata); err != nil {
 		writeBadRequest(w, "INVALID_REQUEST", fmt.Errorf("invalid request body: %w", err))
 
 		return nil, false

--- a/internal/adapter/json/numbers.go
+++ b/internal/adapter/json/numbers.go
@@ -1,0 +1,25 @@
+package json
+
+import (
+	"io"
+
+	"github.com/bytedance/sonic"
+)
+
+var numberDecoder = sonic.Config{UseNumber: true}.Froze()
+
+// UnmarshalUseNumber preserves numeric tokens as encoding/json.Number in
+// interface values. Use it only where the consumer explicitly handles Number;
+// the shared Unmarshal default remains unchanged.
+func UnmarshalUseNumber(data []byte, v any) error {
+	return numberDecoder.Unmarshal(data, v)
+}
+
+// UnmarshalReadUseNumber is UnmarshalRead with exact numeric tokens in interface
+// values. Typed fields and custom UnmarshalJSON methods retain their own rules.
+func UnmarshalReadUseNumber(r io.Reader, v any) error {
+	decoder := sonic.ConfigStd.NewDecoder(r)
+	decoder.UseNumber()
+
+	return decoder.Decode(v)
+}

--- a/internal/adapter/json/numbers_test.go
+++ b/internal/adapter/json/numbers_test.go
@@ -1,0 +1,34 @@
+package json
+
+import (
+	stdjson "encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshalUseNumber(t *testing.T) {
+	t.Parallel()
+	for _, streaming := range []bool{false, true} {
+		t.Run(map[bool]string{false: "bytes", true: "reader"}[streaming], func(t *testing.T) {
+			t.Parallel()
+			body := `{"value":9007199254740993,"typed":9223372036854775807}`
+			var exact, ordinary struct {
+				Value any
+				Typed int64
+			}
+			if streaming {
+				require.NoError(t, UnmarshalReadUseNumber(strings.NewReader(body), &exact))
+				require.NoError(t, UnmarshalRead(strings.NewReader(body), &ordinary))
+			} else {
+				require.NoError(t, UnmarshalUseNumber([]byte(body), &exact))
+				require.NoError(t, Unmarshal([]byte(body), &ordinary))
+			}
+			require.Equal(t, stdjson.Number("9007199254740993"), exact.Value)
+			require.IsType(t, float64(0), ordinary.Value)
+			require.Equal(t, int64(9223372036854775807), exact.Typed)
+			require.Equal(t, exact.Typed, ordinary.Typed)
+		})
+	}
+}

--- a/internal/proto/commonpb/common.pb.json.go
+++ b/internal/proto/commonpb/common.pb.json.go
@@ -404,7 +404,7 @@ func (sm *SavedMetadata) UnmarshalJSON(data []byte) error {
 
 	x := X{}
 
-	err := json.Unmarshal(data, &x)
+	err := json.UnmarshalUseNumber(data, &x)
 	if err != nil {
 		return err
 	}

--- a/internal/proto/commonpb/metadata.go
+++ b/internal/proto/commonpb/metadata.go
@@ -1,8 +1,11 @@
 package commonpb
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/formancehq/go-libs/v5/pkg/types/metadata"
@@ -122,6 +125,7 @@ func MetadataMapToAnyMap(mm *MetadataMap) map[string]any {
 //   - bool → bool_value
 //   - positive integer (fits uint64) → uint_value
 //   - negative integer (fits int64) → int_value
+//   - json.Number → exact integer inference, including integral decimal/exponent forms
 //   - string → string_value
 //   - float with decimal → error (floats not supported)
 //   - nil → signals deletion (returned as nil)
@@ -134,8 +138,11 @@ func MetadataValueFromAny(v any) (*MetadataValue, error) {
 		return NewBoolValue(val), nil
 	case string:
 		return NewStringValue(val), nil
+	case json.Number:
+		return metadataValueFromJSONNumber(val)
 	case float64:
-		// JSON numbers are decoded as float64 by default
+		// Retain support for Go callers with float values. JSON metadata callers
+		// must preserve the token as json.Number before reaching this conversion.
 		if val != math.Trunc(val) {
 			return nil, fmt.Errorf("float values are not supported for metadata, got %v", val)
 		}
@@ -170,6 +177,87 @@ func MetadataValueFromAny(v any) (*MetadataValue, error) {
 	default:
 		return nil, fmt.Errorf("unsupported metadata value type %T (objects and arrays are not supported)", v)
 	}
+}
+
+// metadataValueFromJSONNumber normalizes decimal/exponent notation before
+// parsing the integer. Work and allocation are bounded by the input length,
+// never by an untrusted exponent; the final integer has at most 20 digits.
+func metadataValueFromJSONNumber(number json.Number) (*MetadataValue, error) {
+	s := number.String()
+	if s == "" || (s[0] != '-' && (s[0] < '0' || s[0] > '9')) ||
+		strings.TrimSpace(s) != s || !json.Valid([]byte(s)) {
+		return nil, fmt.Errorf("invalid metadata number %q", s)
+	}
+
+	negative := s[0] == '-'
+	mantissa := strings.TrimPrefix(s, "-")
+	exponentText := "0"
+	if index := strings.IndexAny(mantissa, "eE"); index >= 0 {
+		exponentText = mantissa[index+1:]
+		mantissa = mantissa[:index]
+	}
+
+	fractionDigits := 0
+	if index := strings.IndexByte(mantissa, '.'); index >= 0 {
+		fractionDigits = len(mantissa) - index - 1
+		mantissa = mantissa[:index] + mantissa[index+1:]
+	}
+	digits := strings.TrimLeft(mantissa, "0")
+	if digits == "" {
+		return NewUintValue(0), nil
+	}
+
+	fractionError := func() (*MetadataValue, error) {
+		return nil, fmt.Errorf("float values are not supported for metadata, got %s", s)
+	}
+	overflowError := func() (*MetadataValue, error) {
+		if negative {
+			return nil, fmt.Errorf("integer value %s overflows int64", s)
+		}
+
+		return nil, fmt.Errorf("integer value %s overflows uint64", s)
+	}
+
+	exponent, err := strconv.ParseInt(exponentText, 10, 64)
+	// An exponent beyond the input length cannot be canceled by the decimal
+	// point or trailing zeros. Reject it before computing the decimal shift.
+	limit := int64(len(s)) + 20
+	if err != nil || exponent > limit || exponent < -limit {
+		if strings.HasPrefix(exponentText, "-") {
+			return fractionError()
+		}
+
+		return overflowError()
+	}
+
+	shift := exponent - int64(fractionDigits)
+	if shift < 0 {
+		remove := -shift
+		trailingZeros := len(digits) - len(strings.TrimRight(digits, "0"))
+		if remove > int64(trailingZeros) {
+			return fractionError()
+		}
+		digits = digits[:len(digits)-int(remove)]
+	} else {
+		if int64(len(digits))+shift > 20 {
+			return overflowError()
+		}
+		digits += strings.Repeat("0", int(shift))
+	}
+
+	value, err := strconv.ParseUint(digits, 10, 64)
+	if err != nil || (negative && value > uint64(1)<<63) {
+		return overflowError()
+	}
+	if negative {
+		if value == uint64(1)<<63 {
+			return NewIntValue(math.MinInt64), nil
+		}
+
+		return NewIntValue(-int64(value)), nil
+	}
+
+	return NewUintValue(value), nil
 }
 
 // MetadataFromAnyMap converts a map[string]any to map[string]*MetadataValue with JSON type inference.
@@ -226,7 +314,7 @@ func (mm *MetadataMap) MarshalJSON() ([]byte, error) {
 // Uses JSON type inference (see MetadataValueFromAny).
 func (mm *MetadataMap) UnmarshalJSON(data []byte) error {
 	var m map[string]any
-	if err := jsonPkg.Unmarshal(data, &m); err != nil {
+	if err := jsonPkg.UnmarshalUseNumber(data, &m); err != nil {
 		return err
 	}
 

--- a/internal/proto/commonpb/metadata_number_test.go
+++ b/internal/proto/commonpb/metadata_number_test.go
@@ -1,0 +1,155 @@
+package commonpb
+
+import (
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetadataValueFromJSONNumber(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		input string
+		want  *MetadataValue
+	}{
+		{"0", NewUintValue(0)},
+		{"-0", NewUintValue(0)},
+		{"42", NewUintValue(42)},
+		{"-42", NewIntValue(-42)},
+		{"9007199254740991", NewUintValue(9007199254740991)},
+		{"9007199254740992", NewUintValue(9007199254740992)},
+		{"9007199254740993", NewUintValue(9007199254740993)},
+		{"-9007199254740991", NewIntValue(-9007199254740991)},
+		{"-9007199254740992", NewIntValue(-9007199254740992)},
+		{"-9007199254740993", NewIntValue(-9007199254740993)},
+		{"9223372036854775807", NewUintValue(math.MaxInt64)},
+		{"9223372036854775808", NewUintValue(uint64(1) << 63)},
+		{"-9223372036854775808", NewIntValue(math.MinInt64)},
+		{"18446744073709551615", NewUintValue(math.MaxUint64)},
+		{"1.0", NewUintValue(1)},
+		{"1e3", NewUintValue(1000)},
+		{"10e-1", NewUintValue(1)},
+		{"0.0100e+4", NewUintValue(100)},
+		{"-1.2E+1", NewIntValue(-12)},
+		{"9007199254740993.000", NewUintValue(9007199254740993)},
+		{"9.007199254740993e15", NewUintValue(9007199254740993)},
+		{"-9.223372036854775808e18", NewIntValue(math.MinInt64)},
+		{"184467440737095516150e-1", NewUintValue(math.MaxUint64)},
+		{"0e999999999999999999999999", NewUintValue(0)},
+		{"-0.000e-999999999999999999999999", NewUintValue(0)},
+		{"1" + strings.Repeat("0", 1000) + "e-1000", NewUintValue(1)},
+	} {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := MetadataValueFromAny(json.Number(tc.input))
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestMetadataValueFromJSONNumberRejectsUnsupportedValues(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		input string
+		error string
+	}{
+		{"1.5", "float values are not supported"},
+		{"-1.5", "float values are not supported"},
+		{"9007199254740993.1", "float values are not supported"},
+		{"-9007199254740993.1", "float values are not supported"},
+		{"1.000000000000000000000000001", "float values are not supported"},
+		{"1e-999999999999999999999999", "float values are not supported"},
+		{"-1e-999999999999999999999999", "float values are not supported"},
+		{"1e-999999", "float values are not supported"},
+		{"1e-100", "float values are not supported"},
+		{"100e-3", "float values are not supported"},
+		{"18446744073709551616", "overflows uint64"},
+		{"184467440737095516160e-1", "overflows uint64"},
+		{"-9223372036854775809", "overflows int64"},
+		{"-9223372036854775809.0", "overflows int64"},
+		{"1e999999999999999999999999", "overflows uint64"},
+		{"-1e999999999999999999999999", "overflows int64"},
+		{"1e999999", "overflows uint64"},
+		{"1e100", "overflows uint64"},
+		{"", "invalid metadata number"},
+		{"null", "invalid metadata number"},
+		{"[]", "invalid metadata number"},
+		{"1 ", "invalid metadata number"},
+		{"01", "invalid metadata number"},
+		{"1e", "invalid metadata number"},
+		{"1.2.3", "invalid metadata number"},
+	} {
+		t.Run(tc.input, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := MetadataValueFromAny(json.Number(tc.input))
+			require.ErrorContains(t, err, tc.error)
+			require.Nil(t, got)
+		})
+	}
+}
+
+func TestMetadataJSONDecodersPreserveNumbers(t *testing.T) {
+	t.Parallel()
+
+	for _, decoder := range []struct {
+		name   string
+		decode func(string) (map[string]*MetadataValue, error)
+	}{
+		{"metadata map", func(number string) (map[string]*MetadataValue, error) {
+			var value MetadataMap
+			err := json.Unmarshal([]byte(`{"value":`+number+`}`), &value)
+
+			return value.GetValues(), err
+		}},
+		{"saved metadata", func(number string) (map[string]*MetadataValue, error) {
+			var value SavedMetadata
+			err := json.Unmarshal([]byte(`{"targetType":"ACCOUNT","targetId":"users:001","metadata":{"value":`+number+`}}`), &value)
+
+			return value.GetMetadata(), err
+		}},
+	} {
+		t.Run(decoder.name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, tc := range []struct {
+				number string
+				want   *MetadataValue
+				error  string
+			}{
+				{"42", NewUintValue(42), ""},
+				{"9007199254740993", NewUintValue(9007199254740993), ""},
+				{"-9007199254740993", NewIntValue(-9007199254740993), ""},
+				{"9223372036854775807", NewUintValue(math.MaxInt64), ""},
+				{"-9223372036854775808", NewIntValue(math.MinInt64), ""},
+				{"18446744073709551615", NewUintValue(math.MaxUint64), ""},
+				{"9.007199254740993e15", NewUintValue(9007199254740993), ""},
+				{"1.5", nil, "float values are not supported"},
+				{"9007199254740993.1", nil, "float values are not supported"},
+				{"1e-1000", nil, "float values are not supported"},
+				{"-9223372036854775809", nil, "overflows int64"},
+				{"18446744073709551616", nil, "overflows uint64"},
+			} {
+				t.Run(tc.number, func(t *testing.T) {
+					t.Parallel()
+
+					got, err := decoder.decode(tc.number)
+					if tc.error != "" {
+						require.ErrorContains(t, err, tc.error)
+
+						return
+					}
+					require.NoError(t, err)
+					require.Equal(t, tc.want, got["value"])
+				})
+			}
+		})
+	}
+}

--- a/internal/proto/servicepb/metadata_integers_test.go
+++ b/internal/proto/servicepb/metadata_integers_test.go
@@ -1,0 +1,64 @@
+package servicepb
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/adapter/json"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+)
+
+func TestMetadataIntegers_BulkDecoders(t *testing.T) {
+	t.Parallel()
+	for _, action := range []string{"CREATE_TRANSACTION", "ADD_METADATA", "REVERT_TRANSACTION"} {
+		for _, tc := range []struct {
+			token string
+			want  any
+		}{
+			{"9007199254740993", uint64(9007199254740993)},
+			{"-9007199254740993", int64(-9007199254740993)},
+			{"9223372036854775807", uint64(9223372036854775807)},
+			{"-9223372036854775808", int64(-9223372036854775808)},
+			{"1.5", nil}, {"9007199254740993.1", nil},
+		} {
+			t.Run(action+"/"+tc.token, func(t *testing.T) {
+				t.Parallel()
+				data := fmt.Sprintf(`{"id":1,"targetType":"ACCOUNT","targetId":"users:001","metadata":{"count":%s}}`, tc.token)
+				for _, decode := range []func() (*LedgerAction, error){
+					func() (*LedgerAction, error) {
+						var element BulkElement
+						err := json.Unmarshal([]byte(fmt.Sprintf(`{"action":%q,"data":%s}`, action, data)), &element)
+
+						return element.Action, err
+					},
+					func() (*LedgerAction, error) {
+						var element LedgerAction
+						err := json.Unmarshal([]byte(fmt.Sprintf(`{"action":%q,"data":%s}`, action, data)), &element)
+
+						return &element, err
+					},
+				} {
+					got, err := decode()
+					if tc.want == nil {
+						require.Error(t, err)
+
+						continue
+					}
+					require.NoError(t, err)
+					var md map[string]*commonpb.MetadataValue
+					switch action {
+					case "CREATE_TRANSACTION":
+						md = got.GetCreateTransaction().GetMetadata()
+					case "ADD_METADATA":
+						md = got.GetAddMetadata().GetMetadata()
+					case "REVERT_TRANSACTION":
+						md = got.GetRevertTransaction().GetMetadata()
+					}
+					require.Equal(t, tc.want, commonpb.MetadataValueToAny(md["count"]))
+				}
+			})
+		}
+	}
+}

--- a/internal/proto/servicepb/service.pb.json.go
+++ b/internal/proto/servicepb/service.pb.json.go
@@ -67,7 +67,7 @@ func (x *CreateTransactionPayload) UnmarshalJSON(data []byte) error {
 		Force           bool                      `json:"force"`
 	}
 
-	if err := json.Unmarshal(data, &aux); err != nil {
+	if err := json.UnmarshalUseNumber(data, &aux); err != nil {
 		return err
 	}
 
@@ -310,7 +310,7 @@ func unmarshalSaveMetadataCommand(data json.RawValue) (*commonpb.SaveMetadataCom
 	}
 
 	var raw rawReq
-	if err := json.Unmarshal(data, &raw); err != nil {
+	if err := json.UnmarshalUseNumber(data, &raw); err != nil {
 		return nil, err
 	}
 
@@ -340,7 +340,7 @@ func unmarshalRevertTransactionPayload(data json.RawValue) (*RevertTransactionPa
 	}
 
 	var raw rawReq
-	if err := json.Unmarshal(data, &raw); err != nil {
+	if err := json.UnmarshalUseNumber(data, &raw); err != nil {
 		return nil, err
 	}
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -3163,7 +3163,12 @@ components:
           description: The account address that caused the violation
 
     MetadataValue:
-      description: A typed metadata value (string, integer, boolean, or null). String values must not contain NUL bytes.
+      description: >-
+        A typed metadata value (string, integer, boolean, or null). Integer
+        numbers are decoded exactly, including int64 bounds and values beyond
+        2^53. Integral decimal and exponent spellings are accepted; fractions
+        and out-of-range values are rejected. String values must not contain
+        NUL bytes.
       nullable: true
       oneOf:
         - type: string

--- a/openapi.yml
+++ b/openapi.yml
@@ -3175,7 +3175,9 @@ components:
           pattern: '^[^\u0000]*$'
           description: Metadata string value without NUL bytes
         - type: integer
-          format: int64
+          minimum: -9223372036854775808
+          maximum: 18446744073709551615
+          description: Negative values fit int64; nonnegative values fit uint64.
         - type: boolean
 
     MetadataFieldTypeCommand:


### PR DESCRIPTION
## What changed

HTTP metadata preserves exact integers through `Apply`, including `9007199254740993`, its negative counterpart, and the int64 boundaries. Fractional and out-of-range numbers are rejected before submission. This covers direct metadata writes, transaction/account metadata at creation, reversals, and their bulk decoders.

## Why

[EN-2014](https://formance-team.atlassian.net/browse/EN-2014), under Ledger v3.0 epic EN-867. Decoding metadata into `map[string]any` first converted JSON numbers to float64, irreversibly rounding supported integers before protobuf validation.

## Product / operational motivation

Clients must be able to submit supported metadata integers without silently changing their business data. Router regressions capture native integer values at `Apply`; the durable contract is documented in `docs/technical/architecture/subsystems/api/http-api.md#metadata-number-decoding` and OpenAPI.

## Technical decision

Use explicit number-preserving JSON helpers only in consumers of typed metadata, including custom `UnmarshalJSON` methods. Convert decimal tokens exactly, with work bounded by input length rather than exponent magnitude. Integral spellings such as `1.0` and `1e3` remain accepted. The ordinary shared JSON decoders keep their existing semantics; configuring only the outer HTTP decoder would miss nested custom decoders.

## Risk

**MEDIUM** — several metadata input paths share the conversion, covered by router, bulk, and custom-codec regressions. No new dependencies.

## Validation

- Fail-before: router cases on the original decoder reproduce rounding on account metadata, creation and known-length reversal, including incorrect acceptance of rounded fractions and overflow. Assertions compare native uint64/int64 values, never float64.
- Exact base: `404ac87a4291701bdca5ba9fed4997fb71412933` (`release/v3.0`).
- `bash scripts/agent-check`: PASS, including a second baseline after normalization.
- `go test -race ./internal/adapter/http ./internal/adapter/json ./internal/proto/commonpb ./internal/proto/servicepb -count=1`: PASS.
- Root and operator lint: 0 issues; deterministic generation leaves no unrelated diff.
- `AI_REVIEW_BASE_SHA=404ac87a4291701bdca5ba9fed4997fb71412933 bash scripts/agent-check-pr`: normalization, both lints, baseline and 102 unit-test packages PASS; stops at `tests/antithesis/TestRunModelTestRequiresVerifiedOutcome` (details below).
- Remaining selected gates run separately: Schemathesis PASS (62 endpoints, two recovered transient network errors accepted by the runner); `test-e2e` PASS (business and cluster, with race detector).

## Architecture / behavior impact

Input conversion only: no protobuf schema, gRPC contract, storage, FSM, audit hash, or backup/restore format changes. Nonnegative metadata values retain uint64 inference and negative values int64 inference. [EN-2016 / PR #1978](https://github.com/formancehq/ledger/pull/1978) handles unknown-length reversal bodies separately; the only common production edit is the opt-in decoder call (`UnmarshalReadUseNumber(body, &reqBody)` after its buffered reader change). Metadata size limits in PR #1957 remain separate.

## OpenAPI type correction

Commit `1ab1b67ac` removes the metadata integer's `int64` format and adds exact
bounds `-9223372036854775808` through `18446744073709551615`, matching the
existing signed-negative / unsigned-nonnegative conversion. No Go code changes.
Nine accepted and five rejected schema boundary/type cases pass; baseline and
both lints pass. A fresh exact-base `agent-check-pr` invocation again stops in
the unchanged Antithesis shell fixture, this time with startup deadline
failures in six subcases. These latest timeout signatures have been forwarded
to the dedicated fixture investigation and have not been separately reproduced
on the base. Prior business/cluster E2E results remain applicable to unchanged
server code. Updated-schema Schemathesis: PASS (62 endpoints; two recovered transient
network errors accepted by the runner).

## Review focus

Exact decimal normalization at numeric boundaries, nested decoder coverage, and preservation of ordinary JSON decoding semantics.

## Known concerns

The full selector is not green: Antithesis's shell fixture intermittently misses its 2-second driver outcome. It uses fake Go/server/driver executables and does not execute the metadata implementation. The `driver_exits_before_deadline` failure was reproduced on exact base `404ac87a4291701bdca5ba9fed4997fb71412933` (1 of 8 focused repetitions) and this candidate (2 of 3). The completed-model and blocked-setup subcases that failed under the full-suite load passed every focused base/candidate repetition; those exact failure signatures remain load-only observations. Fixture sources are byte-identical to base. No checks or deadlines were weakened, and no shared caches were purged.

No blocking implementation finding in focused self-review. Jira remains open until merge.


[EN-2014]: https://formance-team.atlassian.net/browse/EN-2014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
