### PR TITLE
fix(events): encode NATS ledger subject tokens (EN-2023)

### DIFF
--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -4787,6 +4787,16 @@ Add or update (upsert) a named event sink configuration. The configuration is re
 
 Currently supported sink types: **NATS JetStream**, **ClickHouse**, **Kafka**, **HTTP**, **Databricks**.
 
+NATS subjects are `{topic}.{ledgerToken}.{lowercaseEventType}`. Ledger-name dots
+are encoded as `%2E`, so ledger `a..b` publishes under
+`ledger.events.a%2E%2Eb.created_ledger` with topic `ledger.events`. The real ledger
+`_system` uses `%5Fsystem`; `_system` alone denotes an empty event ledger.
+Ordinary names such as `orders` are unchanged. Update exact consumer filters,
+stream subjects and NATS permissions for encoded names; a dotted name is now
+one token, not a subject hierarchy. Payloads retain the original ledger name.
+See the [NATS routing contract](../technical/architecture/subsystems/events-mirror/events.md#nats-ledger-name-routing-en-2023)
+for examples and wildcard behavior.
+
 ```bash
 # Add a NATS sink with default settings
 ledgerctl events add-sink --name primary --nats-url nats://localhost:4222 --nats-topic ledger.events

--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -4789,8 +4789,9 @@ Currently supported sink types: **NATS JetStream**, **ClickHouse**, **Kafka**, *
 
 NATS subjects are `{topic}.{ledgerToken}.{lowercaseEventType}`. Ledger-name dots
 are encoded as `%2E`, so ledger `a..b` publishes under
-`ledger.events.a%2E%2Eb.created_ledger` with topic `ledger.events`. The real ledger
-`_system` uses `%5Fsystem`; `_system` alone denotes an empty event ledger.
+`ledger.events.a%2E%2Eb.created_ledger` with topic `ledger.events`. The token
+`_system` denotes an empty event ledger; exact ledger names `_` and `_system`
+are reserved and rejected at admission.
 Ordinary names such as `orders` are unchanged. Update exact consumer filters,
 stream subjects and NATS permissions for encoded names; a dotted name is now
 one token, not a subject hierarchy. Payloads retain the original ledger name.

--- a/docs/technical/architecture/subsystems/admission/README.md
+++ b/docs/technical/architecture/subsystems/admission/README.md
@@ -8,7 +8,7 @@ The admission pipeline (`internal/application/admission`) is the gateway every w
 |----------|-------------|
 | [pipeline.md](pipeline.md) | End-to-end pipeline from gRPC request to Raft proposal: gate, signature, order conversion, numscript, preload, proposal guard, predicted-index trick. |
 | [signing.md](signing.md) | Ed25519 request and response signing — keys, lifecycle, cross-language constraint, audit-chain propagation, replay nuance. |
-| [validation.md](validation.md) | Structural validation (admission, fast UX feedback) vs behavioural validation (FSM, audit-bound). Shared sentinels. |
+| [validation.md](validation.md) | Structural validation (admission, fast UX feedback) vs behavioural validation (FSM, audit-bound). Reserved ledger names and shared sentinels. |
 | [idempotency.md](idempotency.md) | Idempotency key mechanism, hash-based conflict detection, and TTL eviction. |
 | [admission-cache-horizon.md](admission-cache-horizon.md) | Rejecting proposals when the predicted apply-time generation is ≥ 2 ahead of the FSM's current generation. |
 

--- a/docs/technical/architecture/subsystems/admission/validation.md
+++ b/docs/technical/architecture/subsystems/admission/validation.md
@@ -65,3 +65,10 @@ require.ErrorIs(t, err, domain.ErrAccountAddressEmpty)
 ```
 
 `require.ErrorIs` matches both admission-side wraps and FSM-side wraps because the sentinel is shared. If a future refactor moves a check between layers, the test does not have to change.
+
+## Reserved ledger names
+
+Admission rejects the exact names `_` (system API routes) and `_system`
+(system events) on every ledger-scoped write, before proposing to Raft.
+This applies equally to HTTP and gRPC. Other underscore-prefixed names,
+including `_systemx` and `_System`, remain valid.

--- a/docs/technical/architecture/subsystems/events-mirror/README.md
+++ b/docs/technical/architecture/subsystems/events-mirror/README.md
@@ -9,7 +9,7 @@ Two leader-only background workers that tail the global log.
 
 | Document | Description |
 |----------|-------------|
-| [events.md](events.md) | Domain event types and event sink system (NATS, Kafka, ClickHouse, HTTP), including HTTP acknowledgement and redirect rules. |
+| [events.md](events.md) | Domain event types, event sinks, NATS ledger-name token encoding, and HTTP acknowledgement and redirect rules. |
 | [mirror.md](mirror.md) | Mirror worker, ascending HTTP continuation, v2 source payload identity contract, and promotion at cutover. |
 | [cel-rewrite.md](cel-rewrite.md) | CEL rewrite engine that transforms transactions during mirror translation (rename addresses, transform metadata, drop transactions). |
 

--- a/docs/technical/architecture/subsystems/events-mirror/events.md
+++ b/docs/technical/architecture/subsystems/events-mirror/events.md
@@ -342,6 +342,48 @@ Events are published to a configurable topic/subject per sink type:
 - **ClickHouse**: Events are inserted into the configured `table`.
 - **Databricks**: Events are inserted into the configured `catalog.schema.table`.
 
+### NATS ledger-name routing (EN-2023)
+
+Every admitted ledger name must route without blocking later selected events.
+NATS subjects use `{topic}.{ledgerToken}.{lowercaseEventType}`. The ledger token
+replaces every `.` with `%2E` (and every literal `%` with `%25` before escaping
+points). The real ledger name `_system` is represented as `%5Fsystem`; an empty
+event ledger uses `_system`. Other admitted characters (`a-z`, `A-Z`, `0-9`,
+`_`, `:`, `-`) are preserved. Decode percent escapes once to recover a non-system
+ledger name. The event payload always retains the original name.
+
+| Event ledger | Subject with topic `events` and type `CREATED_LEDGER` |
+| --- | --- |
+| `orders` | `events.orders.created_ledger` |
+| `a..b` | `events.a%2E%2Eb.created_ledger` |
+| `.orders` | `events.%2Eorders.created_ledger` |
+| `orders.` | `events.orders%2E.created_ledger` |
+| `a.b` | `events.a%2Eb.created_ledger` |
+| `_system` | `events.%5Fsystem.created_ledger` |
+| empty | `events._system.created_ledger` |
+
+This representation is injective over admitted names and the empty sentinel:
+percent is not an admitted name character, every dot becomes an escape within
+one nonempty token, and the sentinel is disjoint from real names. Escaping
+percent explicitly also prevents escape collisions if such a value reaches the
+transport. Raw interpolation was rejected because leading, trailing and repeated
+dots create empty tokens and block JetStream acknowledgement even with a stream
+capturing `events.>`. Restricting admission would unnecessarily limit every
+transport; encoding every name with base64 would change ordinary-name routing.
+
+Consumers, stream filters and subject permissions must use the encoded token for
+dotted names and the real `_system` ledger. Existing filters using dotted names
+as a hierarchy must be updated: `events.a.*.created_ledger` does not select the
+ledger `a.b`; use `events.a%2Eb.created_ledger`. `events.*.created_ledger` now
+matches exactly one ledger token, and `events.>` continues to capture all events.
+This is the unreleased v3 routing contract; no old-subject dual publication or
+fallback is provided. The configured topic remains the operator's subject prefix.
+
+Publication still waits for each JetStream acknowledgement. On failure, the
+emitter retains the pending batch's cursor, reports the error and retries;
+other named sinks advance independently. This change does not alter persisted
+state, audit payloads, FSM application or incremental restore behavior.
+
 ## Configuration
 
 ### Raft-Replicated Configuration via gRPC

--- a/docs/technical/architecture/subsystems/events-mirror/events.md
+++ b/docs/technical/architecture/subsystems/events-mirror/events.md
@@ -347,8 +347,8 @@ Events are published to a configurable topic/subject per sink type:
 Every admitted ledger name must route without blocking later selected events.
 NATS subjects use `{topic}.{ledgerToken}.{lowercaseEventType}`. The ledger token
 replaces every `.` with `%2E` (and every literal `%` with `%25` before escaping
-points). The real ledger name `_system` is represented as `%5Fsystem`; an empty
-event ledger uses `_system`. Other admitted characters (`a-z`, `A-Z`, `0-9`,
+points). An empty event ledger uses `_system`; the exact ledger names `_`
+and `_system` are rejected at admission. Other admitted characters (`a-z`, `A-Z`, `0-9`,
 `_`, `:`, `-`) are preserved. Decode percent escapes once to recover a non-system
 ledger name. The event payload always retains the original name.
 
@@ -359,7 +359,7 @@ ledger name. The event payload always retains the original name.
 | `.orders` | `events.%2Eorders.created_ledger` |
 | `orders.` | `events.orders%2E.created_ledger` |
 | `a.b` | `events.a%2Eb.created_ledger` |
-| `_system` | `events.%5Fsystem.created_ledger` |
+| `_systemx` | `events._systemx.created_ledger` |
 | empty | `events._system.created_ledger` |
 
 This representation is injective over admitted names and the empty sentinel:
@@ -368,11 +368,11 @@ one nonempty token, and the sentinel is disjoint from real names. Escaping
 percent explicitly also prevents escape collisions if such a value reaches the
 transport. Raw interpolation was rejected because leading, trailing and repeated
 dots create empty tokens and block JetStream acknowledgement even with a stream
-capturing `events.>`. Restricting admission would unnecessarily limit every
+capturing `events.>`. Banning dotted names would unnecessarily limit every
 transport; encoding every name with base64 would change ordinary-name routing.
 
 Consumers, stream filters and subject permissions must use the encoded token for
-dotted names and the real `_system` ledger. Existing filters using dotted names
+dotted names. Existing filters using dotted names
 as a hierarchy must be updated: `events.a.*.created_ledger` does not select the
 ledger `a.b`; use `events.a%2Eb.created_ledger`. `events.*.created_ledger` now
 matches exactly one ledger token, and `events.>` continues to capture all events.

--- a/docs/technical/contributing/api-comparison.md
+++ b/docs/technical/contributing/api-comparison.md
@@ -1032,3 +1032,10 @@ if ok {
     }
 }
 ```
+
+## Reserved ledger names
+
+Admission rejects the exact names `_` (system API routes) and `_system`
+(system events) on every ledger-scoped write, before proposing to Raft.
+This applies equally to HTTP and gRPC. Other underscore-prefixed names,
+including `_systemx` and `_System`, remain valid.

--- a/internal/application/admission/errors.go
+++ b/internal/application/admission/errors.go
@@ -29,18 +29,10 @@ var (
 	// instead of stalling — or corrupting — the mirror on every batch.
 	ErrMirrorRewriteRuleInvalid = domain.NewValidationSentinel("mirrorSource.rewriteRules: each rule must have a boolean match and a cel expression returning a transaction")
 
-	// ErrLedgerNameReservedPrefix rejects the ledger name "_". That single
-	// segment is reserved for system / non-ledger HTTP routes, which all live
-	// under /v3/_/… (e.g. GET /v3/_/audit-entries, /v3/_/indexes,
-	// /v3/_/events-sinks, /v3/_/signing-keys) and share the /v3/{ledgerName} path
-	// namespace. A ledger named "_" would be shadowed by that fixed segment.
-	// Reserving the one segment "_" — rather than an ever-growing list of
-	// individual reserved words — keeps the guard in lock-step with the route
-	// table for free and applies uniformly across transports (see
-	// internal/adapter/http/handler.go). Enforced on every ledger-scoped order
-	// (validateOrderLedgerName), not just CreateLedger, so a "_" ledger can never
-	// be created or written to.
-	ErrLedgerNameReservedPrefix = domain.NewValidationSentinel("ledger name \"_\" is reserved for system API routes")
+	// ErrLedgerNameReservedPrefix rejects the exact names "_" (system API
+	// routes) and "_system" (system events) on every ledger-scoped order.
+	// Other underscore-prefixed names remain valid.
+	ErrLedgerNameReservedPrefix = domain.NewValidationSentinel("ledger names \"_\" and \"_system\" are reserved for system use")
 
 	// ErrIndexTargetUnsupported rejects a CreateIndex order for an IndexID the
 	// builder has no backfill path for: a metadata target other than

--- a/internal/application/admission/ledger_name_event_routing_test.go
+++ b/internal/application/admission/ledger_name_event_routing_test.go
@@ -1,0 +1,76 @@
+package admission
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/infra/node"
+	"github.com/formancehq/ledger/v3/internal/infra/state"
+	"github.com/formancehq/ledger/v3/internal/pkg/futures"
+	"github.com/formancehq/ledger/v3/internal/proto/raftcmdpb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+// Event transports must represent the admitted ledger-name domain themselves;
+// restricting ledger admission to work around NATS subject syntax is not valid.
+// Exercise Admit through proposal serialization, rather than only the validator.
+func TestAdmit_CreateLedgerNamesForEventRouting(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"orders", "a.b", "a..b", ".orders", "orders.", ".", "_system", "a-b_0", strings.Repeat("a", dal.LedgerNameFixedSize)} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			store := createTestStore(t)
+			proposer := NewMockProposer(gomock.NewController(t))
+			proposed := errors.New("create ledger proposal reached consensus boundary")
+			proposer.EXPECT().Propose(gomock.Any(), gomock.Any()).DoAndReturn(
+				func(_ context.Context, proposal *node.Proposal) (*futures.Future[state.ApplyResult], error) {
+					var command raftcmdpb.Proposal
+					require.NoError(t, command.UnmarshalVT(proposal.Data()))
+					require.Len(t, command.GetOrders(), 1)
+					order := command.GetOrders()[0].GetLedgerScoped()
+					require.NotNil(t, order.GetCreateLedger())
+					require.Equal(t, name, order.GetLedger())
+
+					return nil, proposed
+				},
+			).Times(1)
+			admission, _ := createTestAdmissionWithReader(t, store, proposer)
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+
+			_, err := admission.Admit(ctx, businessWrite(name))
+			require.ErrorIs(t, err, proposed)
+		})
+	}
+
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{"", domain.ErrLedgerNameRequired},
+		{"_", ErrLedgerNameReservedPrefix},
+		{"a b", domain.ErrLedgerNameInvalidChar},
+		{"a\x00b", domain.ErrLedgerNameInvalidChar},
+	} {
+		t.Run("rejected_"+tc.name, func(t *testing.T) {
+			t.Parallel()
+			store := createTestStore(t)
+			// No Propose expectation: malformed names must fail before consensus.
+			proposer := NewMockProposer(gomock.NewController(t))
+			admission, _ := createTestAdmissionWithReader(t, store, proposer)
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			defer cancel()
+
+			_, err := admission.Admit(ctx, businessWrite(tc.name))
+			require.ErrorIs(t, err, tc.err)
+		})
+	}
+}

--- a/internal/application/admission/ledger_name_event_routing_test.go
+++ b/internal/application/admission/ledger_name_event_routing_test.go
@@ -24,7 +24,7 @@ import (
 func TestAdmit_CreateLedgerNamesForEventRouting(t *testing.T) {
 	t.Parallel()
 
-	for _, name := range []string{"orders", "a.b", "a..b", ".orders", "orders.", ".", "_system", "a-b_0", strings.Repeat("a", dal.LedgerNameFixedSize)} {
+	for _, name := range []string{"orders", "a.b", "a..b", ".orders", "orders.", ".", "_systemx", "__system", "_System", "a-b_0", strings.Repeat("a", dal.LedgerNameFixedSize)} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			store := createTestStore(t)
@@ -57,6 +57,7 @@ func TestAdmit_CreateLedgerNamesForEventRouting(t *testing.T) {
 	}{
 		{"", domain.ErrLedgerNameRequired},
 		{"_", ErrLedgerNameReservedPrefix},
+		{"_system", ErrLedgerNameReservedPrefix},
 		{"a b", domain.ErrLedgerNameInvalidChar},
 		{"a\x00b", domain.ErrLedgerNameInvalidChar},
 	} {

--- a/internal/application/admission/validate_order.go
+++ b/internal/application/admission/validate_order.go
@@ -104,13 +104,9 @@ func validateOrderLedgerName(order *raftcmdpb.Order) domain.Describable {
 		return err
 	}
 
-	// Reserve the ledger name "_" for the system / non-ledger HTTP routes, which
-	// all live under /v3/_/… so they never shadow a real ledger (see
-	// ErrLedgerNameReservedPrefix and internal/adapter/http/handler.go). Applied
-	// to every ledger-scoped order, not just CreateLedger: a "_" ledger can
-	// never legitimately exist, so rejecting it everywhere is safe and keeps the
-	// rule in one place.
-	if ls.GetLedger() == "_" {
+	// Reserve exact system names across all ledger-scoped orders.
+	// "_" belongs to HTTP system routes; "_system" denotes system events.
+	if ls.GetLedger() == "_" || ls.GetLedger() == "_system" {
 		return ErrLedgerNameReservedPrefix
 	}
 

--- a/internal/application/admission/validate_order_test.go
+++ b/internal/application/admission/validate_order_test.go
@@ -77,10 +77,7 @@ func TestValidateOrder_LedgerName(t *testing.T) {
 			wantErr: ErrLedgerNameReservedPrefix,
 		},
 		{
-			// The guard covers every ledger-scoped order, not just CreateLedger:
-			// a "_" ledger persisted before this reservation (e.g. on upgrade)
-			// can never be written to either, so its /v3/_/… routes stay
-			// unreachable-via-ledger for good.
+			// The guard covers every ledger-scoped order, not just CreateLedger.
 			name: "reserved '_' rejected on Apply too",
 			order: &raftcmdpb.Order{
 				Type: &raftcmdpb.Order_LedgerScoped{
@@ -95,8 +92,37 @@ func TestValidateOrder_LedgerName(t *testing.T) {
 			wantErr: ErrLedgerNameReservedPrefix,
 		},
 		{
-			// Only the exact segment "_" is reserved (it backs the /v3/_/…
-			// system route namespace); names that merely start with '_' remain
+			name: "reserved '_system' ledger name rejected",
+			order: &raftcmdpb.Order{
+				Type: &raftcmdpb.Order_LedgerScoped{
+					LedgerScoped: &raftcmdpb.LedgerScopedOrder{
+						Ledger: "_system",
+						Payload: &raftcmdpb.LedgerScopedOrder_CreateLedger{
+							CreateLedger: &raftcmdpb.CreateLedgerOrder{},
+						},
+					},
+				},
+			},
+			wantErr: ErrLedgerNameReservedPrefix,
+		},
+		{
+			// The guard covers every ledger-scoped order, not just CreateLedger.
+			name: "reserved '_system' rejected on Apply too",
+			order: &raftcmdpb.Order{
+				Type: &raftcmdpb.Order_LedgerScoped{
+					LedgerScoped: &raftcmdpb.LedgerScopedOrder{
+						Ledger: "_system",
+						Payload: &raftcmdpb.LedgerScopedOrder_Apply{
+							Apply: &raftcmdpb.LedgerApplyOrder{},
+						},
+					},
+				},
+			},
+			wantErr: ErrLedgerNameReservedPrefix,
+		},
+		{
+			// The exact names "_" and "_system" are reserved; other names
+			// that merely start with '_' remain
 			// valid ledger names.
 			name: "underscore-prefixed name is allowed",
 			order: &raftcmdpb.Order{

--- a/internal/application/events/sink_nats.go
+++ b/internal/application/events/sink_nats.go
@@ -94,8 +94,6 @@ func (s *NATSSink) subject(event *eventspb.Event) string {
 	switch ledger {
 	case "":
 		ledger = "_system"
-	case "_system":
-		ledger = "%5Fsystem"
 	default:
 		// Escape the escape marker first so encoding remains unambiguous.
 		ledger = strings.ReplaceAll(ledger, "%", "%25")

--- a/internal/application/events/sink_nats.go
+++ b/internal/application/events/sink_nats.go
@@ -86,11 +86,20 @@ func (s *NATSSink) Close() error {
 }
 
 // subject returns the NATS subject for the given event.
-// Format: {topic}.{ledger}.{type} (e.g., "ledger-events.orders.COMMITTED_TRANSACTION").
+// Format: {topic}.{ledgerToken}.{type} (e.g., "ledger-events.orders.committed_transaction").
+// Keep ledger names in one token and distinguish the empty-ledger sentinel.
+// Payloads retain the original name; consumers must use this encoding in filters.
 func (s *NATSSink) subject(event *eventspb.Event) string {
 	ledger := event.GetLedger()
-	if ledger == "" {
+	switch ledger {
+	case "":
 		ledger = "_system"
+	case "_system":
+		ledger = "%5Fsystem"
+	default:
+		// Escape the escape marker first so encoding remains unambiguous.
+		ledger = strings.ReplaceAll(ledger, "%", "%25")
+		ledger = strings.ReplaceAll(ledger, ".", "%2E")
 	}
 
 	eventType := strings.ToLower(event.GetType().String())

--- a/internal/application/events/sink_nats_integration_test.go
+++ b/internal/application/events/sink_nats_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"math/big"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -32,7 +33,7 @@ func startTestNATSServer(t *testing.T) *server.Server {
 	// Use os.MkdirTemp instead of t.TempDir() to control cleanup ordering.
 	// t.TempDir() registers its own cleanup that can race with JetStream
 	// file handles not yet released after WaitForShutdown() on macOS.
-	storeDir, err := os.MkdirTemp("", t.Name()) //nolint:usetesting // intentional: t.TempDir() cleanup races with JetStream file handles
+	storeDir, err := os.MkdirTemp("", strings.ReplaceAll(t.Name(), "/", "_")) //nolint:usetesting // intentional: t.TempDir() cleanup races with JetStream file handles
 	require.NoError(t, err)
 
 	opts := &server.Options{

--- a/internal/application/events/sink_nats_names_integration_test.go
+++ b/internal/application/events/sink_nats_names_integration_test.go
@@ -61,7 +61,7 @@ func TestNATSSinkIntegration_AdmittedLedgerNames(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct{ name, token string }{
 		{"a..b", "a%2E%2Eb"}, {".orders", "%2Eorders"}, {"orders.", "orders%2E"},
-		{"orders", "orders"}, {"a.b", "a%2Eb"}, {"_system", "%5Fsystem"}, {"A_z:0-9", "A_z:0-9"},
+		{"orders", "orders"}, {"a.b", "a%2Eb"}, {"_systemx", "_systemx"}, {"A_z:0-9", "A_z:0-9"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			// Admission.Admit coverage is in TestAdmit_CreateLedgerNamesForEventRouting; this

--- a/internal/application/events/sink_nats_names_integration_test.go
+++ b/internal/application/events/sink_nats_names_integration_test.go
@@ -1,0 +1,222 @@
+//go:build nats
+
+package events_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nats.go/jetstream"
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+
+	"github.com/formancehq/ledger/v3/internal/application/events"
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/eventspb"
+	"github.com/formancehq/ledger/v3/internal/query"
+)
+
+// observedNATSSink instruments the real broker publication, keeping each result
+// at a barrier until the test has inspected the durable cursor and stream.
+type observedNATSSink struct {
+	*events.NATSSink
+
+	results chan error
+	resume  chan struct{}
+}
+
+func (s *observedNATSSink) Publish(ctx context.Context, batch []*eventspb.Event) error {
+	err := s.NATSSink.Publish(ctx, batch)
+	select {
+	case s.results <- err:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	select {
+	case <-s.resume:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func TestNATSSinkIntegration_AdmittedLedgerNames(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct{ name, token string }{
+		{"a..b", "a%2E%2Eb"}, {".orders", "%2Eorders"}, {"orders.", "orders%2E"},
+		{"orders", "orders"}, {"a.b", "a%2Eb"}, {"_system", "%5Fsystem"}, {"A_z:0-9", "A_z:0-9"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			// Admission.Admit coverage is in TestAdmit_CreateLedgerNamesForEventRouting; this
+			// fixture independently pins the shared name contract before log conversion.
+			require.Nil(t, domain.ValidateLedgerName(tc.name))
+			ns := startTestNATSServer(t)
+			conn, err := nats.Connect(ns.ClientURL())
+			require.NoError(t, err)
+			defer conn.Close()
+			js, err := jetstream.New(conn)
+			require.NoError(t, err)
+			createTestStream(t, js, "EVENTS", "events")
+			stream, err := js.Stream(t.Context(), "EVENTS")
+			require.NoError(t, err)
+			store := newTestStore(t)
+			appendTestLogs(t, store,
+				&commonpb.Log{Sequence: 1, Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_CreateLedger{CreateLedger: &commonpb.CreatedLedgerLog{Name: tc.name}}}},
+				&commonpb.Log{Sequence: 2, Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_CreateLedger{CreateLedger: &commonpb.CreatedLedgerLog{Name: "normal"}}}},
+			)
+			realSink, err := events.NewNATSSink(events.NATSSinkConfig{URL: ns.ClientURL(), Topic: "events", Format: events.FormatJSON})
+			require.NoError(t, err)
+			defer func() { require.NoError(t, realSink.Close()) }()
+			sink := &observedNATSSink{NATSSink: realSink, results: make(chan error), resume: make(chan struct{})}
+			cfg := events.DefaultEmitterConfig()
+			cfg.BatchSize = 2 // nil selection includes CREATED_LEDGER and all later events.
+			emitter := events.NewEmitter(store, sink, "nats", &directProposer{store: store}, newPlanBuilder(t, store), logging.Testing(), cfg)
+			healthy := &recordingSink{}
+			second := events.NewEmitter(store, healthy, "second", &directProposer{store: store}, newPlanBuilder(t, store), logging.Testing(), cfg)
+			emitter.Start()
+			defer emitter.Stop()
+			second.Start()
+			defer second.Stop()
+			awaitResult := func() error {
+				select {
+				case err := <-sink.results:
+					return err
+				case <-time.After(10 * time.Second):
+					t.Fatal("no observed NATS publication")
+
+					return nil
+				}
+			}
+			firstErr := awaitResult()
+			cursor, err := query.ReadSinkCursor(store, "nats")
+			require.NoError(t, err)
+			require.Zero(t, cursor, "publication must not be acknowledged before Publish returns")
+			require.Eventually(t, func() bool {
+				c, e := query.ReadSinkCursor(store, "second")
+				return e == nil && c == 2
+			}, 5*time.Second, 10*time.Millisecond)
+			require.Len(t, healthy.getEvents(), 2, "second sink progresses independently")
+			if firstErr != nil {
+				// Diagnostic assertions preserve the fail-before evidence: a second real
+				// retry cannot bypass the invalid subject or acknowledge either event.
+				require.Contains(t, firstErr.Error(), "events."+tc.name+".created_ledger")
+				sink.resume <- struct{}{}
+				retryErr := awaitResult()
+				require.Error(t, retryErr)
+				info, err := stream.Info(t.Context())
+				require.NoError(t, err)
+				require.Zero(t, info.State.Msgs)
+				cursor, err = query.ReadSinkCursor(store, "nats")
+				require.NoError(t, err)
+				require.Zero(t, cursor)
+				t.Logf("two failed real publications; cursor=%d; messages=%d; second sink cursor=2: %v", cursor, info.State.Msgs, firstErr)
+			}
+			require.NoError(t, firstErr, "every admitted ledger name must be routable")
+			sink.resume <- struct{}{}
+			require.Eventually(t, func() bool {
+				c, e := query.ReadSinkCursor(store, "nats")
+				return e == nil && c == 2
+			}, 5*time.Second, 10*time.Millisecond)
+			info, err := stream.Info(t.Context())
+			require.NoError(t, err)
+			require.EqualValues(t, 2, info.State.Msgs)
+			for filter, count := range map[string]uint64{
+				"events.*.created_ledger":                2,
+				"events." + tc.token + ".created_ledger": 1,
+			} {
+				consumer, err := js.CreateConsumer(t.Context(), "EVENTS", jetstream.ConsumerConfig{FilterSubject: filter, AckPolicy: jetstream.AckExplicitPolicy})
+				require.NoError(t, err)
+				consumerInfo, err := consumer.Info(t.Context())
+				require.NoError(t, err)
+				require.Equal(t, count, consumerInfo.NumPending, filter)
+			}
+			for i, want := range []struct{ name, subject string }{{tc.name, "events." + tc.token + ".created_ledger"}, {"normal", "events.normal.created_ledger"}} {
+				msg, err := stream.GetMsg(t.Context(), uint64(i+1))
+				require.NoError(t, err)
+				require.Equal(t, want.subject, msg.Subject)
+				var payload map[string]any
+				require.NoError(t, json.Unmarshal(msg.Data, &payload))
+				require.Equal(t, want.name, payload["ledger"])
+				require.Equal(t, "CREATED_LEDGER", payload["type"])
+				require.Equal(t, float64(i+1), payload["logSequence"])
+			}
+		})
+	}
+}
+
+func TestNATSSinkIntegration_NameRetryAfterStreamRecovery(t *testing.T) {
+	t.Parallel()
+	ns := startTestNATSServer(t)
+	conn, err := nats.Connect(ns.ClientURL())
+	require.NoError(t, err)
+	defer conn.Close()
+	js, err := jetstream.New(conn)
+	require.NoError(t, err)
+	store := newTestStore(t)
+	logs := []*commonpb.Log{
+		{Sequence: 1, Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_CreateLedger{CreateLedger: &commonpb.CreatedLedgerLog{Name: "a..b"}}}},
+		{Sequence: 2, Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_CreateLedger{CreateLedger: &commonpb.CreatedLedgerLog{Name: "normal"}}}},
+	}
+	appendTestLogs(t, store, logs...)
+	realSink, err := events.NewNATSSink(events.NATSSinkConfig{URL: ns.ClientURL(), Topic: "events", Format: events.FormatProto})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, realSink.Close()) }()
+	sink := &observedNATSSink{NATSSink: realSink, results: make(chan error), resume: make(chan struct{})}
+	cfg := events.DefaultEmitterConfig()
+	cfg.BatchSize = 2
+	cfg.EventTypes = map[commonpb.EventType]struct{}{} // Empty also selects all events.
+	emitter := events.NewEmitter(store, sink, "retry", &directProposer{store: store}, newPlanBuilder(t, store), logging.Testing(), cfg)
+	emitter.Start()
+	defer emitter.Stop()
+	awaitResult := func() error {
+		select {
+		case err := <-sink.results:
+			return err
+		case <-time.After(10 * time.Second):
+			t.Fatal("no observed NATS publication")
+
+			return nil
+		}
+	}
+	// A real missing stream produces one failed attempt. Provisioning it is
+	// synchronized before allowing the emitter to retry the same pending batch.
+	err = awaitResult()
+	require.ErrorIs(t, err, jetstream.ErrNoStreamResponse)
+	require.Contains(t, err.Error(), "events.a%2E%2Eb.created_ledger")
+	cursor, err := query.ReadSinkCursor(store, "retry")
+	require.NoError(t, err)
+	require.Zero(t, cursor)
+	createTestStream(t, js, "EVENTS", "events")
+	stream, err := js.Stream(t.Context(), "EVENTS")
+	require.NoError(t, err)
+	info, err := stream.Info(t.Context())
+	require.NoError(t, err)
+	require.Zero(t, info.State.Msgs)
+	sink.resume <- struct{}{}
+	require.NoError(t, awaitResult()) // Exactly the second observed attempt succeeds.
+	sink.resume <- struct{}{}
+	require.Eventually(t, func() bool {
+		c, e := query.ReadSinkCursor(store, "retry")
+		return e == nil && c == 2
+	}, 5*time.Second, 10*time.Millisecond)
+	emitter.Stop()
+	info, err = stream.Info(t.Context())
+	require.NoError(t, err)
+	require.EqualValues(t, 2, info.State.Msgs)
+	for i, name := range []string{"a..b", "normal"} {
+		msg, err := stream.GetMsg(t.Context(), uint64(i+1))
+		require.NoError(t, err)
+		var event eventspb.Event
+		require.NoError(t, event.UnmarshalVT(msg.Data))
+		require.Equal(t, name, event.GetLedger())
+		require.Equal(t, uint64(i+1), event.GetLogSequence())
+		expected, err := events.SerializeEvent(events.LogToEvent(logs[i]), events.FormatProto)
+		require.NoError(t, err)
+		require.Equal(t, expected, msg.Data, "retry must preserve final bytes")
+	}
+}

--- a/internal/application/events/sink_nats_names_integration_test.go
+++ b/internal/application/events/sink_nats_names_integration_test.go
@@ -45,6 +45,18 @@ func (s *observedNATSSink) Publish(ctx context.Context, batch []*eventspb.Event)
 	}
 }
 
+func (s *observedNATSSink) awaitResult(t *testing.T) error {
+	t.Helper()
+	select {
+	case err := <-s.results:
+		return err
+	case <-time.After(10 * time.Second):
+		t.Fatal("no observed NATS publication")
+
+		return nil
+	}
+}
+
 func TestNATSSinkIntegration_AdmittedLedgerNames(t *testing.T) {
 	t.Parallel()
 	for _, tc := range []struct{ name, token string }{
@@ -82,31 +94,23 @@ func TestNATSSinkIntegration_AdmittedLedgerNames(t *testing.T) {
 			defer emitter.Stop()
 			second.Start()
 			defer second.Stop()
-			awaitResult := func() error {
-				select {
-				case err := <-sink.results:
-					return err
-				case <-time.After(10 * time.Second):
-					t.Fatal("no observed NATS publication")
-
-					return nil
-				}
-			}
-			firstErr := awaitResult()
+			firstErr := sink.awaitResult(t)
 			cursor, err := query.ReadSinkCursor(store, "nats")
 			require.NoError(t, err)
 			require.Zero(t, cursor, "publication must not be acknowledged before Publish returns")
 			require.Eventually(t, func() bool {
 				c, e := query.ReadSinkCursor(store, "second")
+
 				return e == nil && c == 2
 			}, 5*time.Second, 10*time.Millisecond)
 			require.Len(t, healthy.getEvents(), 2, "second sink progresses independently")
 			if firstErr != nil {
 				// Diagnostic assertions preserve the fail-before evidence: a second real
 				// retry cannot bypass the invalid subject or acknowledge either event.
-				require.Contains(t, firstErr.Error(), "events."+tc.name+".created_ledger")
+				require.Contains(t, firstErr.Error(), "publishing event seq=1")
+				require.ErrorIs(t, firstErr, jetstream.ErrNoStreamResponse)
 				sink.resume <- struct{}{}
-				retryErr := awaitResult()
+				retryErr := sink.awaitResult(t)
 				require.Error(t, retryErr)
 				info, err := stream.Info(t.Context())
 				require.NoError(t, err)
@@ -120,6 +124,7 @@ func TestNATSSinkIntegration_AdmittedLedgerNames(t *testing.T) {
 			sink.resume <- struct{}{}
 			require.Eventually(t, func() bool {
 				c, e := query.ReadSinkCursor(store, "nats")
+
 				return e == nil && c == 2
 			}, 5*time.Second, 10*time.Millisecond)
 			info, err := stream.Info(t.Context())
@@ -173,19 +178,9 @@ func TestNATSSinkIntegration_NameRetryAfterStreamRecovery(t *testing.T) {
 	emitter := events.NewEmitter(store, sink, "retry", &directProposer{store: store}, newPlanBuilder(t, store), logging.Testing(), cfg)
 	emitter.Start()
 	defer emitter.Stop()
-	awaitResult := func() error {
-		select {
-		case err := <-sink.results:
-			return err
-		case <-time.After(10 * time.Second):
-			t.Fatal("no observed NATS publication")
-
-			return nil
-		}
-	}
 	// A real missing stream produces one failed attempt. Provisioning it is
 	// synchronized before allowing the emitter to retry the same pending batch.
-	err = awaitResult()
+	err = sink.awaitResult(t)
 	require.ErrorIs(t, err, jetstream.ErrNoStreamResponse)
 	require.Contains(t, err.Error(), "events.a%2E%2Eb.created_ledger")
 	cursor, err := query.ReadSinkCursor(store, "retry")
@@ -198,10 +193,11 @@ func TestNATSSinkIntegration_NameRetryAfterStreamRecovery(t *testing.T) {
 	require.NoError(t, err)
 	require.Zero(t, info.State.Msgs)
 	sink.resume <- struct{}{}
-	require.NoError(t, awaitResult()) // Exactly the second observed attempt succeeds.
+	require.NoError(t, sink.awaitResult(t)) // Exactly the second observed attempt succeeds.
 	sink.resume <- struct{}{}
 	require.Eventually(t, func() bool {
 		c, e := query.ReadSinkCursor(store, "retry")
+
 		return e == nil && c == 2
 	}, 5*time.Second, 10*time.Millisecond)
 	emitter.Stop()

--- a/internal/application/events/sink_nats_subject_test.go
+++ b/internal/application/events/sink_nats_subject_test.go
@@ -1,0 +1,45 @@
+//go:build nats
+
+package events
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/ledger/v3/internal/domain"
+	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
+	"github.com/formancehq/ledger/v3/internal/proto/eventspb"
+	"github.com/formancehq/ledger/v3/internal/storage/dal"
+)
+
+func TestNATSSinkSubjectLedgerToken(t *testing.T) {
+	t.Parallel()
+	sink := &NATSSink{topic: "events"}
+	names := []string{"orders", "a..b", ".orders", "orders.", "a.b", "_system", ".", strings.Repeat(".", dal.LedgerNameFixedSize)}
+	// Every admitted character is exercised at both token boundaries.
+	for _, c := range "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:-" {
+		names = append(names, string(c)+"name"+string(c))
+	}
+	seen := map[string]string{}
+	for _, name := range names {
+		require.Nil(t, domain.ValidateLedgerName(name))
+		subject := sink.subject(&eventspb.Event{Ledger: name, Type: commonpb.EventType_CREATED_LEDGER})
+		require.True(t, server.IsValidSubject(subject), subject)
+		parts := strings.Split(subject, ".")
+		require.Len(t, parts, 3)
+		require.NotEqual(t, "_system", parts[1])
+		decoded, err := url.PathUnescape(parts[1])
+		require.NoError(t, err)
+		require.Equal(t, name, decoded)
+		previous, exists := seen[subject]
+		require.False(t, exists, "collision between %q and %q", previous, name)
+		seen[subject] = name
+	}
+	require.Equal(t, "events._system.created_ledger", sink.subject(&eventspb.Event{Type: commonpb.EventType_CREATED_LEDGER}))
+	// Percent is not currently admitted, but must never alias an escaped dot.
+	require.Equal(t, "events.%252E.created_ledger", sink.subject(&eventspb.Event{Ledger: "%2E", Type: commonpb.EventType_CREATED_LEDGER}))
+}

--- a/internal/application/events/sink_nats_subject_test.go
+++ b/internal/application/events/sink_nats_subject_test.go
@@ -19,7 +19,7 @@ import (
 func TestNATSSinkSubjectLedgerToken(t *testing.T) {
 	t.Parallel()
 	sink := &NATSSink{topic: "events"}
-	names := []string{"orders", "a..b", ".orders", "orders.", "a.b", "_system", ".", strings.Repeat(".", dal.LedgerNameFixedSize)}
+	names := []string{"orders", "a..b", ".orders", "orders.", "a.b", "_systemx", ".", strings.Repeat(".", dal.LedgerNameFixedSize)}
 	// Every admitted character is exercised at both token boundaries.
 	for _, c := range "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._:-" {
 		names = append(names, string(c)+"name"+string(c))

--- a/openapi.yml
+++ b/openapi.yml
@@ -183,7 +183,8 @@ paths:
         The ledger name `_` is reserved: all system / non-ledger routes live
         under the `/v3/_/…` segment (e.g. `/v3/_/audit-entries`), so a ledger
         named `_` would be unreachable over REST. Creating it is rejected with a
-        validation error.
+        validation error. The exact name `_system` is also reserved for system
+        events and rejected. Other underscore-prefixed names remain valid.
       operationId: createLedger
       tags:
         - Ledgers


### PR DESCRIPTION
## What changed

Fixes [EN-2023](https://formance-team.atlassian.net/browse/EN-2023). Admitted ledger names such as `a..b`, `.orders` and `orders.` produced empty NATS subject tokens, preventing acknowledgement and blocking later events for that sink. Dots now become `%2E` within a single ledger token; literal percent is escaped first. Payloads and ordinary-name routing are unchanged.

The exact ledger name `_system` is now reserved at admission alongside `_`, for every ledger-scoped write. Similar names such as `_systemx`, `__system` and `_System` remain valid. Empty event ledgers use the `_system` NATS token; no special encoding for a real `_system` ledger is needed.

Additive tests cover admission before consensus, real embedded-broker delivery, exact/wildcard consumers, independent sink cursors and real fail-then-success recovery. The upstream CI internal suite runs NATS-tagged tests with race detection and merges `internal.out`; no separate NATS CI step is needed. Admission, NATS, CLI and API documentation reflect the contract.

## Validation

- Exact-base `agent-check-pr` against `219d78c9ae733f26f761f4a7447810254e837b18`: PASS, including normalization, baseline, tooling race tests and Schemathesis.
- Admission validation and real `Admit` regression tests with `-race`: PASS; reserved names rejected before proposing and nearby names accepted.
- Embedded NATS tests with `-race`: PASS.
- Original fail-before reproduction retained: two failed real publications, zero messages/cursor and independent second-sink progress for invalid raw dot subjects.

## Impact

Exact NATS filters and permissions for dotted ledger names must use the encoded token. `_system` can no longer be created or written to. No persisted format, audited payload, FSM application or restore behavior changes; this is unreleased v3, with no compatibility shim. Current-head CI and renewed bot/human reviews are required before merge.


[EN-2023]: https://formance-team.atlassian.net/browse/EN-2023?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ