### PR TITLE
fix(test): synchronize model runner fixture deadlines

### DIFF
--- a/docs/technical/contributing/testing.md
+++ b/docs/technical/contributing/testing.md
@@ -517,6 +517,16 @@ after a definitive server outcome reaches model validation. Driver liveness,
 assertion registration, and ledger-setup assertions do not satisfy that gate.
 
 It also requires every coverage sonde to have been satisfied (see below).
+
+The local runner's shell-fixture tests use a logical clock. Time remains before
+its deadline until the fake driver has written the scenario's assertions and
+installed its shutdown handler; the runner then gets one live monitor iteration
+before expiration. The early-exit case holds time before the deadline so the
+runner must detect actual process termination. Fixture events and clock replies
+use blocking pipes, with process-group cancellation and collected server/driver
+logs on infrastructure failure. The outer timeout is a watchdog, never evidence
+that the intended model state was reached.
+
 Common tunables (full list in the script header):
 
 | Variable | Meaning |

--- a/tests/antithesis/run_model_test_test.go
+++ b/tests/antithesis/run_model_test_test.go
@@ -183,25 +183,24 @@ esac
 		fixtureErr = errors.Join(fixtureErr, fmt.Errorf("expected one runner workdir, got %d", len(workDirs)))
 	}
 	var driverLog string
+	var collectedLogs strings.Builder
 	for _, workDir := range workDirs {
-		var combinedSb187 strings.Builder
 		for _, name := range []string{"driver.log", "server-0.log"} {
 			data, readErr := os.ReadFile(filepath.Join(workDir, name))
 			if readErr != nil {
-				combinedSb187.WriteString(fmt.Sprintf("\n%s: %v\n", name, readErr))
+				fmt.Fprintf(&collectedLogs, "\n%s: %v\n", name, readErr)
 				fixtureErr = errors.Join(fixtureErr, readErr)
 
 				continue
 			}
-			combinedSb187.WriteString(fmt.Sprintf("\n%s:\n%s", name, data))
+			fmt.Fprintf(&collectedLogs, "\n%s:\n%s", name, data)
 			if name == "driver.log" {
 				driverLog = strings.TrimSpace(string(data))
 			}
 		}
-		combined += combinedSb187.String()
 	}
 
-	return combined, driverLog, err, fixtureErr
+	return combined + collectedLogs.String(), driverLog, err, fixtureErr
 }
 
 func writeExecutable(t *testing.T, path, content string) {
@@ -269,7 +268,7 @@ func runModelFixtureCommand(ctx context.Context, cmd *exec.Cmd, scenario string)
 		return "", nil, err
 	}
 	defer func() { _ = clockReader.Close() }() // Covers failure before Start.
-	defer func() { _ = clockWriter.Close() }()
+	defer func() { _ = clockWriter.Close() }() // Release the pipe; reply write failures are reported separately.
 	cmd.ExtraFiles = []*os.File{eventsWriter, clockReader}
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	cmd.Cancel = func() error {

--- a/tests/antithesis/run_model_test_test.go
+++ b/tests/antithesis/run_model_test_test.go
@@ -1,11 +1,17 @@
 package antithesis_test
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"errors"
+	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -33,7 +39,8 @@ func TestRunModelTestRequiresVerifiedOutcome(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			output, driverLog, err := runModelTestFixture(t, tt.scenario)
+			output, driverLog, err, fixtureErr := runModelTestFixture(t, tt.scenario)
+			require.NoError(t, fixtureErr, output)
 			if tt.wantPass {
 				require.NoError(t, err, output)
 			} else {
@@ -50,7 +57,7 @@ func TestRunModelTestRequiresVerifiedOutcome(t *testing.T) {
 	}
 }
 
-func runModelTestFixture(t *testing.T, scenario string) (string, string, error) {
+func runModelTestFixture(t *testing.T, scenario string) (string, string, error, error) {
 	t.Helper()
 
 	tempDir := t.TempDir()
@@ -61,6 +68,17 @@ func runModelTestFixture(t *testing.T, scenario string) (string, string, error) 
 	require.NoError(t, os.MkdirAll(filepath.Join(harnessDir, "tests", "antithesis", "workload"), 0o755))
 	require.NoError(t, os.MkdirAll(binDir, 0o755))
 
+	// Only the fixture clock is substituted: liveness checks and reporting run
+	// unchanged. File descriptors 3/4 carry events/clock replies, respectively.
+	writeExecutable(t, filepath.Join(binDir, "date"), `#!/bin/sh
+if [ "$#" -ne 1 ] || [ "$1" != '+%s' ]; then
+	printf 'invalid-date\n' >&3
+	exit 1
+fi
+printf 'clock\n' >&3
+read -r now <&4 || exit 1
+printf '%s\n' "$now"
+`)
 	fakeGo := filepath.Join(binDir, "go")
 	fakeSeq := filepath.Join(binDir, "seq")
 	fakeServer := filepath.Join(tempDir, "fake-server")
@@ -89,11 +107,13 @@ trap 'exit 0' TERM INT
 while :; do sleep 1; done
 `)
 	writeExecutable(t, fakeDriver, `#!/bin/sh
+trap 'printf "driver-exit %s\n" "$?" >&3' EXIT
 write_assertion() {
 	printf '%s\n' "$1" >>"$ANTITHESIS_SDK_LOCAL_OUTPUT"
 }
 stay_alive() {
 	trap 'exit 0' TERM INT
+	printf 'ready\n' >&3
 	while :; do sleep 1; done
 }
 case "$FAKE_MODEL_SCENARIO" in
@@ -102,6 +122,10 @@ case "$FAKE_MODEL_SCENARIO" in
 		echo "first setup Apply entered"
 		stay_alive
 		echo "first setup Apply completed"
+		;;
+	fail-before-ready)
+		echo "injected driver failure before readiness"
+		exit 7
 		;;
 	early-exit)
 		exit 0
@@ -139,6 +163,8 @@ esac
 	defer cancel()
 	cmd := exec.CommandContext(ctx, runner, "2")
 	cmd.Env = append(os.Environ(),
+		"NODES=1",
+		"RESTORE=0",
 		"PATH="+binDir+string(os.PathListSeparator)+os.Getenv("PATH"),
 		"IN_NIX_SHELL=1",
 		"KEEP_WORKDIR=1",
@@ -149,21 +175,218 @@ esac
 		"FAKE_DRIVER_BIN="+fakeDriver,
 		"FAKE_MODEL_SCENARIO="+scenario,
 	)
-	combined, err := cmd.CombinedOutput()
-	require.NoError(t, ctx.Err(), string(combined))
+	combined, err, fixtureErr := runModelFixtureCommand(ctx, cmd, scenario)
 
 	workDirs, globErr := filepath.Glob(filepath.Join(tempDir, "model-test.*"))
 	require.NoError(t, globErr)
-	require.Len(t, workDirs, 1, string(combined))
-	driverLogPath := filepath.Join(workDirs[0], "driver.log")
-	require.FileExists(t, driverLogPath, string(combined))
-	driverLog, readErr := os.ReadFile(driverLogPath)
-	require.NoError(t, readErr, string(combined))
+	if len(workDirs) != 1 {
+		fixtureErr = errors.Join(fixtureErr, fmt.Errorf("expected one runner workdir, got %d", len(workDirs)))
+	}
+	var driverLog string
+	for _, workDir := range workDirs {
+		var combinedSb187 strings.Builder
+		for _, name := range []string{"driver.log", "server-0.log"} {
+			data, readErr := os.ReadFile(filepath.Join(workDir, name))
+			if readErr != nil {
+				combinedSb187.WriteString(fmt.Sprintf("\n%s: %v\n", name, readErr))
+				fixtureErr = errors.Join(fixtureErr, readErr)
 
-	return string(combined), strings.TrimSpace(string(driverLog)), err
+				continue
+			}
+			combinedSb187.WriteString(fmt.Sprintf("\n%s:\n%s", name, data))
+			if name == "driver.log" {
+				driverLog = strings.TrimSpace(string(data))
+			}
+		}
+		combined += combinedSb187.String()
+	}
+
+	return combined, driverLog, err, fixtureErr
 }
 
 func writeExecutable(t *testing.T, path, content string) {
 	t.Helper()
 	require.NoError(t, os.WriteFile(path, []byte(content), 0o755))
+}
+
+// modelFixtureClock holds time before the deadline until the expected driver
+// state exists. The first two queries initialize deadline/restart bookkeeping;
+// subsequent queries guard the monitor. One live iteration follows readiness.
+// Early-exit never advances time: only the runner's real liveness check may
+// finish that scenario. The context deadline remains an infrastructure failure.
+type modelFixtureClock struct {
+	scenario      string
+	queries       int
+	ready         bool
+	observedReady bool
+	expired       bool
+	exiting       bool
+}
+
+func (clock *modelFixtureClock) event(event string) (string, error) {
+	switch event {
+	case "clock":
+		clock.queries++
+		if clock.scenario == "early-exit" || !clock.ready || clock.queries <= 2 {
+			return "100\n", nil
+		}
+		if !clock.observedReady {
+			clock.observedReady = true
+
+			return "100\n", nil
+		}
+		clock.expired = true
+
+		return "102\n", nil
+	case "ready":
+		if clock.ready || clock.exiting || clock.scenario == "early-exit" {
+			return "", fmt.Errorf("unexpected driver readiness: %+v", clock)
+		}
+		clock.ready = true
+
+		return "", nil
+	case "driver-exit 0":
+		if clock.exiting || (clock.scenario != "early-exit" && !clock.expired) {
+			return "", errors.New("driver exited before the fixture deadline")
+		}
+		clock.exiting = true
+
+		return "", nil
+	default:
+		return "", fmt.Errorf("unexpected fixture event %q", event)
+	}
+}
+
+func runModelFixtureCommand(ctx context.Context, cmd *exec.Cmd, scenario string) (string, error, error) {
+	eventsReader, eventsWriter, err := os.Pipe()
+	if err != nil {
+		return "", nil, err
+	}
+	defer func() { _ = eventsReader.Close() }() // Also interrupts the scanner on abort.
+	defer func() { _ = eventsWriter.Close() }() // Covers failure before Start.
+	clockReader, clockWriter, err := os.Pipe()
+	if err != nil {
+		return "", nil, err
+	}
+	defer func() { _ = clockReader.Close() }() // Covers failure before Start.
+	defer func() { _ = clockWriter.Close() }()
+	cmd.ExtraFiles = []*os.File{eventsWriter, clockReader}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	cmd.Cancel = func() error {
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if errors.Is(err, syscall.ESRCH) {
+			return os.ErrProcessDone
+		}
+
+		return err
+	}
+	cmd.WaitDelay = time.Second
+	var output bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &output, &output
+	if err := cmd.Start(); err != nil {
+		return "", nil, err
+	}
+	_ = eventsWriter.Close() // Only descendants own the event writer now.
+	_ = clockReader.Close()  // Only fake date consumes replies.
+	finished := make(chan error, 1)
+	go func() { finished <- cmd.Wait() }()
+	events := make(chan string)
+	stop := make(chan struct{})
+	defer close(stop)
+	go func(events chan<- string) {
+		defer close(events)
+		scanner := bufio.NewScanner(eventsReader)
+		for scanner.Scan() {
+			select {
+			case events <- scanner.Text():
+			case <-stop:
+				return
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			select {
+			case events <- "event pipe: " + err.Error():
+			case <-stop:
+			}
+		}
+	}(events)
+	clock := modelFixtureClock{scenario: scenario}
+	var fixtureErr, runnerErr error
+	runnerDone := false
+	for fixtureErr == nil && (!runnerDone || events != nil) {
+		select {
+		case event, ok := <-events:
+			if !ok {
+				events = nil // EOF is not an exit notification; wait for cmd.Wait.
+
+				continue
+			}
+			var reply string
+			reply, fixtureErr = clock.event(event)
+			if fixtureErr == nil && reply != "" {
+				_, fixtureErr = io.WriteString(clockWriter, reply)
+			}
+		case runnerErr = <-finished:
+			runnerDone = true
+			finished = nil
+			// Wait and pipe delivery are independent. Drain events before deciding
+			// success so an exit/protocol error cannot be lost to select ordering.
+		case <-ctx.Done():
+			fixtureErr = ctx.Err()
+		}
+	}
+	if fixtureErr != nil {
+		if err := cmd.Cancel(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+			fixtureErr = errors.Join(fixtureErr, err)
+		}
+	} else if scenario != "early-exit" && !clock.expired {
+		fixtureErr = errors.New("runner exited before driver readiness and the fixture deadline")
+	}
+	if !runnerDone {
+		runnerErr = <-finished // Reap and finish output collection before reading logs.
+	}
+
+	return output.String(), runnerErr, fixtureErr
+}
+
+func TestRunModelFixtureReportsDriverFailure(t *testing.T) {
+	t.Parallel()
+	output, driverLog, _, err := runModelTestFixture(t, "fail-before-ready")
+	require.ErrorContains(t, err, `unexpected fixture event "driver-exit 7"`, output)
+	require.NotErrorIs(t, err, context.DeadlineExceeded, output)
+	require.Contains(t, driverLog, "injected driver failure before readiness")
+	require.Contains(t, output, "server-0.log:")
+	require.Contains(t, output, "Became leader")
+}
+
+func TestModelFixtureClockWaitsForReadiness(t *testing.T) {
+	t.Parallel()
+	clock := modelFixtureClock{scenario: "verified"}
+	// Repeated monitor probes before driver startup cannot consume its budget.
+	for range 5 {
+		reply, err := clock.event("clock")
+		require.NoError(t, err)
+		require.Equal(t, "100\n", reply)
+	}
+	_, err := clock.event("ready")
+	require.NoError(t, err)
+	reply, err := clock.event("clock")
+	require.NoError(t, err)
+	require.Equal(t, "100\n", reply)
+	reply, err = clock.event("clock")
+	require.NoError(t, err)
+	require.Equal(t, "102\n", reply)
+	_, err = clock.event("ready")
+	require.ErrorContains(t, err, "unexpected driver readiness")
+	_, err = clock.event("invalid-date")
+	require.ErrorContains(t, err, "unexpected fixture event")
+}
+
+func TestModelFixtureDrainsEventsAfterRunnerExit(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "sh", "-c", `printf 'driver-exit 7\n' >&3; exit 7`)
+	_, _, err := runModelFixtureCommand(ctx, cmd, "verified")
+	require.ErrorContains(t, err, `unexpected fixture event "driver-exit 7"`)
 }


### PR DESCRIPTION
## What changed

Make the local Antithesis model-runner fixture use a controlled clock tied to driver readiness. Preserve all six scenarios and the runner's real liveness checks, and add supervision that cancels the process group and collects driver/server logs when a fixture peer fails.

## Why

The fixture's two-second wall-clock window can expire before the driver reaches its intended state or before the monitor observes its exit. This produces intermittent `NO VERIFIED MODEL OUTCOMES` instead of `DRIVER EXITED EARLY`, and can interrupt the positive/blocked scenarios before they write evidence. The early-exit failure was reproduced on the exact base of #1981, independently of its metadata changes.

Follow-up to the fixture introduced by #1941 (EN-1975), discovered during #1981 validation. This PR does not change the production runner or relax the verified-outcome guard.

## Product / operational motivation

N/A — local test-fixture reliability correction.

## Technical decision

N/A

## Risk

**LOW** — test fixture and contributor documentation only.

## Validation

- [x] `AI_REVIEW_BASE_SHA=f76499637a5af0d92a2cfabbdacf8247256fa4bb bash scripts/agent-check-pr` — generation/tidy, root and operator lint, canonical `agent-check`.
- [x] `go test -race ./tests/antithesis -count=10 -v` — all six scenarios and three fixture regressions pass on each repetition.
- [x] Isolated mutations: removing the outcome gate fails the four negative cases while both controls pass; bypassing readiness fails the controlled-clock regression; removing early-exit detection reaches the watchdog.
- The initial mutation batch hit infrastructure timeouts; only the focused reruns above are used as mutation evidence.

## Architecture / behavior impact

None. Runner, Ledger binaries, APIs and persisted state are unchanged.

## Review focus

Clock advancement must require driver readiness while early-exit continues to exercise the real process-liveness branch. Runner completion must drain pending fixture events before deciding success; infrastructure errors must stay distinct from expected model findings.

## Known concerns

The controlled diagnostic reproduced a sufficient missed-exit ordering, but no naturally failing scheduling trace was captured. The separate 15-second infrastructure watchdog remains in place: a later run of the old fixture reached it during fake build/server startup, before monitoring. This PR does not claim to fix that distinct timeout signature. Local execution uses macOS; Linux CI remains the cross-platform check.
