### PR TITLE
fix(api): roll back atomic bulks when a worker panics

### DIFF
--- a/internal/api/bulking/bulker.go
+++ b/internal/api/bulking/bulker.go
@@ -48,6 +48,18 @@ func (b *Bulker) run(ctx context.Context, ctrl ledgercontroller.Controller, sche
 				trace.WithAttributes(attribute.Int("index", itemIndex)),
 			)
 			defer span.End()
+			// pond recovers worker panics and does not propagate them. Without
+			// this, hasError stays false and an atomic bulk commits survivors.
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					hasError.Store(true)
+					err := fmt.Errorf("bulk element panicked: %v", recovered)
+					observe.RecordError(ctx, err)
+					result <- BulkElementResult{
+						Error: err,
+					}
+				}
+			}()
 
 			select {
 			case <-ctx.Done():

--- a/internal/api/bulking/bulker_test.go
+++ b/internal/api/bulking/bulker_test.go
@@ -1,6 +1,7 @@
 package bulking
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"math/big"
@@ -433,4 +434,61 @@ func TestBulk(t *testing.T) {
 			require.NoError(t, bulker.Run(ctx, bulk, results, testCase.options))
 		})
 	}
+}
+
+func TestBulkAtomicPanicRollsBack(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.TestingContext()
+	ctrl := gomock.NewController(t)
+	ledgerController := NewLedgerController(ctrl)
+
+	ledgerController.EXPECT().
+		BeginTX(gomock.Any(), nil).
+		Return(ledgerController, &bun.Tx{}, nil)
+	ledgerController.EXPECT().
+		CreateTransaction(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(context.Context, ledgercontroller.Parameters[ledgercontroller.CreateTransaction]) (*ledger.Log, *ledger.CreatedTransaction, bool, error) {
+			panic("simulated worker panic")
+		})
+	ledgerController.EXPECT().
+		Rollback(gomock.Any()).
+		Return(nil)
+
+	bulker := NewBulker(ledgerController)
+	bulk := make(Bulk, 2)
+	results := make(chan BulkElementResult, 2)
+	now := time.Now()
+	bulk <- BulkElement{
+		Action: ActionCreateTransaction,
+		Data: TransactionRequest{
+			Postings: []ledger.Posting{{
+				Source:      "world",
+				Destination: "bank",
+				Amount:      big.NewInt(100),
+				Asset:       "USD/2",
+			}},
+			Timestamp: now,
+		},
+	}
+	bulk <- BulkElement{
+		Action: ActionAddMetadata,
+		Data: AddMetadataRequest{
+			TargetID:   json.RawMessage(`"world"`),
+			TargetType: "ACCOUNT",
+			Metadata: metadata.Metadata{
+				"foo": "bar",
+			},
+		},
+	}
+	close(bulk)
+
+	require.NoError(t, bulker.Run(ctx, bulk, results, BulkingOptions{Atomic: true}))
+
+	var got []BulkElementResult
+	for result := range results {
+		got = append(got, result)
+	}
+	require.GreaterOrEqual(t, len(got), 1)
+	require.ErrorContains(t, got[0].Error, "bulk element panicked")
 }


### PR DESCRIPTION
## Summary

`Bulker.run` submits each element to a pond worker pool. pond recovers panics and does not propagate them.

`hasError` is only set on the normal error return path. When `processElement` panics, no result is emitted and `hasError` stays false. `Bulker.Run` then commits an `atomic=true` bulk and returns success with a short results array.

The caller asked for all-or-nothing and got a partial commit reported as success.

This recovers the panic in the submit closure, sets `hasError`, and emits an error result so atomic bulks roll back.

## Test plan

- [x] `go test ./internal/api/bulking/ -count=1` green
- [x] Revert-tested: without the recover, the new spec fails (unexpected Commit, missing Rollback)

Made with [Cursor](https://cursor.com)