### PR TITLE
fix(bootstrap): shut down on fatal HTTP serve errors (EN-1995)

### DIFF
--- a/cmd/server/http_failure_test.go
+++ b/cmd/server/http_failure_test.go
@@ -1,0 +1,169 @@
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/formancehq/go-libs/v5/pkg/service"
+
+	"github.com/formancehq/ledger/v3/internal/pkg/network"
+)
+
+const httpFailureHelperEnv = "LEDGER_HTTP_FAILURE_HELPER"
+const httpFailureSentinel = "EN-1995 injected permanent accept failure"
+
+// Exercise the production command, module wiring, service runner and process
+// exit together. A helper process isolates service.Execute's os.Exit call.
+func TestHTTPServeFailureStopsServerProcess(t *testing.T) {
+	if mode := os.Getenv(httpFailureHelperEnv); mode != "" {
+		runHTTPFailureHelper(t, mode)
+
+		return
+	}
+	t.Parallel()
+
+	for _, mode := range []string{"normal", "restore"} {
+		t.Run(mode, func(t *testing.T) {
+			t.Parallel()
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+			defer cancel()
+			command := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestHTTPServeFailureStopsServerProcess$")
+			command.Env = append(os.Environ(), httpFailureHelperEnv+"="+mode, "LEDGER_HTTP_FAILURE_DIR="+t.TempDir())
+			input, err := command.StdinPipe()
+			require.NoError(t, err)
+			output, err := command.StdoutPipe()
+			require.NoError(t, err)
+			command.Stderr = command.Stdout
+			require.NoError(t, command.Start())
+			waited := false
+			var waitErr error
+			wait := func() error {
+				if !waited {
+					waitErr = command.Wait()
+					waited = true
+				}
+
+				return waitErr
+			}
+			defer func() {
+				cancel()
+				_ = wait() // Reap the helper even when an earlier assertion fails.
+			}()
+
+			ready := make(chan string, 1)
+			captured := make(chan string, 1)
+			go func() {
+				var log bytes.Buffer
+				scanner := bufio.NewScanner(output)
+				for scanner.Scan() {
+					line := scanner.Text()
+					fmt.Fprintln(&log, line)
+					if address, ok := strings.CutPrefix(line, "HTTP_FAILURE_ADDRESS="); ok {
+						ready <- address
+					}
+				}
+				captured <- log.String()
+			}()
+
+			select {
+			case address := <-ready:
+				path := "/readyz"
+				if mode == "restore" {
+					path = "/health"
+				}
+				client := &http.Client{Timeout: time.Second}
+				require.Eventually(t, func() bool {
+					response, requestErr := client.Get("http://" + address + path)
+					if requestErr != nil {
+						return false
+					}
+					_ = response.Body.Close() // Only the readiness status is needed.
+
+					return response.StatusCode == http.StatusOK
+				}, 20*time.Second, 20*time.Millisecond, "server must become ready before injecting the failure")
+				_, err = io.WriteString(input, "fail\n")
+				require.NoError(t, err)
+			case log := <-captured:
+				_ = wait()
+				t.Fatalf("server exited before reaching HTTP Accept:\n%s", log)
+			case <-ctx.Done():
+				_ = wait()
+				t.Fatalf("server did not reach HTTP Accept:\n%s", <-captured)
+			}
+			_ = input.Close() // The injected failure needs only the first input byte.
+			log := <-captured
+			err = wait()
+			require.NoError(t, ctx.Err(), "server remained alive after permanent HTTP failure:\n%s", log)
+			var exitErr *exec.ExitError
+			require.ErrorAs(t, err, &exitErr, "server must exit unsuccessfully:\n%s", log)
+			require.Equal(t, 1, exitErr.ExitCode(), log)
+			require.Contains(t, log, httpFailureSentinel)
+			require.Contains(t, log, "App stopped!", "service runner must finish its shutdown path")
+			if mode == "normal" {
+				require.Contains(t, log, "Raft cluster stopped successfully", "HTTP failure must run application cleanup")
+			}
+		})
+	}
+}
+
+type controlledHTTPFailureListener struct {
+	net.Listener
+
+	failed atomic.Bool
+}
+
+func (l *controlledHTTPFailureListener) Accept() (net.Conn, error) {
+	connection, err := l.Listener.Accept()
+	if err != nil && l.failed.Load() {
+		return nil, errors.New(httpFailureSentinel)
+	}
+
+	return connection, err
+}
+
+func runHTTPFailureHelper(t *testing.T, mode string) {
+	t.Helper()
+	listen := func() net.Listener {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+
+		return listener
+	}
+	httpListener, serviceListener, raftListener := listen(), listen(), listen()
+	controlled := &controlledHTTPFailureListener{Listener: httpListener}
+	go func() {
+		var control [1]byte
+		if _, err := os.Stdin.Read(control[:]); err == nil {
+			controlled.failed.Store(true)
+			_ = controlled.Close() // Force Accept to return the injected permanent failure.
+		}
+	}()
+	fmt.Println("HTTP_FAILURE_ADDRESS=" + httpListener.Addr().String())
+	command := NewRunCommandWithBindings(network.Bindings{
+		HTTP: controlled, Service: serviceListener, Raft: raftListener,
+	})
+	dataDir := os.Getenv("LEDGER_HTTP_FAILURE_DIR")
+	args := []string{"--node-id=1", "--cluster-id=http-failure-test", "--data-dir=" + filepath.Join(dataDir, "data"), "--wal-dir=" + filepath.Join(dataDir, "wal"), "--bind-addr=" + raftListener.Addr().String()}
+	if mode == "restore" {
+		args = append(args, "--restore")
+	} else {
+		args = append(args, "--bootstrap")
+	}
+	command.SetArgs(args)
+	service.Execute(command)
+}

--- a/docs/technical/architecture/subsystems/api/README.md
+++ b/docs/technical/architecture/subsystems/api/README.md
@@ -9,7 +9,7 @@ Client-facing transport layers (`internal/adapter/grpc`, `internal/adapter/http`
 | [grpc-api.md](grpc-api.md) | gRPC service, methods, request/response types, type-owned public error details, client examples, and restore-mode service lifetime. |
 | [grpc-connections.md](grpc-connections.md) | gRPC connection mechanics, reconnection, and rolling deployment optimizations. |
 | [protocol-compatibility.md](protocol-compatibility.md) | Mandatory service protocol revision, client/server rejection behavior, diagnostics, and revision maintenance (EN-1851). |
-| [http-api.md](http-api.md) | HTTP REST API endpoints, single-decoding metadata key paths, response formats, exact metadata number decoding, ledger-log JSON output and discriminators, error handling, and the `apierr`/`grpcerr` error boundary crossed by a forwarded write. |
+| [http-api.md](http-api.md) | HTTP endpoint lifecycle and failure shutdown, REST API endpoints, single-decoding metadata key paths, response formats, exact metadata number decoding, ledger-log JSON output and discriminators, error handling, and the `apierr`/`grpcerr` error boundary crossed by a forwarded write. |
 | [auth.md](auth.md) | Client JWT authentication (OIDC + Ed25519), scope-based authorization, and the Raft inter-node cluster-secret auth layer. |
 
 Decoded leader errors retain their exact gRPC status through routing wrappers

--- a/docs/technical/architecture/subsystems/api/http-api.md
+++ b/docs/technical/architecture/subsystems/api/http-api.md
@@ -7,6 +7,16 @@ Ledger v3 exposes two types of APIs:
 1. **HTTP REST API**: Public API for clients (documented here)
 2. **gRPC API**: Inter-node communication and programmatic API (see [gRPC API](grpc-api.md))
 
+## HTTP server lifecycle
+
+Normal and restore mode supervise the HTTP endpoint through the bootstrap
+lifecycle. Listener bind errors fail startup synchronously. An unexpected
+`http.Server.Serve` error requests application shutdown and is returned during
+cleanup, causing the service runner to exit unsuccessfully. Normal shutdown
+ignores `http.ErrServerClosed` and drains active requests within the stop context.
+Temporary accept errors remain subject to the standard HTTP server retry policy.
+The endpoint retains its 10-second header read timeout and 120-second idle timeout.
+
 ## HTTP REST API
 
 ### Base URL

--- a/internal/bootstrap/http_server_hook.go
+++ b/internal/bootstrap/http_server_hook.go
@@ -1,0 +1,72 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"go.uber.org/fx"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+	"github.com/formancehq/go-libs/v5/pkg/transport/serverport"
+
+	"github.com/formancehq/ledger/v3/internal/infra/monitoring/otlplogs"
+)
+
+// httpServerHook owns the HTTP endpoint in both normal and restore mode.
+// An unexpected Serve failure requests shutdown immediately and is retained for
+// OnStop so the service runner reports an unsuccessful exit.
+func httpServerHook(handler http.Handler, listener net.Listener, address string, logger logging.Logger, requestShutdown func() error) fx.Hook {
+	port := serverport.NewServer("http", serverport.WithListener(listener), serverport.WithAddress(address))
+	server := &http.Server{
+		Handler:           handler,
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       120 * time.Second,
+	}
+	var (
+		wait     func()
+		serveErr error
+	)
+
+	return fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			if requestShutdown == nil {
+				return errors.New("HTTP server: no shutdown requester wired into the hook")
+			}
+			if err := port.Listen(ctx); err != nil {
+				return fmt.Errorf("HTTP server: %w", err)
+			}
+			wait = otlplogs.GoWait(func() {
+				err := server.Serve(port.Listener)
+				if errors.Is(err, http.ErrServerClosed) {
+					return
+				}
+				if err == nil {
+					err = errors.New("Serve returned without an error")
+				}
+				serveErr = fmt.Errorf("HTTP server stopped serving: %w", err)
+				logger.Errorf("%v", serveErr)
+				if err := requestShutdown(); err != nil {
+					logger.Errorf("HTTP server: requesting application shutdown: %v", err)
+				}
+			}, logger)
+			logger.Info("HTTP server started")
+
+			return nil
+		},
+		OnStop: func(ctx context.Context) error {
+			if wait == nil {
+				return errors.New("HTTP server: OnStop ran without a completed OnStart")
+			}
+			err := server.Shutdown(ctx)
+			// Shutdown closes the listener even if request draining times out. Joining
+			// Serve publishes serveErr before it is read here.
+			wait()
+
+			return errors.Join(err, serveErr)
+		},
+	}
+}

--- a/internal/bootstrap/http_server_hook_controls_test.go
+++ b/internal/bootstrap/http_server_hook_controls_test.go
@@ -1,0 +1,200 @@
+package bootstrap
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+func TestHTTPServerHookOccupiedAddressFailsStart(t *testing.T) {
+	t.Parallel()
+	occupied := mustListenLoopback(t, 0)
+	var shutdowns atomic.Int32
+	hook := httpServerHook(http.NotFoundHandler(), nil, occupied.Addr().String(), logging.Testing(), func() error {
+		shutdowns.Add(1)
+
+		return nil
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := hook.OnStart(ctx)
+	require.Error(t, err)
+	var opErr *net.OpError
+	require.ErrorAs(t, err, &opErr)
+	require.Equal(t, "listen", opErr.Op)
+	require.Zero(t, shutdowns.Load(), "synchronous bind failures must be returned by OnStart")
+}
+
+func TestHTTPServerHookGracefulStopDrainsRequest(t *testing.T) {
+	t.Parallel()
+	listener := &httpControlListener{Listener: mustListenLoopback(t, 0), closed: make(chan struct{})}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(release) })
+	var shutdowns atomic.Int32
+	hook := httpServerHook(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		close(entered)
+		<-release
+		_, _ = io.WriteString(w, "drained") // The response is verified by the client below.
+	}), listener, "", logging.Testing(), func() error {
+		shutdowns.Add(1)
+
+		return nil
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, hook.OnStart(ctx))
+	defer func() {
+		releaseOnce.Do(func() { close(release) })
+		require.NoError(t, hook.OnStop(ctx))
+	}()
+	type result struct {
+		body string
+		err  error
+	}
+	response := make(chan result, 1)
+	go func() {
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+listener.Addr().String(), nil)
+		if err != nil {
+			response <- result{err: err}
+
+			return
+		}
+		res, err := http.DefaultClient.Do(request)
+		if err != nil {
+			response <- result{err: err}
+
+			return
+		}
+		body, err := io.ReadAll(res.Body)
+		err = errors.Join(err, res.Body.Close())
+		response <- result{body: string(body), err: err}
+	}()
+	select {
+	case <-entered:
+	case <-ctx.Done():
+		t.Fatal("request did not reach the handler")
+	}
+	stopped := make(chan error, 1)
+	stopDone := make(chan struct{})
+	go func() {
+		defer close(stopDone)
+		stopped <- hook.OnStop(ctx)
+	}()
+	defer func() {
+		releaseOnce.Do(func() { close(release) })
+		<-stopDone
+	}()
+	select {
+	case <-listener.closed:
+	case <-ctx.Done():
+		t.Fatal("shutdown did not close the listener")
+	}
+	select {
+	case err := <-stopped:
+		t.Fatalf("shutdown returned before the active request drained: %v", err)
+	default:
+	}
+	releaseOnce.Do(func() { close(release) })
+	select {
+	case got := <-response:
+		require.NoError(t, got.err)
+		require.Equal(t, "drained", got.body)
+	case <-ctx.Done():
+		t.Fatal("active request did not complete")
+	}
+	select {
+	case err := <-stopped:
+		require.NoError(t, err)
+	case <-ctx.Done():
+		t.Fatal("shutdown did not finish after request drained")
+	}
+	require.Zero(t, shutdowns.Load(), "normal shutdown must not be reported as a serving failure")
+}
+
+func TestHTTPServerHookRetriesTemporaryAcceptError(t *testing.T) {
+	t.Parallel()
+	listener := &httpControlListener{
+		Listener: mustListenLoopback(t, 0),
+		firstErr: &net.DNSError{Err: "temporary accept failure", IsTemporary: true},
+	}
+	var shutdowns atomic.Int32
+	hook := httpServerHook(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}), listener, "", logging.Testing(), func() error {
+		shutdowns.Add(1)
+
+		return nil
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, hook.OnStart(ctx))
+	defer func() { require.NoError(t, hook.OnStop(ctx)) }()
+	requireHTTPOK(t, listener.Addr().String())
+	require.GreaterOrEqual(t, listener.accepts.Load(), int32(2), "the injected failure must be retried before serving a request")
+	require.NoError(t, hook.OnStop(ctx))
+	require.Zero(t, shutdowns.Load())
+}
+
+func TestHTTPServerHookCanceledStopRetainsServeFailure(t *testing.T) {
+	t.Parallel()
+	failure := errors.New("permanent accept failure")
+	listener := &httpControlListener{Listener: mustListenLoopback(t, 0), firstErr: failure}
+	shutdown := make(chan struct{})
+	hook := httpServerHook(http.NotFoundHandler(), listener, "", logging.Testing(), func() error {
+		close(shutdown)
+
+		return nil
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, hook.OnStart(ctx))
+	select {
+	case <-shutdown:
+	case <-ctx.Done():
+		t.Fatal("permanent serving failure did not request shutdown")
+	}
+	stopCtx, stopCancel := context.WithCancel(context.Background())
+	stopCancel()
+	require.ErrorIs(t, hook.OnStop(stopCtx), failure)
+	require.Equal(t, int32(1), listener.accepts.Load())
+}
+
+// httpControlListener injects a single Accept failure and exposes listener closure
+// while preserving real TCP connections and net/http's serving lifecycle.
+type httpControlListener struct {
+	net.Listener
+
+	firstErr error
+	accepts  atomic.Int32
+	closed   chan struct{}
+	once     sync.Once
+}
+
+func (l *httpControlListener) Accept() (net.Conn, error) {
+	if l.accepts.Add(1) == 1 && l.firstErr != nil {
+		return nil, l.firstErr
+	}
+
+	return l.Listener.Accept()
+}
+
+func (l *httpControlListener) Close() error {
+	err := l.Listener.Close()
+	if l.closed != nil {
+		l.once.Do(func() { close(l.closed) })
+	}
+
+	return err
+}

--- a/internal/bootstrap/http_server_hook_test.go
+++ b/internal/bootstrap/http_server_hook_test.go
@@ -1,0 +1,36 @@
+package bootstrap
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/fx"
+
+	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
+)
+
+func TestHTTPServerFailureStopsApplication(t *testing.T) {
+	t.Parallel()
+	listener := mustListenLoopback(t, 0)
+	app := fx.New(fx.NopLogger, fx.Invoke(func(lc fx.Lifecycle, shutdowner fx.Shutdowner) {
+		lc.Append(httpServerHook(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}), listener, "", logging.Testing(), shutdownRequester(shutdowner)))
+	}))
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	require.NoError(t, app.Start(ctx))
+	t.Cleanup(func() { _ = app.Stop(context.Background()) })
+	requireHTTPOK(t, listener.Addr().String())
+	require.NoError(t, listener.Close())
+	select {
+	case <-app.Wait():
+	case <-ctx.Done():
+		t.Fatal("HTTP Serve failure did not request application shutdown")
+	}
+	require.ErrorIs(t, app.Stop(ctx), net.ErrClosed)
+}

--- a/internal/bootstrap/listener_options.go
+++ b/internal/bootstrap/listener_options.go
@@ -7,15 +7,13 @@ import (
 
 	"go.uber.org/fx"
 
-	"github.com/formancehq/go-libs/v5/pkg/transport/httpserver"
-
 	grpcadp "github.com/formancehq/ledger/v3/internal/adapter/grpc"
 	"github.com/formancehq/ledger/v3/internal/pkg/network"
 )
 
 // The listeners themselves are described by network.Bindings, which runServer
-// supplies into the fx graph. This file holds the two adapters that turn an
-// optional binding into the server option that adopts it.
+// supplies into the fx graph. HTTP adopts its binding in httpServerHook; this
+// file adapts gRPC bindings and releases all injected sockets on stop.
 
 // listenerOptions turns an optional binding into the gRPC server options that
 // adopt it. No binding means no option, so the server binds its own port.
@@ -25,19 +23,6 @@ func listenerOptions(listener net.Listener) []grpcadp.Option {
 	}
 
 	return []grpcadp.Option{grpcadp.WithListener(listener)}
-}
-
-// httpListenerOption selects how the HTTP server gets its socket: the injected
-// listener when there is one, the configured address otherwise. go-libs requires
-// exactly one of the two — serverport.Listen errors when both are unset, and a
-// listener silently wins over an address — so the choice is made here rather
-// than by appending both.
-func httpListenerOption(listener net.Listener, addr string) httpserver.ServerOptionModifier {
-	if listener == nil {
-		return httpserver.WithAddress(addr)
-	}
-
-	return httpserver.WithListener(listener)
 }
 
 // releaseBindingsHook returns the lifecycle hook that closes every injected

--- a/internal/bootstrap/listener_options_test.go
+++ b/internal/bootstrap/listener_options_test.go
@@ -41,17 +41,14 @@ func TestListenerOptionsMakeTheServerAdoptTheBinding(t *testing.T) {
 	require.NoError(t, srv.Stop())
 }
 
-// TestHTTPListenerOptionServesTheInjectedListener and its fallback twin pin the
-// choice go-libs forces: serverport.Listen wants exactly one of listener or
-// address, and a listener silently wins over an address, so the two must never be
-// passed together.
+// Exercise injected listener precedence and configured address fallback.
 func TestHTTPListenerOptionServesTheInjectedListener(t *testing.T) {
 	t.Parallel()
 
 	listener := mustListenLoopback(t, 0)
 
 	address := listener.Addr().String()
-	stop := startHTTPHook(t, httpListenerOption(listener, "127.0.0.1:0"))
+	stop := startHTTPHook(t, listener, "127.0.0.1:0")
 
 	requireHTTPOK(t, address)
 	require.NoError(t, stop(context.Background()))
@@ -66,23 +63,32 @@ func TestHTTPListenerOptionFallsBackToTheConfiguredAddress(t *testing.T) {
 	address := probe.Addr().String()
 	require.NoError(t, probe.Close())
 
-	stop := startHTTPHook(t, httpListenerOption(nil, address))
+	stop := startHTTPHook(t, nil, address)
 
 	requireHTTPOK(t, address)
 	require.NoError(t, stop(context.Background()))
 }
 
-func startHTTPHook(t *testing.T, option httpserver.ServerOptionModifier) func(context.Context) error {
+func startHTTPHook(t *testing.T, listener net.Listener, address string) func(context.Context) error {
 	t.Helper()
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	hook := httpserver.NewHook(handler, option)
+	hook := httpServerHook(handler, listener, address, logging.Testing(), func() error {
+		t.Error("normal HTTP shutdown requested failure shutdown")
+
+		return nil
+	})
 
 	ctx := httpserver.ContextWithServerInfo(logging.TestingContext())
 	require.NoError(t, hook.OnStart(ctx))
+	if listener != nil {
+		require.Equal(t, "http://"+listener.Addr().String(), httpserver.URL(ctx))
+	} else {
+		require.Equal(t, "http://"+address, httpserver.URL(ctx))
+	}
 
 	stopped := false
 	stop := func(stopCtx context.Context) error {

--- a/internal/bootstrap/module.go
+++ b/internal/bootstrap/module.go
@@ -23,10 +23,8 @@ import (
 
 	"github.com/formancehq/go-libs/v5/pkg/authn/oidc"
 	oidcclient "github.com/formancehq/go-libs/v5/pkg/authn/oidc/client"
-	"github.com/formancehq/go-libs/v5/pkg/fx/transportfx"
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 	otlpmetrics "github.com/formancehq/go-libs/v5/pkg/observe/metrics"
-	"github.com/formancehq/go-libs/v5/pkg/transport/httpserver"
 
 	internalauth "github.com/formancehq/ledger/v3/internal/adapter/auth"
 	grpcadp "github.com/formancehq/ledger/v3/internal/adapter/grpc"
@@ -945,10 +943,8 @@ func Module() fx.Option {
 			// transport/server/node startup hooks) so it runs before any inbound
 			// Raft traffic can be stepped — see the joinPreflightHook closure
 			// above and its doc comment for the EN-1436 ordering rationale.
-			func(lc fx.Lifecycle, cfg Config, handler http.Handler, bindings network.Bindings) {
-				lc.Append(transportfx.FXHook(httpserver.NewHook(handler,
-					httpListenerOption(bindings.HTTP, fmt.Sprintf(":%d", cfg.HTTPPort)),
-				)))
+			func(lc fx.Lifecycle, cfg Config, handler http.Handler, bindings network.Bindings, logger logging.Logger, shutdowner fx.Shutdowner) {
+				lc.Append(httpServerHook(handler, bindings.HTTP, fmt.Sprintf(":%d", cfg.HTTPPort), logger, shutdownRequester(shutdowner)))
 			},
 			func(lc fx.Lifecycle, collector *diskusage.Collector) {
 				lc.Append(worker.FxHook(collector))

--- a/internal/bootstrap/module_restore.go
+++ b/internal/bootstrap/module_restore.go
@@ -8,9 +8,7 @@ import (
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
-	"github.com/formancehq/go-libs/v5/pkg/fx/transportfx"
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
-	"github.com/formancehq/go-libs/v5/pkg/transport/httpserver"
 
 	grpcadp "github.com/formancehq/ledger/v3/internal/adapter/grpc"
 	"github.com/formancehq/ledger/v3/internal/infra/node"
@@ -111,16 +109,14 @@ func RestoreModule() fx.Option {
 			},
 			// Start minimal HTTP server with /health only, bound to the same
 			// host as the gRPC restore server (see comment on RestoreModule).
-			func(lc fx.Lifecycle, cfg Config, bindings network.Bindings) {
+			func(lc fx.Lifecycle, cfg Config, bindings network.Bindings, logger logging.Logger, shutdowner fx.Shutdowner) {
 				mux := http.NewServeMux()
 				mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 					w.WriteHeader(http.StatusOK)
 					_, _ = w.Write([]byte(`{"status":"restore_mode"}`))
 				})
 
-				lc.Append(transportfx.FXHook(httpserver.NewHook(mux,
-					httpListenerOption(bindings.HTTP, fmt.Sprintf("%s:%d", cfg.EffectiveRestoreListen(), cfg.HTTPPort)),
-				)))
+				lc.Append(httpServerHook(mux, bindings.HTTP, fmt.Sprintf("%s:%d", cfg.EffectiveRestoreListen(), cfg.HTTPPort), logger, shutdownRequester(shutdowner)))
 			},
 			// Registered last so it is this module's first OnStop hook: close restore
 			// admission and cancel its application-owned job at the Fx shutdown

--- a/internal/bootstrap/restore_download_lifecycle_test.go
+++ b/internal/bootstrap/restore_download_lifecycle_test.go
@@ -51,7 +51,7 @@ func (l *restoreLifecycleEvents) stopPhases() []string {
 		switch {
 		case strings.Contains(name, "RestoreServiceServerImpl).BeginShutdown"):
 			phases = append(phases, "close admission and cancel download")
-		case strings.Contains(name, "httpserver.NewHook."):
+		case strings.Contains(name, ".httpServerHook."):
 			phases = append(phases, "stop HTTP")
 		case strings.Contains(name, ".grpcServerHook."):
 			phases = append(phases, "stop gRPC")


### PR DESCRIPTION
## What changed

Supervise the HTTP server in normal and restore mode. A permanent serving failure now requests application shutdown and propagates the original error through cleanup, producing a nonzero process exit. Graceful draining, temporary accept retries, listener selection, and HTTP timeouts are preserved.

## Why

[EN-1995](https://formance-team.atlassian.net/browse/EN-1995): the previous HTTP hook only logged unexpected `Serve` errors, leaving Ledger alive with a dead endpoint.

## Product / operational motivation

An owned HTTP endpoint that permanently fails must terminate the application unsuccessfully so operators can detect and recover from the failure. Subprocess regressions exercise this after HTTP readiness in both modes. The lifecycle contract is documented in `docs/technical/architecture/subsystems/api/http-api.md` and `internal/bootstrap/http_server_hook.go`.

## Technical decision

Use a local HTTP lifecycle hook following the existing gRPC supervision pattern: bind synchronously, request Fx shutdown on unexpected `Serve` errors, join the serving goroutine, and return serving and shutdown errors together. This keeps the fix within Ledger; a go-libs release would require cross-repository coordination, and an Accept wrapper would not observe the actual Serve result.

## Bugfix evidence

DISCOVERY: DIRECT_FIX
BEFORE_FIX: BUG_REPRODUCED
AFTER_FIX: PASS

## Risk

**LOW** — limited to HTTP lifecycle supervision, with normal shutdown and failure-path regression coverage.

## Validation

All checks passed locally in the pinned Nix environment on `0dae6053b`, rebased onto `release/v3.0` at `219d78c9a`.

- [x] `bash scripts/agent-check`
- [x] Dirty: `just pre-commit`; subsequent all-feature lint without autofix reports zero issues.
- [x] `go test -race ./internal/bootstrap ./cmd/server -run TestHTTP -count=1 -timeout 2m`
- [x] Tagged S3 restore lifecycle regression.
- [x] Full CI suites: unit coverage, optional-feature internal coverage, business/cluster E2E coverage, scenarios, operator tests, workload race tests, and `just test-model-cluster 180` (four restart cycles, no findings).
- [x] Schemathesis with CI settings: 62 endpoints passed; root/operator builds, Windows amd64/arm64 cross-builds, and coverage merge passed at 55.7%.

The new subprocess regressions first obtain HTTP readiness, inject a permanent listener error, and assert automatic exit code 1 with the original error and completed cleanup. Both regressions fail against the original wiring because the processes remain alive. Controls cover graceful draining, synchronous bind failure, temporary retries, and canceled-stop error retention.

## Architecture / behavior impact

Fatal HTTP endpoint failures now stop Ledger in both normal and restore mode. No wire, persisted-state, or consensus contract changes.

## Review focus

Error propagation from the serving goroutine through Fx cleanup to process exit, plus preservation of restore shutdown ordering and graceful HTTP draining.

## Known concerns

None. Independent standards and specification reviews found no actionable issues.


[EN-1995]: https://formance-team.atlassian.net/browse/EN-1995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
