### PR TITLE
fix(mirror): preserve ascending HTTP history (EN-2024)

### DIFF
--- a/docs/technical/architecture/subsystems/events-mirror/README.md
+++ b/docs/technical/architecture/subsystems/events-mirror/README.md
@@ -10,7 +10,7 @@ Two leader-only background workers that tail the global log.
 | Document | Description |
 |----------|-------------|
 | [events.md](events.md) | Domain event types and event sink system (NATS, Kafka, ClickHouse, HTTP). |
-| [mirror.md](mirror.md) | Mirror worker that ingests Ledger v2 logs (HTTP or PostgreSQL) into a v3 mirror ledger, with promotion to normal mode at cutover. |
+| [mirror.md](mirror.md) | Mirror worker that ingests Ledger v2 logs (HTTP or PostgreSQL), including ascending boundary-based HTTP continuation and promotion at cutover. |
 | [cel-rewrite.md](cel-rewrite.md) | CEL rewrite engine that transforms transactions during mirror translation (rename addresses, transform metadata, drop transactions). |
 
 Mirror [source initialization and cancellation](mirror.md#source-initialization-and-cancellation)

--- a/docs/technical/architecture/subsystems/events-mirror/mirror.md
+++ b/docs/technical/architecture/subsystems/events-mirror/mirror.md
@@ -79,10 +79,28 @@ Two concrete implementations:
 
 | Adapter | Mechanism | File |
 |---------|-----------|------|
-| HTTP | `GET /v2/{ledger}/logs?pageSize=X&after=Y` against a v2 server, OAuth2 credentials supported | `source_http.go:14-88` |
+| HTTP | `GET /v2/{ledger}/logs` with `pageSize`, `sort=id:asc`, and a numeric `query` filter `{"$gt":{"id":Y}}`, OAuth2 credentials supported | `source_http.go` |
 | PostgreSQL | Direct `SELECT` on the v2 `{bucket}.logs` table; the v2 schema is discovered via `_system.ledgers` | `source_postgres.go:17-79` |
 
 Both adapters return v2 log entries in their native shape; translation to v3 orders happens upstream of the source interface.
+
+Ingestion must return the oldest available logs strictly after the supplied
+boundary, so replaying history cannot replace available transactions with
+synthetic gaps (EN-2024). The HTTP adapter uses the public sort and numeric
+ID-filter contract supported by Ledger v2.4.7. That API defaults to descending
+order and ignores `after`; reversing a truncated descending page would still
+omit older history. Every fetch builds a new ascending query from `afterID`,
+including after an empty tail, a retry, or worker restart. It does not retain
+the response's opaque continuation token. `LedgerBoundaries` remains the only
+durable ingestion position, and a speculative prefetch cannot advance it.
+The numeric filter preserves uint64 precision and needs no `afterID + 1`
+arithmetic. `GetLatestLogID` separately requests `sort=id:desc&pageSize=1`
+without a boundary filter; an ingestion batch of size one still reads ascending.
+
+The HTTP regression fixture follows upstream's default descending order,
+explicit sort/filter, and lookahead pagination independently of page size.
+Tests cover multiple pages, nonzero-boundary resume, append after an empty
+tail, fail-then-success fetching, large IDs, and absence of fabricated gaps.
 
 ## The translation layer
 

--- a/internal/adapter/v2/source_http.go
+++ b/internal/adapter/v2/source_http.go
@@ -67,10 +67,11 @@ func (s *HTTPSource) doGet(ctx context.Context, path string, query url.Values) (
 func (s *HTTPSource) FetchLogs(ctx context.Context, afterID uint64, pageSize int) ([]V2Log, bool, error) {
 	q := url.Values{}
 	q.Set("pageSize", strconv.Itoa(pageSize))
-
-	if afterID > 0 {
-		q.Set("after", strconv.FormatUint(afterID, 10))
-	}
+	q.Set("sort", "id:asc")
+	// v2 supports a numeric query filter, not an "after" parameter. Rebuild
+	// the query from the applied boundary on every fetch, including after an
+	// empty tail or a failed batch; no HTTP cursor becomes a second authority.
+	q.Set("query", fmt.Sprintf(`{"$gt":{"id":%d}}`, afterID))
 
 	resp, err := s.doGet(ctx, "logs", q)
 	if err != nil {
@@ -92,6 +93,7 @@ func (s *HTTPSource) FetchLogs(ctx context.Context, afterID uint64, pageSize int
 func (s *HTTPSource) GetLatestLogID(ctx context.Context) (uint64, error) {
 	q := url.Values{}
 	q.Set("pageSize", "1")
+	q.Set("sort", "id:desc")
 
 	resp, err := s.doGet(ctx, "logs", q)
 	if err != nil {

--- a/internal/adapter/v2/source_http_pagination_test.go
+++ b/internal/adapter/v2/source_http_pagination_test.go
@@ -1,0 +1,183 @@
+package v2
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// upstreamLogFixture models v2.4.7's initial log query: descending by default,
+// explicit sort, query filters, and a pageSize+1 lookahead. Unknown parameters
+// (notably after) do not change the result. It never infers ordering from size.
+type upstreamLogFixture struct {
+	mu       sync.Mutex
+	logs     []V2Log
+	requests []string
+	failNext bool
+}
+
+func (f *upstreamLogFixture) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.requests = append(f.requests, r.URL.RawQuery)
+	if f.failNext {
+		f.failNext = false
+		http.Error(w, "injected fetch failure", http.StatusServiceUnavailable)
+		return
+	}
+	size, err := strconv.Atoi(r.URL.Query().Get("pageSize"))
+	if err != nil || size <= 0 {
+		http.Error(w, "invalid pageSize", 400)
+		return
+	}
+	var filter struct {
+		GT struct {
+			ID uint64 `json:"id"`
+		} `json:"$gt"`
+	}
+	if q := r.URL.Query().Get("query"); q != "" {
+		if err := json.Unmarshal([]byte(q), &filter); err != nil {
+			http.Error(w, err.Error(), 400)
+			return
+		}
+	}
+	var logs []V2Log
+	for _, log := range f.logs {
+		if r.URL.Query().Get("query") == "" || log.ID > filter.GT.ID {
+			logs = append(logs, log)
+		}
+	}
+	slices.SortFunc(logs, func(a, b V2Log) int {
+		if a.ID < b.ID {
+			return -1
+		}
+		if a.ID > b.ID {
+			return 1
+		}
+		return 0
+	})
+	if r.URL.Query().Get("sort") != "id:asc" {
+		slices.Reverse(logs)
+	}
+	more := len(logs) > size
+	if more {
+		logs = logs[:size]
+	}
+	w.Header().Set("Content-Type", "application/json")
+	// A real server also returns opaque next/previous tokens. The adapter's
+	// boundary-based request must not depend on a token retained by this fixture.
+	_ = json.NewEncoder(w).Encode(V2LogPage{Cursor: V2LogCursor{Data: logs, PageSize: size, HasMore: more}})
+}
+
+func TestHTTPSource_AscendingHistory(t *testing.T) {
+	t.Parallel()
+	fixture := &upstreamLogFixture{}
+	for id := uint64(1); id <= 3; id++ {
+		fixture.logs = append(fixture.logs, V2Log{ID: id, Type: "NEW_TRANSACTION", Date: "2024-01-01T00:00:00Z", Data: json.RawMessage(`{"transaction":{"id":` + strconv.FormatUint(id-1, 10) + `,"postings":[{"source":"world","destination":"users:001","amount":100,"asset":"USD/2"}],"timestamp":"2024-01-01T00:00:00Z"}}`)})
+	}
+	srv := httptest.NewServer(fixture)
+	defer srv.Close()
+	source := NewHTTPSource(srv.URL, "default", srv.Client())
+	ctx := context.Background()
+	logs, more, err := source.FetchLogs(ctx, 0, 2)
+	require.NoError(t, err)
+	require.True(t, more)
+	orders, _, _, err := TranslateBatch("mirror", logs, 1, 0, nil)
+	require.NoError(t, err)
+	// This is the lossy branch: descending [3,2] translates successfully but
+	// fabricates gaps for available logs 1 and 2 before replaying the real log 2.
+	for _, order := range orders {
+		require.Nil(t, order.GetLedgerScoped().GetMirrorIngest().GetEntry().GetFillGap(), "available source history became a synthetic gap; fetched IDs: %v", logIDs(logs))
+	}
+	require.Equal(t, []uint64{1, 2}, logIDs(logs))
+
+	// A new source instance resumes from the confirmed nonzero boundary.
+	source = NewHTTPSource(srv.URL, "default", srv.Client())
+	logs, more, err = source.FetchLogs(ctx, 2, 2)
+	require.NoError(t, err)
+	require.False(t, more)
+	require.Equal(t, []uint64{3}, logIDs(logs))
+	logs, more, err = source.FetchLogs(ctx, 3, 2)
+	require.NoError(t, err)
+	require.False(t, more)
+	require.Empty(t, logs)
+
+	fixture.mu.Lock()
+	fixture.logs = append(fixture.logs, V2Log{ID: 4})
+	fixture.failNext = true
+	before := len(fixture.requests)
+	fixture.mu.Unlock()
+	_, _, err = source.FetchLogs(ctx, 3, 2)
+	require.ErrorContains(t, err, "503")
+	logs, more, err = source.FetchLogs(ctx, 3, 2)
+	require.NoError(t, err)
+	require.False(t, more)
+	require.Equal(t, []uint64{4}, logIDs(logs))
+	fixture.mu.Lock()
+	requests := slices.Clone(fixture.requests)
+	fixture.mu.Unlock()
+	require.Len(t, requests, before+2)
+	require.Equal(t, requests[before], requests[before+1], "failed fetch must retry the same boundary")
+
+	latest, err := source.GetLatestLogID(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(4), latest)
+	logs, more, err = source.FetchLogs(ctx, 0, 1)
+	require.NoError(t, err)
+	require.True(t, more)
+	require.Equal(t, []uint64{1}, logIDs(logs), "pageSize=1 ingestion must differ from a head probe")
+}
+
+func logIDs(logs []V2Log) []uint64 {
+	ids := make([]uint64, len(logs))
+	for i, log := range logs {
+		ids[i] = log.ID
+	}
+	return ids
+}
+
+func TestHTTPSource_LargeBoundary(t *testing.T) {
+	t.Parallel()
+	for _, boundary := range []uint64{1<<53 + 1, ^uint64(0) - 1, ^uint64(0)} {
+		t.Run(strconv.FormatUint(boundary, 10), func(t *testing.T) {
+			t.Parallel()
+			fixture := &upstreamLogFixture{logs: []V2Log{{ID: boundary}}}
+			var expected []uint64
+			if boundary != ^uint64(0) {
+				fixture.logs = append(fixture.logs, V2Log{ID: boundary + 1})
+				expected = []uint64{boundary + 1}
+			}
+			srv := httptest.NewServer(fixture)
+			defer srv.Close()
+			logs, more, err := NewHTTPSource(srv.URL, "default", srv.Client()).FetchLogs(context.Background(), boundary, 2)
+			require.NoError(t, err)
+			require.False(t, more)
+			if expected == nil {
+				require.Empty(t, logs)
+			} else {
+				require.Equal(t, expected, logIDs(logs))
+			}
+		})
+	}
+}
+
+func TestUpstreamLogFixture_DefaultDescendingIgnoresAfter(t *testing.T) {
+	t.Parallel()
+	fixture := &upstreamLogFixture{logs: []V2Log{{ID: 1}, {ID: 2}, {ID: 3}}}
+	for _, query := range []string{"pageSize=2", "pageSize=2&after=2"} {
+		recorder := httptest.NewRecorder()
+		fixture.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/v2/default/logs?"+query, nil))
+		require.Equal(t, http.StatusOK, recorder.Code)
+		var page V2LogPage
+		require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &page))
+		require.Equal(t, []uint64{3, 2}, logIDs(page.Cursor.Data))
+		require.True(t, page.Cursor.HasMore)
+	}
+}

--- a/internal/adapter/v2/source_http_pagination_test.go
+++ b/internal/adapter/v2/source_http_pagination_test.go
@@ -30,11 +30,13 @@ func (f *upstreamLogFixture) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if f.failNext {
 		f.failNext = false
 		http.Error(w, "injected fetch failure", http.StatusServiceUnavailable)
+
 		return
 	}
 	size, err := strconv.Atoi(r.URL.Query().Get("pageSize"))
 	if err != nil || size <= 0 {
-		http.Error(w, "invalid pageSize", 400)
+		http.Error(w, "invalid pageSize", http.StatusBadRequest)
+
 		return
 	}
 	var filter struct {
@@ -44,7 +46,8 @@ func (f *upstreamLogFixture) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	if q := r.URL.Query().Get("query"); q != "" {
 		if err := json.Unmarshal([]byte(q), &filter); err != nil {
-			http.Error(w, err.Error(), 400)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+
 			return
 		}
 	}
@@ -61,6 +64,7 @@ func (f *upstreamLogFixture) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		if a.ID > b.ID {
 			return 1
 		}
+
 		return 0
 	})
 	if r.URL.Query().Get("sort") != "id:asc" {
@@ -73,7 +77,9 @@ func (f *upstreamLogFixture) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	// A real server also returns opaque next/previous tokens. The adapter's
 	// boundary-based request must not depend on a token retained by this fixture.
-	_ = json.NewEncoder(w).Encode(V2LogPage{Cursor: V2LogCursor{Data: logs, PageSize: size, HasMore: more}})
+	if err := json.NewEncoder(w).Encode(V2LogPage{Cursor: V2LogCursor{Data: logs, PageSize: size, HasMore: more}}); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
 }
 
 func TestHTTPSource_AscendingHistory(t *testing.T) {
@@ -140,6 +146,7 @@ func logIDs(logs []V2Log) []uint64 {
 	for i, log := range logs {
 		ids[i] = log.ID
 	}
+
 	return ids
 }
 

--- a/internal/adapter/v2/source_http_test.go
+++ b/internal/adapter/v2/source_http_test.go
@@ -21,6 +21,7 @@ func TestHTTPSource_FetchLogs_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/v2/default/logs", r.URL.Path)
 		require.Equal(t, "10", r.URL.Query().Get("pageSize"))
+		require.Equal(t, "id:asc", r.URL.Query().Get("sort"))
 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(V2LogPage{
@@ -49,7 +50,8 @@ func TestHTTPSource_FetchLogs_WithAfterID(t *testing.T) {
 	t.Parallel()
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "5", r.URL.Query().Get("after"))
+		require.JSONEq(t, `{"$gt":{"id":5}}`, r.URL.Query().Get("query"))
+		require.Empty(t, r.URL.Query().Get("after"))
 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(V2LogPage{
@@ -151,6 +153,8 @@ func TestHTTPSource_GetLatestLogID_Success(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, "/v2/default/logs", r.URL.Path)
 		require.Equal(t, "1", r.URL.Query().Get("pageSize"))
+		require.Equal(t, "id:desc", r.URL.Query().Get("sort"))
+		require.Empty(t, r.URL.Query().Get("query"))
 
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(V2LogPage{

--- a/tests/e2e/cluster/mirror_test.go
+++ b/tests/e2e/cluster/mirror_test.go
@@ -9,6 +9,8 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"slices"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -83,23 +85,9 @@ func (m *mockV2Server) resume() {
 	m.gate.Unlock()
 }
 
-// handler serves the two shapes the mirror worker issues against /logs, which
-// disagree about ordering and are distinguishable only by pageSize:
-//
-//   - HTTPSource.GetLatestLogID sends pageSize=1 with no "after" and reads
-//     Data[0] as the NEWEST log. PostgresSource implements the same interface
-//     method as SELECT MAX(id), so "newest" is the contract, and serving this
-//     shape ascending would report the OLDEST log as the source head — making
-//     MirrorSyncProgress.SourceLogCount unassertable and FOLLOWING satisfiable
-//     by any non-zero head.
-//   - HTTPSource.FetchLogs pages forward with "after" and needs ASCENDING
-//     logs; TranslateBatch enforces source-log-id contiguity. It also omits
-//     "after" when resuming from 0, which is why pageSize is the discriminator
-//     here rather than the presence of "after".
-//
-// That the two production call sites make opposite ordering assumptions about
-// the same request shape is a real question about the v2 API contract, not a
-// fixture concern. It is out of scope for this suite.
+// handler models the v2.4.7 public log-list contract: descending by default,
+// explicit ascending sort, and a numeric id filter. Page size never selects
+// ordering, and the unsupported "after" parameter is ignored by upstream.
 func (m *mockV2Server) handler(w http.ResponseWriter, r *http.Request) {
 	// Park before the counter moves, so a paused mock leaves requestCount
 	// untouched. See pause.
@@ -111,39 +99,52 @@ func (m *mockV2Server) handler(w http.ResponseWriter, r *http.Request) {
 
 	m.requests++
 
-	// Parse "after" query param
-	afterStr := r.URL.Query().Get("after")
-	var afterID uint64
-	if afterStr != "" {
-		_, _ = fmt.Sscanf(afterStr, "%d", &afterID)
-	}
-
-	// Respect pageSize
-	pageSizeStr := r.URL.Query().Get("pageSize")
+	q := r.URL.Query()
 	pageSize := 100
-	if pageSizeStr != "" {
-		_, _ = fmt.Sscanf(pageSizeStr, "%d", &pageSize)
+	if raw := q.Get("pageSize"); raw != "" {
+		var err error
+		pageSize, err = strconv.Atoi(raw)
+		if err != nil || pageSize <= 0 {
+			http.Error(w, "invalid pageSize", http.StatusBadRequest)
+			return
+		}
 	}
 
-	// Filter logs after the given ID (ascending order)
+	var afterID uint64
+	if raw := q.Get("query"); raw != "" {
+		var filter struct {
+			GT struct {
+				ID uint64 `json:"id"`
+			} `json:"$gt"`
+		}
+		if err := json.Unmarshal([]byte(raw), &filter); err != nil {
+			http.Error(w, "invalid query", http.StatusBadRequest)
+			return
+		}
+		afterID = filter.GT.ID
+	}
+
 	var result []v2.V2Log
 	for _, log := range m.logs {
-		if log.ID > afterID {
+		if q.Get("query") == "" || log.ID > afterID {
 			result = append(result, log)
 		}
 	}
-
-	hasMore := false
-
-	if pageSize == 1 && afterStr == "" {
-		// Head probe: answer newest-first, as the contract requires.
-		if len(result) > 0 {
-			result = []v2.V2Log{result[len(result)-1]}
-			hasMore = len(m.logs) > 1
+	slices.SortFunc(result, func(a, b v2.V2Log) int {
+		if a.ID < b.ID {
+			return -1
 		}
-	} else if len(result) > pageSize {
+		if a.ID > b.ID {
+			return 1
+		}
+		return 0
+	})
+	if q.Get("sort") != "id:asc" {
+		slices.Reverse(result)
+	}
+	hasMore := len(result) > pageSize
+	if hasMore {
 		result = result[:pageSize]
-		hasMore = true
 	}
 
 	w.Header().Set("Content-Type", "application/json")
@@ -456,6 +457,59 @@ var _ = Describe("Mirror", Ordered, func() {
 		})
 	})
 
+	It("Should preserve every transaction across ascending HTTP pages and a tail append", func() {
+		mockV2 := newMockV2Server()
+		DeferCleanup(mockV2.Close)
+		const ledgerName = "mirror-http-pagination"
+		for id := uint64(1); id <= 3; id++ {
+			mockV2.addLog(newV2TransactionLog(id, id-1, "world", fmt.Sprintf("users:%d", id), strconv.FormatUint(id*100, 10), "USD/2"))
+		}
+		_, err := client.Apply(ctx, servicepb.UnsignedApplyRequest("", &servicepb.Request{
+			Type: &servicepb.Request_CreateLedger{
+				CreateLedger: &servicepb.CreateLedgerRequest{
+					Name: ledgerName,
+					Mode: commonpb.LedgerMode_LEDGER_MODE_MIRROR,
+					MirrorSource: &commonpb.MirrorSourceConfig{
+						LedgerName: "default",
+						BatchSize:  2,
+						Type: &commonpb.MirrorSourceConfig_Http{
+							Http: &commonpb.HttpMirrorSourceConfig{BaseUrl: mockV2.URL()},
+						},
+					},
+				},
+			},
+		}))
+		Expect(err).To(Succeed())
+
+		assertSynced := func(count uint64) {
+			Eventually(func(g Gomega) {
+				txs, err := listAllTransactions(ctx, client, ledgerName, 10, 0)
+				g.Expect(err).To(Succeed())
+				g.Expect(txs).To(HaveLen(int(count)), "every real transaction must survive; a reached cursor alone can hide synthetic gaps")
+				byID := make(map[uint64]*commonpb.Transaction, len(txs))
+				for _, tx := range txs {
+					byID[tx.GetId()] = tx
+				}
+				for id := uint64(0); id < count; id++ {
+					g.Expect(byID).To(HaveKey(id))
+					g.Expect(byID[id].GetPostings()).To(HaveLen(1))
+					g.Expect(byID[id].GetPostings()[0].GetDestination()).To(Equal(fmt.Sprintf("users:%d", id+1)))
+				}
+				info, err := client.GetLedger(ctx, &servicepb.GetLedgerRequest{Ledger: ledgerName})
+				g.Expect(err).To(Succeed())
+				g.Expect(info.GetMirrorSyncProgress().GetCursor()).To(Equal(count))
+				g.Expect(info.GetMirrorSyncProgress().GetSourceLogCount()).To(Equal(count))
+			}).Within(20 * time.Second).ProbeEvery(250 * time.Millisecond).Should(Succeed())
+		}
+		assertSynced(3)
+
+		// After reaching the tail, continue from the nonzero durable boundary.
+		// A retained exhausted page cursor must not hide newly appended logs.
+		mockV2.addLog(newV2TransactionLog(4, 3, "world", "users:4", "400", "USD/2"))
+		mockV2.addLog(newV2TransactionLog(5, 4, "world", "users:5", "500", "USD/2"))
+		assertSynced(5)
+	})
+
 	Context("When syncing with CEL rewrite rules", Ordered, func() {
 		var mockV2 *mockV2Server
 
@@ -497,10 +551,10 @@ var _ = Describe("Mirror", Ordered, func() {
 									Actions: []*commonpb.CreatedTransactionAction{{
 										Action: &commonpb.CreatedTransactionAction_SetMetadata{
 											SetMetadata: &commonpb.SetMetadataAction{
-											Key:    "mirrored",
-											Source: &commonpb.SetMetadataAction_Value{Value: "true"},
+												Key:    "mirrored",
+												Source: &commonpb.SetMetadataAction_Value{Value: "true"},
+											},
 										},
-									},
 									}},
 								}}},
 								// Never mirror transactions flagged skip=yes.


### PR DESCRIPTION
## What changed

HTTP mirror ingestion now requests `sort=id:asc` with the public numeric filter `query={"$gt":{"id":boundary}}`. Each request derives its position from the supplied boundary; the source retains no HTTP cursor. Latest-ID probes explicitly request descending order.

The HTTP fixture now follows v2.4.7's descending default independently of page size. Additive regressions cover multiple pages, nonzero-boundary resume, tail append, fail-then-success fetching, large uint64 IDs, head probes and complete destination transactions.

## Why

Fixes [EN-2024](https://formance-team.atlassian.net/browse/EN-2024). With source logs 1–3 and batch size 2, the previous request returned `[3,2]`, and translation silently synthesized gaps for available logs 1 and 2. Revert decoding (EN-2025) is outside this PR.

## Product / operational motivation

Need: preserve all available transaction history during v2 migration.
Requirement: fetch the oldest available logs strictly after the applied boundary without fabricating missing history.
Evidence: reproduced the exact `[3,2]` → `FillGap` branch before the production fix; upstream v2.4.7 source checked at `6fc0fe23682e1f0915729d8c3a6814fd7ef34752`.
Durable repository evidence: `docs/technical/architecture/subsystems/events-mirror/mirror.md`, source comments and pagination regressions.

## Technical decision

Use v2's supported sort and numeric ID filter on every fetch, including restart, retry and empty-tail polling. This keeps `LedgerBoundaries` as the only durable position. Page reversal would still omit older history; retaining an opaque cursor is unnecessary. Numeric JSON preserves uint64 precision and requires no increment arithmetic.

## Risk

**LOW** — confined to HTTP source requests and test fixtures. No persisted format, protobuf, service protocol, FSM or CEL behavior changes.

## Validation

- Fail-before: `TestHTTPSource_AscendingHistory` failed because `[3,2]` produced a synthetic gap for available history; translation itself succeeded.
- `bash scripts/agent-check`: PASS.
- `go test -race` for v2, CEL, mirror worker and processing: PASS.
- `go test -race -tags=e2e ./tests/e2e/cluster -run TestCluster -ginkgo.focus=Mirror -ginkgo.fail-fast`: PASS, including all original mirror cases and the new multipage/tail scenario.
- `AI_REVIEW_BASE_SHA=a69f7244942245159a31ddd3774a5ea859c1fe99 bash scripts/agent-check-pr`: see known concerns below.
- Repository-pinned Nix tools and normal bounded shared caches used throughout. No live customer source, deployment or Antithesis cloud run.

## Architecture / behavior impact

HTTP requests now match the upstream continuation contract. Durable ingestion advancement still occurs only through successful FSM application; no additional cursor is persisted or cached.

## Review focus

Supported upstream query semantics, boundary-derived retry/resume, and fixture fidelity. Destination E2E assertions require every source transaction and the applied progress, so an advanced cursor alone cannot conceal fabricated gaps.

## Known concerns

No blocking findings. Live upstream v2-server testing was not performed; the v2.4.7 contract was verified against immutable upstream sources, with local fixture and destination-cluster runtime coverage. Shipfox's optional fixture-factoring comment was reviewed; no correctness repair was needed.

Final candidate `6b96ead19c33b622224b034790e6e723712ac24d`: canonical `agent-check-pr` on exact base `a69f7244942245159a31ddd3774a5ea859c1fe99` PASS, including normalization/lint, baseline, focused race, full E2E and Schemathesis. GitHub CI is green. NumaryBot explicitly approves without findings; Shipfox approves with non-blocking comments, addressed with source evidence. Initial query compilation and fixture lint failures have been resolved by the base update and dedicated fixture fix respectively.


[EN-2024]: https://formance-team.atlassian.net/browse/EN-2024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ