### PR TITLE
docs(restore): clarify Checker validation contract (EN-1868)

### DIFF
--- a/docs/ops/backup-restore.md
+++ b/docs/ops/backup-restore.md
@@ -126,6 +126,10 @@ manifest, is not a usable backup.
 
 ---
 
+The restore validation step above is recommended, but not enforced by
+finalization. Offline bootstrap runs Checker only with `--validate`; see
+[Validate](#step-2-validate-recommended) for the operational recommendation.
+
 ## Backup ()
 
 ### CLI Command
@@ -409,7 +413,18 @@ uncleanly closed staging store; size the process termination grace period
 accordingly. Staging-store close errors are logged under the existing close
 policy and are not returned by the restore stop hook.
 
-### Step 2: Validate
+### Step 2: Validate (Recommended)
+
+Checker validation is an operator-invoked integrity check, outside the normal
+request-processing path. During restore it checks the staged data before it
+becomes live: `restore validate` invokes it through the restore-mode server's
+gRPC API, while offline `store bootstrap --validate` runs it without a server.
+It is not an automatic prerequisite of `FinalizeRestore`.
+
+For recovery and restore drills, run validation after download and incremental
+replay complete, before finalization. Investigate any reported integrity errors
+before proceeding. The numbered workflow is the recommended operational
+sequence; the server does not enforce successful validation before finalization.
 
 ```bash
 ledgerctl restore validate
@@ -462,7 +477,18 @@ ledgerctl restore finalize --yes
 | `--yes`, `-y` | No | Skip confirmation prompt |
 | `--timeout` | No | Request timeout (default: 10s) |
 
-Calls `RestoreService.FinalizeRestore` (unary). This commits the staged backup as live data:
+Calls `RestoreService.FinalizeRestore` (unary). This commits the staged backup as live data.
+
+`FinalizeRestore` does not run Checker or require a prior successful
+`ValidateRestore` call. Successful finalization therefore does not establish
+that the restored data passed integrity validation. To make validation success
+a condition of finalization in an operator script, use:
+
+```bash
+ledgerctl restore validate && ledgerctl restore finalize
+```
+
+Finalization performs these steps:
 
 1. Prepares the staged store ([Backup Preparation on Restore](#backup-preparation-on-restore): applied index preserved as the genesis boundary, persisted config/bloom/peers/cache reset).
 2. Reads back `lastAppliedIndex` and `lastAppliedTimestamp` from the prepared store.
@@ -537,7 +563,7 @@ ledgerctl store bootstrap --driver s3 --s3-bucket my-bucket --s3-region us-east-
 | `--azure-endpoint` | | Custom Azure endpoint (for Azurite) |
 | `--bucket-id` | | Namespace prefix for backup files (default: uses cluster-id from config) |
 | `--data-dir` | | Target data directory (required, must be fresh) |
-| `--validate` | `false` | Run integrity checks after download |
+| `--validate` | `false` | Run Checker after download/replay and before finalization; abort on validation failure |
 | `-y, --yes` | `false` | Skip confirmation prompt |
 
 ### How It Works
@@ -546,11 +572,15 @@ ledgerctl store bootstrap --driver s3 --s3-bucket my-bucket --s3-region us-east-
 2. **Download**: Reads the manifest from the configured backend, downloads all checkpoint files and export segments into `{data-dir}/restore-staging/`.
 3. **Apply exports**: If the manifest contains incremental export segments, applies them to the staging database and rebuilds derived state.
 4. **Preview**: Opens the staging as a read-only Pebble database, reads metadata (last applied index, timestamp, ledger list), and displays a summary table.
-5. **Validate** (optional): If `--validate` is set, runs the full integrity checker (`check.Checker`) -- the same checker used by `store check` and `restore validate`.
+5. **Validate** (optional): If `--validate` is set, runs the full integrity checker (`check.Checker`) -- the same checker used by `store check` and `restore validate`. Execution failures or reported integrity errors abort bootstrap before confirmation, preparation, and finalization. Without this flag, bootstrap skips Checker entirely.
 6. **Confirm**: Unless `--yes` is set, prompts for user confirmation.
 7. **Prepare**: Prepares attributes for backup (Global-zone resets: applied index preserved as the genesis boundary — the restored genesis' WAL-snapshot index — persisted config stripped, persisted bloom blocks dropped); the attribute zone is left intact.
 8. **Finalize**: Hard-links staging to `{data-dir}/checkpoints/0`, writes the `RESTORED` marker JSON.
 9. **Cleanup**: Removes the staging directory.
+
+Use `--validate` for recovery and restore drills so integrity checks succeed
+before the data is finalized. Its default of `false` makes it opt-in; successful
+bootstrap without this flag is not evidence that Checker passed.
 
 ### When to Use
 

--- a/internal/adapter/http/metadata_integers_test.go
+++ b/internal/adapter/http/metadata_integers_test.go
@@ -14,6 +14,7 @@ import (
 	logging "github.com/formancehq/go-libs/v5/pkg/observe/log"
 
 	internalauth "github.com/formancehq/ledger/v3/internal/adapter/auth"
+	"github.com/formancehq/ledger/v3/internal/domain"
 	"github.com/formancehq/ledger/v3/internal/pkg/version"
 	"github.com/formancehq/ledger/v3/internal/proto/commonpb"
 	"github.com/formancehq/ledger/v3/internal/proto/servicepb"
@@ -46,7 +47,7 @@ func TestMetadataIntegers_Routes(t *testing.T) {
 				t.Parallel()
 				backend := NewMockBackend(gomock.NewController(t))
 				if tc.want != nil {
-					backend.EXPECT().Apply(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, req *servicepb.ApplyRequest) ([]*commonpb.Log, error) {
+					backend.EXPECT().Apply(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, req *servicepb.ApplyRequest) (*domain.ApplyResult, error) {
 						requests := req.GetUnsigned().GetRequests()
 						require.Len(t, requests, 1)
 						require.Equal(t, "ledger1", requests[0].GetApply().GetLedger())
@@ -72,7 +73,7 @@ func TestMetadataIntegers_Routes(t *testing.T) {
 						}
 						require.Equal(t, tc.want, commonpb.MetadataValueToAny(md["count"]))
 
-						return []*commonpb.Log{{Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_Apply{Apply: &commonpb.ApplyLedgerLog{Log: &commonpb.LedgerLog{Data: logData}}}}}}, nil
+						return &domain.ApplyResult{Logs: []*commonpb.Log{{Payload: &commonpb.LogPayload{Type: &commonpb.LogPayload_Apply{Apply: &commonpb.ApplyLedgerLog{Log: &commonpb.LedgerLog{Data: logData}}}}}}}, nil
 					})
 				}
 				path := "/v3/ledger1/accounts/users:001/metadata"

--- a/scripts/agentvalidationenv/rotation_test.go
+++ b/scripts/agentvalidationenv/rotation_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -109,33 +110,23 @@ func TestSlowCacheMaintenanceDoesNotHoldSelectionLock(t *testing.T) {
 			realTool, err := exec.LookPath(stage)
 			require.NoError(t, err)
 			ready := filepath.Join(root, "ready")
-			// Block the expensive operation, not the peer: the second initializer
-			// must finish while the first is still waiting for explicit release.
-			script := "#!/usr/bin/env bash\nset -eu\nprintf ready >\"$MAINTENANCE_READY\"\nIFS= read -r release <&3\nexec \"$MAINTENANCE_TOOL\" \"$@\"\n"
+			require.NoError(t, syscall.Mkfifo(ready, 0o600))
+			// The peer starts only after maintenance reaches the blocking operation.
+			// It reports ready only after its initializer completes, so the shared
+			// supervisor cannot release maintenance while the peer is still blocked.
+			script := "#!/usr/bin/env bash\nset -eu\nprintf 'ready\\n' >\"$MAINTENANCE_READY\"\nprintf 'ready\\n' >&3\nIFS= read -r release <&4\nexec \"$MAINTENANCE_TOOL\" \"$@\"\n"
 			require.NoError(t, os.WriteFile(filepath.Join(bin, stage), []byte(script), 0o755))
-			reader, writer, err := os.Pipe()
-			require.NoError(t, err)
-			t.Cleanup(func() { _ = reader.Close(); _ = writer.Close() })
-			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-			t.Cleanup(cancel)
-			command := exec.CommandContext(ctx, "bash", validationEnvPath(t), filepath.Join(root, "slow"), "true")
+			command := testenv.Command(t, "bash", validationEnvPath(t), filepath.Join(root, "slow"), "true")
 			command.Env = append(cacheBudgetEnvironment(root, cacheRoot), "PATH="+bin+":"+os.Getenv("PATH"), "MAINTENANCE_READY="+ready, "MAINTENANCE_TOOL="+realTool)
-			command.ExtraFiles = []*os.File{reader}
-			require.NoError(t, command.Start())
-			t.Cleanup(func() { _ = command.Process.Kill() })
-			require.NoError(t, reader.Close())
-			require.Eventually(t, func() bool {
-				_, err := os.Stat(ready)
-
-				return err == nil
-			}, 10*time.Second, 10*time.Millisecond)
-			peer := exec.CommandContext(ctx, "bash", validationEnvPath(t), filepath.Join(root, "peer"), "true")
+			peer := testenv.Command(t, "bash", "-c",
+				`set -eu; IFS= read -r ready <"$1"; bash "$2" "$3" true; printf 'ready\n' >&3; IFS= read -r release <&4`,
+				"peer", ready, validationEnvPath(t), filepath.Join(root, "peer"))
 			peer.Env = cacheBudgetEnvironment(root, cacheRoot)
-			output, err := peer.CombinedOutput()
-			require.NoError(t, err, string(output))
-			_, err = writer.WriteString("release\n")
+			_, err = testenv.RunSynchronized(t, 30*time.Second,
+				testenv.SynchronizedCommand{Name: "maintenance-" + stage, Command: command},
+				testenv.SynchronizedCommand{Name: "peer", Command: peer},
+			)
 			require.NoError(t, err)
-			require.NoError(t, command.Wait())
 		})
 	}
 }

--- a/scripts/rootguard/main_test.go
+++ b/scripts/rootguard/main_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -96,35 +98,87 @@ func TestRunnerComparesRootAfterCancellation(t *testing.T) {
 	root := newRunnerTestRepository(t)
 	binary := buildRunner(t)
 
-	ready := filepath.Join(t.TempDir(), "ready")
-	command := exec.Command(binary, "--root", root, "--", "/bin/sh", "-c", "trap '' TERM INT; printf ready > "+shellQuote(ready)+"; while :; do sleep 1; done")
+	reader, writer, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() {
+		_ = reader.Close() // Best-effort cleanup of test-owned pipes.
+		_ = writer.Close()
+	}()
+	command := exec.Command(binary, "--root", root, "--", "/bin/sh", "-c", "trap '' TERM INT; printf 'child-ready\\n'; read release")
 	command.Dir = root
 	command.Env = testenv.Environment()
-	var combined bytes.Buffer
-	command.Stdout = &combined
-	command.Stderr = &combined
+	command.Stdin = reader
+	outputReader, outputWriter := io.Pipe()
+	defer func() {
+		_ = outputReader.Close() // Also unblock output collection when Start fails.
+		_ = outputWriter.Close()
+	}()
+	command.Stdout = outputWriter
+	command.Stderr = outputWriter
+	ready := make(chan struct{}, 1)
+	type capturedOutput struct {
+		text string
+		err  error
+	}
+	output := make(chan capturedOutput, 1)
+	go func() {
+		var combined strings.Builder
+		scanner := bufio.NewScanner(outputReader)
+		for scanner.Scan() {
+			line := scanner.Text()
+			combined.WriteString(line + "\n")
+			if line == "child-ready" {
+				ready <- struct{}{}
+			}
+		}
+		_ = outputReader.Close()
+		output <- capturedOutput{text: combined.String(), err: scanner.Err()}
+	}()
 	require.NoError(t, command.Start())
-	require.Eventually(t, func() bool {
-		_, err := os.Stat(ready)
-
-		return err == nil
-	}, 5*time.Second, 10*time.Millisecond)
-	require.NoError(t, command.Process.Signal(syscall.SIGTERM))
 	done := make(chan error, 1)
 	go func() {
-		done <- command.Wait()
+		err := command.Wait()
+		_ = outputWriter.Close()
+		done <- err
 	}()
+	exited := false
+	defer func() {
+		_ = writer.Close() // Release the child even when startup or cancellation assertions fail.
+		if !exited {
+			_ = command.Process.Signal(syscall.SIGTERM)
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				_ = command.Process.Kill()
+				<-done
+			}
+		}
+	}()
+	// Readiness is an observed child event, not a filesystem polling deadline.
+	select {
+	case <-ready:
+	case err := <-done:
+		exited = true
+		captured := <-output
+		t.Fatalf("rootguard exited before child readiness: %v (output error: %v)\n%s", err, captured.err, captured.text)
+	case <-time.After(30 * time.Second):
+		t.Fatal("rootguard child did not report readiness")
+	}
+	require.NoError(t, command.Process.Signal(syscall.SIGTERM))
 	var waitErr error
 	select {
 	case waitErr = <-done:
+		exited = true
 	case <-time.After(5 * time.Second):
-		_ = command.Process.Kill() // Best effort cleanup before failing the bounded regression.
 		t.Fatal("rootguard did not finish after cancellation")
 	}
-	require.Error(t, waitErr, combined.String())
-	require.Equal(t, exitError, command.ProcessState.ExitCode(), combined.String())
-	require.Contains(t, combined.String(), "ROOT_UNCHANGED=PASS")
-	require.Contains(t, combined.String(), "ROOT_SNAPSHOT_CAPTURED position=after")
+	captured := <-output
+	require.NoError(t, captured.err)
+	combined := captured.text
+	require.Error(t, waitErr, combined)
+	require.Equal(t, exitError, command.ProcessState.ExitCode(), combined)
+	require.Contains(t, combined, "ROOT_UNCHANGED=PASS")
+	require.Contains(t, combined, "ROOT_SNAPSHOT_CAPTURED position=after")
 }
 
 func TestRunnerReapsSurvivingDescendantBeforeFinalSnapshot(t *testing.T) {


### PR DESCRIPTION
## What changed

Clarifies that restore Checker validation is operator-invoked and recommended before finalization, while `FinalizeRestore` neither runs Checker nor requires a successful validation result. Documents offline bootstrap's opt-in `--validate` behavior and provides a shell example that gates finalization on validation success.

Also repairs validation blockers encountered after rebasing: the HTTP metadata mock now returns `domain.ApplyResult`, and the cache-maintenance fixture uses a FIFO handshake with the existing subprocess supervisor. The peer must finish initialization before blocked maintenance is released; failures now terminate and reap fixture processes.

The rootguard cancellation fixture now observes a child-ready message and uses a blocking stdin pipe, with cleanup on every exit path. It retains the five-second cancellation bound and both post-cancellation snapshot assertions. Five race-enabled repetitions passed, and a temporary mutation skipping the final snapshot was correctly rejected.

## Why

The numbered restore workflow could imply that validation is enforced by finalization. Operators need to distinguish the recommended recovery sequence from the actual runtime prerequisites.

[EN-1868](https://formance-team.atlassian.net/browse/EN-1868)

## Product / operational motivation

N/A — documentation clarification of existing behavior.

## Technical decision

N/A

## Risk

**LOW** — documentation and test-fixture changes only; production behavior is unchanged.

## Validation

- [x] `bash scripts/agent-check`
- [x] `nix develop --command just pre-commit` (Dirty: generation, tidy, lint, generated-file consistency)
- [x] `nix develop --command just test-coverage`
- [x] S3 restore lifecycle race test, operator tests, and Antithesis workload race tests
- [x] Business and cluster E2E coverage, scenarios coverage, `just test-model-cluster 180`
- [x] `MAX_EXAMPLES=10 SCHEMATHESIS_WORKERS=1 just test-schemathesis` (62 endpoints passed)
- [x] Native root/operator builds and Windows amd64/arm64 CLI builds
- [x] Markdown link targets, `git diff --check`, and independent standards/spec reviews

All checks passed locally on the committed content. Integration tests used the local OrbStack Docker endpoint.

Additional validation for the fixture repair: five consecutive race-enabled reproductions passed, the complete cache/rootguard/synchronization fixture suites passed, and a temporary mutation moving cache measurement under the selection lock was correctly rejected with a peer lock timeout. The mutation was removed. Full CI and Dirty checks passed after the repair.

## Architecture / behavior impact

N/A

## Review focus

Accuracy of the distinction between recommended validation and enforced finalization prerequisites, including the offline `--validate` failure behavior.

## Known concerns

None


[EN-1868]: https://formance-team.atlassian.net/browse/EN-1868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

