### PR TITLE
fix(events): reject bodyless HTTP redirect acknowledgements (EN-2022)

### DIFF
--- a/docs/technical/architecture/subsystems/events-mirror/README.md
+++ b/docs/technical/architecture/subsystems/events-mirror/README.md
@@ -9,7 +9,7 @@ Two leader-only background workers that tail the global log.
 
 | Document | Description |
 |----------|-------------|
-| [events.md](events.md) | Domain event types and event sink system (NATS, Kafka, ClickHouse, HTTP). |
+| [events.md](events.md) | Domain event types and event sink system (NATS, Kafka, ClickHouse, HTTP), including HTTP acknowledgement and redirect rules. |
 | [mirror.md](mirror.md) | Mirror worker, ascending HTTP continuation, v2 source payload identity contract, and promotion at cutover. |
 | [cel-rewrite.md](cel-rewrite.md) | CEL rewrite engine that transforms transactions during mirror translation (rename addresses, transform metadata, drop transactions). |
 

--- a/docs/technical/architecture/subsystems/events-mirror/events.md
+++ b/docs/technical/architecture/subsystems/events-mirror/events.md
@@ -314,6 +314,24 @@ The cursor is advanced only after the entire batch is successfully published to 
 
 New sink types can be added by implementing the `Sink` interface and adding a variant to `SinkConfig.oneof type`.
 
+### HTTP acknowledgement and redirects
+
+The HTTP sink acknowledges an event only after an event-bearing POST receives
+2xx. This is a transport acknowledgement; it does not prove that the receiver
+completed downstream business processing.
+
+Redirects that change POST to a bodyless GET (301, 302, and 303) are rejected
+before following the redirect. Their status is reported as a publication error,
+so a login page returning 200 cannot advance the sink cursor. Redirects that
+preserve POST and its replayable body (307 and 308) remain supported, with a
+maximum of ten requests in a redirect chain.
+
+If any event in a batch fails, publication stops and the batch cursor remains
+unchanged. The emitter reports the error and retries the batch from that cursor,
+including any preceding events already acknowledged. Receivers must deduplicate
+redelivery. Restart resumes from the persisted cursor; successful publication
+of the whole batch advances that cursor and clears the prior error.
+
 ### Topic/Subject Mapping
 
 Events are published to a configurable topic/subject per sink type:

--- a/internal/application/events/sink_http.go
+++ b/internal/application/events/sink_http.go
@@ -24,7 +24,6 @@ type HTTPSinkConfig struct {
 }
 
 // HTTPSink publishes events to an HTTP endpoint via POST requests.
-// Each batch is sent as a single POST with a JSON array or protobuf body.
 // Events are sent one at a time to allow the receiver to process them individually.
 type HTTPSink struct {
 	client   *http.Client
@@ -42,6 +41,19 @@ func NewHTTPSink(cfg HTTPSinkConfig) (*HTTPSink, error) {
 	return &HTTPSink{
 		client: &http.Client{
 			Timeout: 30 * time.Second,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				// A bodyless GET cannot acknowledge the event POST. Return the
+				// redirect response so post reports its non-2xx status as a failure.
+				if req.Method != http.MethodPost {
+					return http.ErrUseLastResponse
+				}
+				// Installing a policy replaces net/http's default redirect limit.
+				if len(via) >= 10 {
+					return errors.New("stopped after 10 redirects")
+				}
+
+				return nil
+			},
 		},
 		endpoint: cfg.Endpoint,
 		secret:   cfg.Secret,

--- a/internal/application/events/sink_http_redirect_policy_test.go
+++ b/internal/application/events/sink_http_redirect_policy_test.go
@@ -40,9 +40,11 @@ func TestHTTPSink_PreservingRedirectThenFailure(t *testing.T) {
 	for _, status := range []int{http.StatusFound, http.StatusInternalServerError} {
 		t.Run(http.StatusText(status), func(t *testing.T) {
 			t.Parallel()
-			var mu sync.Mutex
-			var methods []string
-			var bodies [][]byte
+			var (
+				mu      sync.Mutex
+				methods []string
+				bodies  [][]byte
+			)
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				body, err := io.ReadAll(r.Body)
 				if err != nil {

--- a/internal/application/events/sink_http_redirect_policy_test.go
+++ b/internal/application/events/sink_http_redirect_policy_test.go
@@ -1,0 +1,81 @@
+package events
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/proto/eventspb"
+)
+
+func TestHTTPSink_RedirectLoopIsBounded(t *testing.T) {
+	t.Parallel()
+	var mu sync.Mutex
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		attempts++
+		mu.Unlock()
+		http.Redirect(w, r, "/loop", http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+	sink, err := NewHTTPSink(HTTPSinkConfig{Endpoint: server.URL, Format: FormatJSON})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, sink.Close()) }()
+	err = sink.Publish(context.Background(), []*eventspb.Event{{LogSequence: 1}})
+	require.ErrorContains(t, err, "stopped after 10 redirects")
+	mu.Lock()
+	defer mu.Unlock()
+	require.Equal(t, 10, attempts)
+}
+
+func TestHTTPSink_PreservingRedirectThenFailure(t *testing.T) {
+	t.Parallel()
+	for _, status := range []int{http.StatusFound, http.StatusInternalServerError} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			t.Parallel()
+			var mu sync.Mutex
+			var methods []string
+			var bodies [][]byte
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, err := io.ReadAll(r.Body)
+				if err != nil {
+					w.WriteHeader(http.StatusInternalServerError)
+
+					return
+				}
+				mu.Lock()
+				methods = append(methods, r.Method)
+				bodies = append(bodies, body)
+				mu.Unlock()
+				switch r.URL.Path {
+				case "/webhook":
+					http.Redirect(w, r, "/next", http.StatusTemporaryRedirect)
+				case "/next":
+					w.Header().Set("Location", "/login")
+					w.WriteHeader(status)
+				default:
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			defer server.Close()
+			sink, err := NewHTTPSink(HTTPSinkConfig{Endpoint: server.URL + "/webhook", Format: FormatJSON})
+			require.NoError(t, err)
+			defer func() { require.NoError(t, sink.Close()) }()
+			err = sink.Publish(context.Background(), []*eventspb.Event{{LogSequence: 1}})
+			require.ErrorContains(t, err, fmt.Sprintf("unexpected status code: %d", status))
+			mu.Lock()
+			defer mu.Unlock()
+			require.Equal(t, []string{http.MethodPost, http.MethodPost}, methods)
+			require.Len(t, bodies, 2)
+			require.NotEmpty(t, bodies[0])
+			require.Equal(t, bodies[0], bodies[1])
+		})
+	}
+}

--- a/internal/application/events/sink_http_redirect_test.go
+++ b/internal/application/events/sink_http_redirect_test.go
@@ -1,0 +1,198 @@
+package events
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/infra/state"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/eventspb"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+	"github.com/formancehq/ledger/v3/internal/query"
+)
+
+type redirectRequest struct {
+	Path, Method, Sequence string
+	Body                   []byte
+}
+
+// This receiver records HTTP acknowledgments, not remote business processing.
+type redirectReceiver struct {
+	mu           sync.Mutex
+	status       int
+	failSequence string
+	recovered    bool
+	requests     []redirectRequest
+	acknowledged []redirectRequest
+}
+
+func (r *redirectReceiver) serve(w http.ResponseWriter, req *http.Request) {
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	record := redirectRequest{req.URL.Path, req.Method, req.Header.Get("X-Log-Sequence"), body}
+	r.requests = append(r.requests, record)
+	if req.URL.Path == "/webhook" && !r.recovered && r.status != 0 && (r.failSequence == "" || r.failSequence == record.Sequence) {
+		http.Redirect(w, req, "/login", r.status)
+
+		return
+	}
+	if req.Method == http.MethodPost && len(body) > 0 {
+		r.acknowledged = append(r.acknowledged, record)
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+func (r *redirectReceiver) snapshot() ([]redirectRequest, []redirectRequest) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return append([]redirectRequest(nil), r.requests...), append([]redirectRequest(nil), r.acknowledged...)
+}
+
+func TestHTTPSinkRedirectEmitterCursorAndRetry(t *testing.T) {
+	t.Parallel()
+	for _, status := range []int{0, 301, 302, 303, 307, 308} {
+		t.Run(strconv.Itoa(status), func(t *testing.T) {
+			t.Parallel()
+			receiver := &redirectReceiver{status: status}
+			server := httptest.NewServer(http.HandlerFunc(receiver.serve))
+			defer server.Close()
+			sink, err := NewHTTPSink(HTTPSinkConfig{Endpoint: server.URL + "/webhook", Format: FormatJSON})
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, sink.Close()) })
+			builder, store := newTestBuilder(t)
+			// Persist two real logs, then drive the same batch boundary used by run.
+			session := store.OpenWriteSession()
+			logs := make([]*commonpb.Log, 0, 2)
+			for _, seq := range []uint64{1, 2} {
+				logs = append(logs, &commonpb.Log{Sequence: seq, Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_CreateLedger{CreateLedger: &commonpb.CreatedLedgerLog{Name: fmt.Sprintf("ledger-%d", seq), CreatedAt: &commonpb.Timestamp{Data: 1000}}}}})
+			}
+			require.NoError(t, state.AppendLogs(session, logs))
+			require.NoError(t, state.SetAppliedIndex(session, 1))
+			require.NoError(t, session.Commit())
+			proposer := &capturingProposer{}
+			emitter := NewEmitter(store, sink, "redirect", proposer, builder, logging.Testing(), DefaultEmitterConfig())
+			cursor, _, publishErr := emitter.processLogBatch(context.Background(), 0)
+			require.Len(t, proposer.captured, 1)
+			proposal := &raftcmdpb.Proposal{}
+			require.NoError(t, proposal.UnmarshalVT(proposer.captured[0]))
+			update := proposal.GetTechnicalUpdates()[0].GetEventsSink()
+			requests, acknowledged := receiver.snapshot()
+			t.Logf("status=%d publishErr=%v returnedCursor=%d proposedCursor=%d HTTP-acknowledged POSTs=%d", status, publishErr, cursor, update.GetCursor(), len(acknowledged))
+			for _, request := range requests {
+				t.Logf("request path=%s method=%s sequence=%s bodyBytes=%d", request.Path, request.Method, request.Sequence, len(request.Body))
+			}
+			if status == 301 || status == 302 || status == 303 {
+				// Do not abort: on the vulnerable source the subsequent restart proves
+				// that the incorrectly proposed cursor actually excludes both logs.
+				assert.Error(t, publishErr)
+				assert.Zero(t, cursor)
+				assert.Zero(t, update.GetCursor())
+				assert.Empty(t, acknowledged)
+				assert.Len(t, requests, 1, "method-changing redirect must not reach /login")
+				if publishErr != nil {
+					assert.Contains(t, publishErr.Error(), fmt.Sprintf("unexpected status code: %d", status))
+				}
+			} else {
+				require.NoError(t, publishErr)
+				require.Equal(t, uint64(2), cursor)
+				require.Equal(t, uint64(2), update.GetCursor())
+				require.Len(t, acknowledged, 2)
+				for _, ack := range acknowledged {
+					require.Equal(t, http.MethodPost, ack.Method)
+					require.NotEmpty(t, ack.Body)
+				}
+				if status != 0 {
+					require.Len(t, requests, 4)
+					require.Equal(t, requests[0].Body, requests[1].Body)
+					require.Equal(t, requests[2].Body, requests[3].Body)
+				}
+
+				return
+			}
+			receiver.mu.Lock()
+			receiver.recovered = true
+			receiver.mu.Unlock()
+			// Apply the captured cursor update to the fixture store, as the FSM
+			// does after accepting the proposal, then read it back on restart.
+			cursorSession := store.OpenWriteSession()
+			require.NoError(t, state.SetSinkCursor(cursorSession, "redirect", update.GetCursor()))
+			require.NoError(t, cursorSession.Commit())
+			persistedCursor, err := query.ReadSinkCursor(store, "redirect")
+			require.NoError(t, err)
+			require.Equal(t, update.GetCursor(), persistedCursor)
+			// A fresh emitter resets backoff as on leader restart.
+			restarted := NewEmitter(store, sink, "redirect", proposer, builder, logging.Testing(), DefaultEmitterConfig())
+			resumedCursor, _, err := restarted.processLogBatch(context.Background(), persistedCursor)
+			require.NoError(t, err)
+			require.Equal(t, uint64(2), resumedCursor)
+			resumedRequests, resumedAcknowledged := receiver.snapshot()
+			t.Logf("restart cursor=%d additional requests=%d acknowledged POSTs=%d", update.GetCursor(), len(resumedRequests)-len(requests), len(resumedAcknowledged))
+			require.Len(t, resumedAcknowledged, 2, "restart must retry the complete unacknowledged batch")
+			require.Equal(t, "1", resumedAcknowledged[0].Sequence)
+			require.Equal(t, "2", resumedAcknowledged[1].Sequence)
+			require.Equal(t, requests[0].Body, resumedAcknowledged[0].Body)
+			require.Len(t, resumedRequests, 3, "one failed POST plus exactly two retry POSTs")
+		})
+	}
+}
+
+func TestHTTPSinkRedirectPartialBatchRetry(t *testing.T) {
+	t.Parallel()
+	for _, status := range []int{301, 302, 303} {
+		t.Run(strconv.Itoa(status), func(t *testing.T) {
+			t.Parallel()
+			receiver := &redirectReceiver{status: status, failSequence: "2"}
+			server := httptest.NewServer(http.HandlerFunc(receiver.serve))
+			defer server.Close()
+			sink, err := NewHTTPSink(HTTPSinkConfig{Endpoint: server.URL + "/webhook", Format: FormatJSON})
+			require.NoError(t, err)
+			t.Cleanup(func() { require.NoError(t, sink.Close()) })
+			builder, store := newTestBuilder(t)
+			proposer := &capturingProposer{}
+			emitter := NewEmitter(store, sink, "partial", proposer, builder, logging.Testing(), DefaultEmitterConfig())
+			batch := []*eventspb.Event{{LogSequence: 1}, {LogSequence: 2}}
+			err = emitter.publishBatch(context.Background(), batch)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), fmt.Sprintf("posting event seq=2: unexpected status code: %d", status))
+			requests, acknowledged := receiver.snapshot()
+			require.Len(t, requests, 2)
+			require.Len(t, acknowledged, 1)
+			update := &raftcmdpb.Proposal{}
+			require.NoError(t, update.UnmarshalVT(proposer.captured[0]))
+			require.Zero(t, update.GetTechnicalUpdates()[0].GetEventsSink().GetCursor())
+			receiver.mu.Lock()
+			receiver.recovered = true
+			receiver.mu.Unlock()
+			require.NoError(t, emitter.publishBatch(context.Background(), batch))
+			requests, acknowledged = receiver.snapshot()
+			require.Len(t, requests, 4)
+			require.Len(t, acknowledged, 3)
+			require.Equal(t, []string{"1", "1", "2"}, []string{acknowledged[0].Sequence, acknowledged[1].Sequence, acknowledged[2].Sequence})
+			require.Equal(t, requests[0].Body, requests[2].Body)
+			require.Equal(t, requests[1].Body, requests[3].Body)
+			require.Len(t, proposer.captured, 2)
+			update.Reset()
+			require.NoError(t, update.UnmarshalVT(proposer.captured[1]))
+			require.Equal(t, uint64(2), update.GetTechnicalUpdates()[0].GetEventsSink().GetCursor())
+			require.True(t, update.GetTechnicalUpdates()[0].GetEventsSink().GetClearError())
+		})
+	}
+}


### PR DESCRIPTION
## What changed

HTTP webhook publication rejects redirects that rewrite the event POST to a bodyless GET. Direct POST and replayable 307/308 redirects remain supported, including the existing ten-request redirect limit. Additive tests cover restart from the persisted cursor, partial-batch retry, mixed redirect chains and redirect loops.

## Why

Fixes [EN-2022](https://formance-team.atlassian.net/browse/EN-2022). A webhook returning 301/302/303 to a login page returning 200 previously made publication succeed without any event-bearing POST receiving 2xx, advancing the cursor past undelivered events.

## Product / operational motivation

The event cursor must only advance after the selected batch receives transport acknowledgement. HTTP acknowledgement does not imply downstream business processing. The requirement and retry behavior are documented in `docs/technical/architecture/subsystems/events-mirror/events.md`, under “HTTP acknowledgement and redirects”.

## Technical decision

Reject method-changing redirects through `CheckRedirect` and return their original status through the existing publication error path. Preserve method/body-preserving redirects and explicitly retain the default redirect limit. Rejecting all redirects would unnecessarily remove working 307/308 delivery. No emitter or persistence changes are needed.

## Risk

**LOW** — limited to HTTP redirect handling. Endpoints relying on POST-to-GET redirects now report a sink error instead of falsely advancing their cursor.

## Validation

- Before correction at `22f378c1a492316f3638fdb74afd9506111b5421`, additive tests failed for 301/302/303: bodyless GET, no acknowledged POST, cursor 2, then zero requests on restart. Direct POST and 307/308 controls passed.
- After correction, focused redirect tests pass with `-race`, including complete partial-batch retry with identical bytes and exact request counts.
- Cursor persistence uses real storage helpers with simulated proposal application; this is not a full Raft cluster test.
- Entire `internal/application/events` suite with `-race`: PASS. Targeted golangci-lint with sink feature tags: PASS (0 issues).
- `bash scripts/agent-check`: PASS.
- `AI_REVIEW_BASE_SHA=1c6960b58162b1a5908806df506c58f34f41a30c bash scripts/agent-check-pr`: PASS after rebasing onto the upstream query test correction. Full pre-commit (generation, tidy, root/operator lint), baseline and events race suite passed; no generated drift.

## Architecture / behavior impact

301/302/303 stop before the rewritten request is sent and enter the existing error/retry path. No changes to wire formats, persisted state, FSM behavior or restore semantics.

## Review focus

Method-changing redirects must fail at every hop without changing 307/308 handling or allowing partial-batch cursor advancement.

## Known concerns

The initial store/Store test compilation failure was fixed upstream in #1955; the branch is rebased and the canonical PR gate now passes. Await required CI and renewed NumaryBot/Shipfox validation on the current candidate before human-review handoff.

#1977 overlaps `sink_http.go` for error sanitization and has a 307-to-EOF test; it does not fix this mechanism. This PR is independent of that stack. No deployment or Antithesis cloud tests were run. CI remains the broad validation boundary before merge.


[EN-2022]: https://formance-team.atlassian.net/browse/EN-2022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ